### PR TITLE
fix(cliproxy): prevent shared proxy termination on multi-session exit

### DIFF
--- a/src/cliproxy/session-tracker.ts
+++ b/src/cliproxy/session-tracker.ts
@@ -1,0 +1,226 @@
+/**
+ * Session Tracker for CLIProxy Multi-Instance Support
+ *
+ * Manages reference counting for shared CLIProxy instances.
+ * Multiple CCS sessions can share a single proxy on the same port.
+ * Proxy only terminates when ALL sessions exit (count reaches 0).
+ *
+ * Lock file format: ~/.ccs/cliproxy/sessions.json
+ * {
+ *   "port": 8317,
+ *   "pid": 12345,        // CLIProxy process PID
+ *   "sessions": ["abc123", "def456"],  // Active session IDs
+ *   "startedAt": "2024-01-01T00:00:00Z"
+ * }
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { getCliproxyDir } from './config-generator';
+
+/** Session lock file structure */
+interface SessionLock {
+  port: number;
+  pid: number;
+  sessions: string[];
+  startedAt: string;
+}
+
+/** Generate unique session ID */
+function generateSessionId(): string {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+/** Get path to session lock file */
+function getSessionLockPath(): string {
+  return path.join(getCliproxyDir(), 'sessions.json');
+}
+
+/** Read session lock file (returns null if not exists or invalid) */
+function readSessionLock(): SessionLock | null {
+  const lockPath = getSessionLockPath();
+  try {
+    if (!fs.existsSync(lockPath)) {
+      return null;
+    }
+    const content = fs.readFileSync(lockPath, 'utf-8');
+    const lock = JSON.parse(content) as SessionLock;
+    // Validate structure
+    if (
+      typeof lock.port !== 'number' ||
+      typeof lock.pid !== 'number' ||
+      !Array.isArray(lock.sessions)
+    ) {
+      return null;
+    }
+    return lock;
+  } catch {
+    return null;
+  }
+}
+
+/** Write session lock file */
+function writeSessionLock(lock: SessionLock): void {
+  const lockPath = getSessionLockPath();
+  const dir = path.dirname(lockPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2), { mode: 0o600 });
+}
+
+/** Delete session lock file */
+function deleteSessionLock(): void {
+  const lockPath = getSessionLockPath();
+  try {
+    if (fs.existsSync(lockPath)) {
+      fs.unlinkSync(lockPath);
+    }
+  } catch {
+    // Ignore errors on cleanup
+  }
+}
+
+/** Check if a PID is still running */
+function isProcessRunning(pid: number): boolean {
+  try {
+    // Sending signal 0 checks if process exists without killing it
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check if there's an existing proxy running that we can reuse.
+ * Returns the existing lock if proxy is healthy, null otherwise.
+ */
+export function getExistingProxy(port: number): SessionLock | null {
+  const lock = readSessionLock();
+  if (!lock) {
+    return null;
+  }
+
+  // Verify port matches
+  if (lock.port !== port) {
+    return null;
+  }
+
+  // Verify proxy process is still running
+  if (!isProcessRunning(lock.pid)) {
+    // Proxy crashed - clean up stale lock
+    deleteSessionLock();
+    return null;
+  }
+
+  return lock;
+}
+
+/**
+ * Register a new session with the proxy.
+ * Call this when starting a new CCS session that will use an existing proxy.
+ * @returns Session ID for this session
+ */
+export function registerSession(port: number, proxyPid: number): string {
+  const sessionId = generateSessionId();
+  const existingLock = readSessionLock();
+
+  if (existingLock && existingLock.port === port && existingLock.pid === proxyPid) {
+    // Add to existing sessions
+    existingLock.sessions.push(sessionId);
+    writeSessionLock(existingLock);
+  } else {
+    // Create new lock (first session for this proxy)
+    const newLock: SessionLock = {
+      port,
+      pid: proxyPid,
+      sessions: [sessionId],
+      startedAt: new Date().toISOString(),
+    };
+    writeSessionLock(newLock);
+  }
+
+  return sessionId;
+}
+
+/**
+ * Unregister a session from the proxy.
+ * @returns true if this was the last session (proxy should be killed)
+ */
+export function unregisterSession(sessionId: string): boolean {
+  const lock = readSessionLock();
+  if (!lock) {
+    // No lock file - assume we're the only session
+    return true;
+  }
+
+  // Remove this session from the list
+  const index = lock.sessions.indexOf(sessionId);
+  if (index !== -1) {
+    lock.sessions.splice(index, 1);
+  }
+
+  // Check if any sessions remain
+  if (lock.sessions.length === 0) {
+    // Last session - clean up lock file
+    deleteSessionLock();
+    return true;
+  }
+
+  // Other sessions still active - keep proxy running
+  writeSessionLock(lock);
+  return false;
+}
+
+/**
+ * Get current session count for the proxy.
+ */
+export function getSessionCount(): number {
+  const lock = readSessionLock();
+  if (!lock) {
+    return 0;
+  }
+  return lock.sessions.length;
+}
+
+/**
+ * Check if proxy has any active sessions.
+ * Used to determine if a "zombie" proxy should be killed.
+ */
+export function hasActiveSessions(): boolean {
+  const lock = readSessionLock();
+  if (!lock) {
+    return false;
+  }
+
+  // Verify proxy is still running
+  if (!isProcessRunning(lock.pid)) {
+    deleteSessionLock();
+    return false;
+  }
+
+  return lock.sessions.length > 0;
+}
+
+/**
+ * Clean up orphaned sessions (when proxy crashes).
+ * Called on startup to ensure clean state.
+ */
+export function cleanupOrphanedSessions(port: number): void {
+  const lock = readSessionLock();
+  if (!lock) {
+    return;
+  }
+
+  // If port doesn't match, this lock is for a different proxy
+  if (lock.port !== port) {
+    return;
+  }
+
+  // If proxy is dead, clean up lock
+  if (!isProcessRunning(lock.pid)) {
+    deleteSessionLock();
+  }
+}

--- a/tests/unit/cliproxy/session-tracker.test.js
+++ b/tests/unit/cliproxy/session-tracker.test.js
@@ -1,0 +1,330 @@
+/**
+ * Session Tracker Tests
+ *
+ * Tests for multi-instance CLIProxy session management.
+ * Verifies reference counting and cleanup behavior.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Set test isolation environment before importing
+const testHome = path.join(os.tmpdir(), `ccs-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+process.env.CCS_HOME = testHome;
+
+const {
+  getExistingProxy,
+  registerSession,
+  unregisterSession,
+  getSessionCount,
+  hasActiveSessions,
+  cleanupOrphanedSessions,
+} = require('../../../dist/cliproxy/session-tracker');
+
+describe('Session Tracker', function () {
+  const testPort = 18317;
+  let sessionLockPath;
+
+  beforeEach(function () {
+    // Create test directories
+    const cliproxyDir = path.join(testHome, '.ccs', 'cliproxy');
+    fs.mkdirSync(cliproxyDir, { recursive: true });
+    sessionLockPath = path.join(cliproxyDir, 'sessions.json');
+
+    // Clean up any existing lock file
+    if (fs.existsSync(sessionLockPath)) {
+      fs.unlinkSync(sessionLockPath);
+    }
+  });
+
+  afterEach(function () {
+    // Clean up lock file
+    if (fs.existsSync(sessionLockPath)) {
+      fs.unlinkSync(sessionLockPath);
+    }
+  });
+
+  afterAll(function () {
+    // Clean up test directory
+    try {
+      fs.rmSync(testHome, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+    delete process.env.CCS_HOME;
+  });
+
+  describe('getExistingProxy', function () {
+    it('should return null when no lock file exists', function () {
+      const result = getExistingProxy(testPort);
+      assert.strictEqual(result, null);
+    });
+
+    it('should return null when port does not match', function () {
+      // Create lock with different port
+      const lock = {
+        port: 9999,
+        pid: process.pid, // Use current process as it's definitely running
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      const result = getExistingProxy(testPort);
+      assert.strictEqual(result, null);
+    });
+
+    it('should return lock when proxy is healthy', function () {
+      // Create lock with current process (guaranteed to be running)
+      const lock = {
+        port: testPort,
+        pid: process.pid,
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      const result = getExistingProxy(testPort);
+      assert.notStrictEqual(result, null);
+      assert.strictEqual(result.port, testPort);
+      assert.strictEqual(result.pid, process.pid);
+      assert.deepStrictEqual(result.sessions, ['session1']);
+    });
+
+    it('should return null and cleanup when proxy is dead', function () {
+      // Create lock with non-existent PID
+      const lock = {
+        port: testPort,
+        pid: 999999999, // Very unlikely to exist
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      const result = getExistingProxy(testPort);
+      assert.strictEqual(result, null);
+
+      // Lock file should be cleaned up
+      assert.strictEqual(fs.existsSync(sessionLockPath), false);
+    });
+  });
+
+  describe('registerSession', function () {
+    it('should create new lock file for first session', function () {
+      const sessionId = registerSession(testPort, process.pid);
+
+      assert.ok(sessionId, 'should return session ID');
+      assert.ok(fs.existsSync(sessionLockPath), 'should create lock file');
+
+      const lock = JSON.parse(fs.readFileSync(sessionLockPath, 'utf-8'));
+      assert.strictEqual(lock.port, testPort);
+      assert.strictEqual(lock.pid, process.pid);
+      assert.strictEqual(lock.sessions.length, 1);
+      assert.strictEqual(lock.sessions[0], sessionId);
+    });
+
+    it('should add session to existing lock', function () {
+      // Register first session
+      const session1 = registerSession(testPort, process.pid);
+
+      // Register second session
+      const session2 = registerSession(testPort, process.pid);
+
+      assert.notStrictEqual(session1, session2, 'should generate unique IDs');
+
+      const lock = JSON.parse(fs.readFileSync(sessionLockPath, 'utf-8'));
+      assert.strictEqual(lock.sessions.length, 2);
+      assert.ok(lock.sessions.includes(session1));
+      assert.ok(lock.sessions.includes(session2));
+    });
+
+    it('should create new lock if PID differs', function () {
+      // Create lock with different PID
+      const oldLock = {
+        port: testPort,
+        pid: 12345,
+        sessions: ['old-session'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(oldLock));
+
+      // Register with new PID
+      const sessionId = registerSession(testPort, process.pid);
+
+      const lock = JSON.parse(fs.readFileSync(sessionLockPath, 'utf-8'));
+      assert.strictEqual(lock.pid, process.pid);
+      assert.strictEqual(lock.sessions.length, 1);
+      assert.strictEqual(lock.sessions[0], sessionId);
+    });
+  });
+
+  describe('unregisterSession', function () {
+    it('should return true when no lock exists', function () {
+      const result = unregisterSession('nonexistent');
+      assert.strictEqual(result, true);
+    });
+
+    it('should remove session and return false when others remain', function () {
+      // Register two sessions
+      const session1 = registerSession(testPort, process.pid);
+      const session2 = registerSession(testPort, process.pid);
+
+      // Unregister first
+      const shouldKill = unregisterSession(session1);
+
+      assert.strictEqual(shouldKill, false, 'should not kill - other sessions active');
+
+      const lock = JSON.parse(fs.readFileSync(sessionLockPath, 'utf-8'));
+      assert.strictEqual(lock.sessions.length, 1);
+      assert.strictEqual(lock.sessions[0], session2);
+    });
+
+    it('should return true and delete lock when last session', function () {
+      // Register single session
+      const session1 = registerSession(testPort, process.pid);
+
+      // Unregister it
+      const shouldKill = unregisterSession(session1);
+
+      assert.strictEqual(shouldKill, true, 'should kill - last session');
+      assert.strictEqual(fs.existsSync(sessionLockPath), false, 'should delete lock file');
+    });
+
+    it('should handle unregistering non-existent session gracefully', function () {
+      // Register a session
+      registerSession(testPort, process.pid);
+
+      // Try to unregister wrong session
+      const shouldKill = unregisterSession('wrong-session-id');
+
+      // Should return false since a session still exists
+      assert.strictEqual(shouldKill, false);
+    });
+  });
+
+  describe('getSessionCount', function () {
+    it('should return 0 when no lock exists', function () {
+      assert.strictEqual(getSessionCount(), 0);
+    });
+
+    it('should return correct count', function () {
+      registerSession(testPort, process.pid);
+      assert.strictEqual(getSessionCount(), 1);
+
+      registerSession(testPort, process.pid);
+      assert.strictEqual(getSessionCount(), 2);
+
+      registerSession(testPort, process.pid);
+      assert.strictEqual(getSessionCount(), 3);
+    });
+  });
+
+  describe('hasActiveSessions', function () {
+    it('should return false when no lock exists', function () {
+      assert.strictEqual(hasActiveSessions(), false);
+    });
+
+    it('should return true when sessions exist and proxy running', function () {
+      registerSession(testPort, process.pid);
+      assert.strictEqual(hasActiveSessions(), true);
+    });
+
+    it('should return false and cleanup when proxy is dead', function () {
+      // Create lock with dead PID
+      const lock = {
+        port: testPort,
+        pid: 999999999,
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      assert.strictEqual(hasActiveSessions(), false);
+      assert.strictEqual(fs.existsSync(sessionLockPath), false);
+    });
+  });
+
+  describe('cleanupOrphanedSessions', function () {
+    it('should do nothing when no lock exists', function () {
+      cleanupOrphanedSessions(testPort);
+      // Should not throw
+    });
+
+    it('should not cleanup when port differs', function () {
+      const lock = {
+        port: 9999,
+        pid: 999999999, // Dead PID
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      cleanupOrphanedSessions(testPort);
+
+      // Should still exist (different port)
+      assert.strictEqual(fs.existsSync(sessionLockPath), true);
+    });
+
+    it('should cleanup when proxy is dead', function () {
+      const lock = {
+        port: testPort,
+        pid: 999999999, // Dead PID
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      cleanupOrphanedSessions(testPort);
+
+      assert.strictEqual(fs.existsSync(sessionLockPath), false);
+    });
+
+    it('should not cleanup when proxy is alive', function () {
+      const lock = {
+        port: testPort,
+        pid: process.pid, // Current process - alive
+        sessions: ['session1'],
+        startedAt: new Date().toISOString(),
+      };
+      fs.writeFileSync(sessionLockPath, JSON.stringify(lock));
+
+      cleanupOrphanedSessions(testPort);
+
+      assert.strictEqual(fs.existsSync(sessionLockPath), true);
+    });
+  });
+
+  describe('Multi-session scenario', function () {
+    it('should handle complete multi-terminal workflow', function () {
+      // Terminal 1 starts - first session
+      const session1 = registerSession(testPort, process.pid);
+      assert.strictEqual(getSessionCount(), 1);
+
+      // Terminal 2 starts - joins existing
+      const session2 = registerSession(testPort, process.pid);
+      assert.strictEqual(getSessionCount(), 2);
+
+      // Terminal 3 starts - joins existing
+      const session3 = registerSession(testPort, process.pid);
+      assert.strictEqual(getSessionCount(), 3);
+
+      // Terminal 1 exits - should NOT kill proxy
+      let shouldKill = unregisterSession(session1);
+      assert.strictEqual(shouldKill, false);
+      assert.strictEqual(getSessionCount(), 2);
+
+      // Terminal 3 exits - should NOT kill proxy
+      shouldKill = unregisterSession(session3);
+      assert.strictEqual(shouldKill, false);
+      assert.strictEqual(getSessionCount(), 1);
+
+      // Terminal 2 exits - SHOULD kill proxy (last session)
+      shouldKill = unregisterSession(session2);
+      assert.strictEqual(shouldKill, true);
+      assert.strictEqual(getSessionCount(), 0);
+      assert.strictEqual(fs.existsSync(sessionLockPath), false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #118 - CLIProxy shared port causes ConnectionRefused when one session exits.

- Add session tracking with reference counting via lock file (`~/.ccs/cliproxy/sessions.json`)
- Multiple CCS sessions now safely share a single proxy on port 8317
- When any session exits, proxy only terminates if it was the last session
- New sessions join existing healthy proxy instead of killing it

## Changes

| File | Change |
|------|--------|
| `src/cliproxy/session-tracker.ts` | **New** - Lock file based reference counting |
| `src/cliproxy/cliproxy-executor.ts` | Reuse existing proxy, conditional cleanup |
| `tests/unit/cliproxy/session-tracker.test.js` | **New** - 21 unit tests |

## How It Works

```
Terminal 1 → spawn proxy → register session1
Terminal 2 → detect existing → register session2 (shows "Joined existing CLIProxy")
Terminal 1 exits → unregister session1 → proxy stays (session2 active)
Terminal 2 exits → unregister session2 → proxy killed (last session)
```

## Test Plan

- [x] TypeScript compiles (`bun run typecheck`)
- [x] ESLint passes (`bun run lint:fix`)
- [x] Prettier formatted (`bun run format`)
- [x] All 491 tests pass (`bun run test:all`)
- [x] Manual test: Open 2 terminals, run `ccs gemini`, exit first terminal, verify second continues working
