### PR TITLE
fix(auth): prevent default profile from using stale glm env vars

### DIFF
--- a/src/auth/profile-detector.ts
+++ b/src/auth/profile-detector.ts
@@ -178,10 +178,21 @@ class ProfileDetector {
     const config = this.readConfig();
 
     if (config.profiles && config.profiles['default']) {
+      const settingsPath = config.profiles['default'];
+      // Safety net: If default points to ~/.claude/settings.json, treat as pass-through
+      // to avoid loading stale env vars from previous profile sessions (issue #37).
+      // The ~/.claude/settings.json is Claude's native config - let Claude handle it.
+      if (settingsPath.includes('.claude') && settingsPath.endsWith('settings.json')) {
+        return {
+          type: 'default',
+          name: 'default',
+          message: 'Using native Claude auth (no custom env vars)',
+        };
+      }
       return {
         type: 'settings',
         name: 'default',
-        settingsPath: config.profiles['default'],
+        settingsPath,
       };
     }
 


### PR DESCRIPTION
Fixes #37. Removes default entry from config.json and adds ProfileDetector safety net.