### PR TITLE
fix(auth): improve default account hint and add reset-default command

### DIFF
--- a/src/auth/profile-registry.ts
+++ b/src/auth/profile-registry.ts
@@ -218,6 +218,15 @@ export class ProfileRegistry {
   }
 
   /**
+   * Clear default profile (restore original CCS behavior)
+   */
+  clearDefaultProfile(): void {
+    const data = this._read();
+    data.default = null;
+    this._write(data);
+  }
+
+  /**
    * Check if profile exists
    */
   hasProfile(name: string): boolean {
@@ -281,6 +290,15 @@ export class ProfileRegistry {
       throw new Error(`Profile not found: ${name}`);
     }
     config.default = name;
+    saveUnifiedConfig(config);
+  }
+
+  /**
+   * Clear default profile in unified config (restore original CCS behavior)
+   */
+  clearDefaultUnified(): void {
+    const config = loadOrCreateUnifiedConfig();
+    config.default = undefined;
     saveUnifiedConfig(config);
   }
 

--- a/src/commands/help-command.ts
+++ b/src/commands/help-command.ts
@@ -141,6 +141,8 @@ Claude Code Profile & Model Switcher`.trim();
       ['ccs auth --help', 'Show account management commands'],
       ['ccs auth create <name>', 'Create new account profile'],
       ['ccs auth list', 'List all account profiles'],
+      ['ccs auth default <name>', 'Set default profile'],
+      ['ccs auth reset-default', 'Restore original CCS default'],
     ]
   );
 

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -301,6 +301,18 @@ export function infoBox(content: string, title?: string): string {
   });
 }
 
+/**
+ * Render warning box (yellow border)
+ */
+export function warnBox(content: string, title = 'WARNING'): string {
+  return box(content, {
+    title,
+    borderColor: 'yellow',
+    borderStyle: 'round',
+    padding: 1,
+  });
+}
+
 // =============================================================================
 // TABLE RENDERING
 // =============================================================================
@@ -613,6 +625,7 @@ export const ui = {
   box,
   errorBox,
   infoBox,
+  warnBox,
   table,
 
   // Progress


### PR DESCRIPTION
## Summary

- Changed post-create hint from casual text to **warning box** with clear messaging
- Added `ccs auth reset-default` command to restore original CCS behavior
- Updated main `--help` to document default/reset-default commands

## Changes

| File | Change |
|------|--------|
| `auth-commands.ts` | Warning box after create, `handleResetDefault()`, route, help |
| `profile-registry.ts` | `clearDefaultProfile()`, `clearDefaultUnified()` |
| `help-command.ts` | Added auth default/reset-default to main help |
| `ui.ts` | Added `warnBox()` helper |

## Test plan

- [x] `bun run validate` passes (447 tests)
- [ ] Run `ccs auth create test` and verify warning box appears
- [ ] Run `ccs auth reset-default` and verify default is cleared
- [ ] Run `ccs --help` and verify new commands shown

Closes #106
