### PR TITLE
fix(auth): Profile not found for account profiles in unified config mode

### DIFF
--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -397,8 +397,12 @@ async function main(): Promise<void> {
       // Ensure instance exists (lazy init if needed)
       const instancePath = instanceMgr.ensureInstance(profileInfo.name);
 
-      // Update last_used timestamp
-      registry.touchProfile(profileInfo.name);
+      // Update last_used timestamp (check unified config first, fallback to legacy)
+      if (registry.hasAccountUnified(profileInfo.name)) {
+        registry.touchAccountUnified(profileInfo.name);
+      } else {
+        registry.touchProfile(profileInfo.name);
+      }
 
       // Execute Claude with instance isolation
       const envVars: NodeJS.ProcessEnv = { CLAUDE_CONFIG_DIR: instancePath };


### PR DESCRIPTION
## Summary
- Fix account profiles in unified config mode failing with "Profile not found"
- `touchProfile()` was only checking legacy `profiles.json` for updating `last_used` timestamp
- Now checks unified config first with `hasAccountUnified()` and calls `touchAccountUnified()` when profile exists there

## Root Cause
In `ccs.ts:401`, when handling `account` type profiles, the code called `registry.touchProfile()` which only reads from legacy `profiles.json`. However, profiles created via `ccs auth create <name>` in unified config mode are stored in `config.yaml`, causing "Profile not found" error.

## Fix
Check if account exists in unified config first, use appropriate touch method:
```typescript
if (registry.hasAccountUnified(profileInfo.name)) {
  registry.touchAccountUnified(profileInfo.name);
} else {
  registry.touchProfile(profileInfo.name);
}
```

## Test plan
- [x] `bun run validate` passes (typecheck, lint, format, 447 tests)
- [ ] Manual test: `ccs auth create test` → `ccs test "hello"` should work

Fixes #98
