### PR TITLE
fix(websearch): pass through to native WebSearch for account profiles

### DIFF
--- a/lib/hooks/websearch-transformer.cjs
+++ b/lib/hooks/websearch-transformer.cjs
@@ -116,6 +116,24 @@ const DEFAULT_TIMEOUT_SEC = 55;
 // HOOK LOGIC - Generally no need to edit below
 // ============================================================================
 
+/**
+ * Determine if hook should skip and pass through to native WebSearch.
+ * Returns true for native Claude accounts where WebSearch works server-side.
+ */
+function shouldSkipHook() {
+  // Explicit skip signal (set by CCS for account profiles)
+  if (process.env.CCS_WEBSEARCH_SKIP === '1') return true;
+
+  // Account/default profiles - use native WebSearch
+  const profileType = process.env.CCS_PROFILE_TYPE;
+  if (profileType === 'account' || profileType === 'default') return true;
+
+  // Explicit disable
+  if (process.env.CCS_WEBSEARCH_ENABLED === '0') return true;
+
+  return false;
+}
+
 // Read input from stdin
 let input = '';
 process.stdin.setEncoding('utf8');
@@ -164,13 +182,8 @@ function isProviderEnabled(provider) {
  */
 async function processHook() {
   try {
-    // Skip if disabled (for official Claude subscriptions)
-    if (process.env.CCS_WEBSEARCH_SKIP === '1') {
-      process.exit(0);
-    }
-
-    // Check if enabled (default: enabled)
-    if (process.env.CCS_WEBSEARCH_ENABLED === '0') {
+    // Skip for native accounts (account, default profiles) or explicit disable
+    if (shouldSkipHook()) {
       process.exit(0);
     }
 
@@ -238,7 +251,9 @@ async function processHook() {
 
     // All providers failed or none enabled
     if (enabledProviders.length === 0) {
-      outputNoProvidersEnabled(query);
+      // No providers enabled - pass through to native WebSearch
+      // This allows native Claude accounts to use server-side WebSearch
+      process.exit(0);
     } else {
       outputAllFailedMessage(query, errors);
     }

--- a/src/cliproxy/cliproxy-executor.ts
+++ b/src/cliproxy/cliproxy-executor.ts
@@ -426,7 +426,12 @@ export async function execClaudeWithCLIProxy(
   // Uses custom settings path (for variants), user settings, or bundled defaults
   const envVars = getEffectiveEnvVars(provider, cfg.port, cfg.customSettingsPath);
   const webSearchEnv = getWebSearchHookEnv();
-  const env = { ...process.env, ...envVars, ...webSearchEnv };
+  const env = {
+    ...process.env,
+    ...envVars,
+    ...webSearchEnv,
+    CCS_PROFILE_TYPE: 'cliproxy', // Signal to WebSearch hook this is a third-party provider
+  };
 
   log(`Claude env: ANTHROPIC_BASE_URL=${envVars.ANTHROPIC_BASE_URL}`);
   log(`Claude env: ANTHROPIC_MODEL=${envVars.ANTHROPIC_MODEL}`);


### PR DESCRIPTION
## Summary
- Fix WebSearch hook blocking native Claude accounts (`ccs ck`, `default`) with "No Providers Enabled" instead of passing through to server-side WebSearch
- Add profile type awareness to WebSearch hook via `CCS_PROFILE_TYPE` and `CCS_WEBSEARCH_SKIP` env vars
- Fix critical bug: when no providers enabled, hook now exits with code 0 (pass-through) instead of blocking

## Changes
| File | Change |
|------|--------|
| `lib/hooks/websearch-transformer.cjs` | Add `shouldSkipHook()` function; fix pass-through when no providers enabled |
| `src/ccs.ts` | Add profile type env vars for account/default/settings profiles |
| `src/cliproxy/cliproxy-executor.ts` | Add `CCS_PROFILE_TYPE: 'cliproxy'` to env |

## Behavior After Fix
| Profile Type | WebSearch Behavior |
|--------------|-------------------|
| `cliproxy` (gemini, codex, agy, qwen) | Replaced by Gemini/OpenCode/Grok |
| `settings` (glm, glmt, kimi) | Replaced |
| `account` (ck, work, personal) | **Native (pass-through)** ✅ |
| `default` (no profile) | **Native (pass-through)** ✅ |

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] All 491 unit tests pass
- [x] Manual hook test: `CCS_PROFILE_TYPE=account` → exit 0 (pass-through)
- [x] Manual hook test: `CCS_PROFILE_TYPE=cliproxy CCS_WEBSEARCH_GEMINI=1` → blocks with results