### PR TITLE
fix(remote-proxy): fix TypeError and make port optional with protocol defaults

### DIFF
--- a/src/cliproxy/config-generator.ts
+++ b/src/cliproxy/config-generator.ts
@@ -490,9 +490,13 @@ export function ensureProviderSettings(provider: CLIProxyProvider): void {
  */
 export function getRemoteEnvVars(
   provider: CLIProxyProvider,
-  remoteConfig: { host: string; port: number; protocol: 'http' | 'https'; authToken?: string }
+  remoteConfig: { host: string; port?: number; protocol: 'http' | 'https'; authToken?: string }
 ): Record<string, string> {
-  const baseUrl = `${remoteConfig.protocol}://${remoteConfig.host}:${remoteConfig.port}/api/provider/${provider}`;
+  // Build URL with smart port handling - omit if using protocol default
+  const defaultPort = remoteConfig.protocol === 'https' ? 443 : 80;
+  const effectivePort = remoteConfig.port ?? defaultPort;
+  const portSuffix = effectivePort === defaultPort ? '' : `:${effectivePort}`;
+  const baseUrl = `${remoteConfig.protocol}://${remoteConfig.host}${portSuffix}/api/provider/${provider}`;
   const models = getModelMapping(provider);
 
   // Get global env vars (DISABLE_TELEMETRY, etc.)

--- a/src/config/unified-config-loader.ts
+++ b/src/config/unified-config-loader.ts
@@ -184,7 +184,8 @@ function mergeWithDefaults(partial: Partial<UnifiedConfig>): UnifiedConfig {
         enabled:
           partial.cliproxy_server?.remote?.enabled ?? DEFAULT_CLIPROXY_SERVER_CONFIG.remote.enabled,
         host: partial.cliproxy_server?.remote?.host ?? DEFAULT_CLIPROXY_SERVER_CONFIG.remote.host,
-        port: partial.cliproxy_server?.remote?.port ?? DEFAULT_CLIPROXY_SERVER_CONFIG.remote.port,
+        // Port is optional - undefined means use protocol default (443/80)
+        port: partial.cliproxy_server?.remote?.port,
         protocol:
           partial.cliproxy_server?.remote?.protocol ??
           DEFAULT_CLIPROXY_SERVER_CONFIG.remote.protocol,

--- a/src/config/unified-config-types.ts
+++ b/src/config/unified-config-types.ts
@@ -195,8 +195,14 @@ export interface ProxyRemoteConfig {
   enabled: boolean;
   /** Remote proxy hostname or IP (empty = not configured) */
   host: string;
-  /** Remote proxy port (default: 8317) */
-  port: number;
+  /**
+   * Remote proxy port.
+   * Optional - defaults based on protocol:
+   * - HTTPS: 443
+   * - HTTP: 80
+   * When empty/undefined, uses protocol default.
+   */
+  port?: number;
   /** Protocol for remote connection */
   protocol: 'http' | 'https';
   /** Auth token for remote proxy (optional, sent as header) */
@@ -345,12 +351,13 @@ export const DEFAULT_COPILOT_CONFIG: CopilotConfig = {
 /**
  * Default CLIProxy server configuration.
  * Local mode by default - remote must be explicitly enabled.
+ * Port is optional for remote - defaults based on protocol.
  */
 export const DEFAULT_CLIPROXY_SERVER_CONFIG: CliproxyServerConfig = {
   remote: {
     enabled: false,
     host: '',
-    port: 8317,
+    // port is intentionally omitted - will use protocol default (443 for HTTPS, 80 for HTTP)
     protocol: 'http',
     auth_token: '',
   },

--- a/src/web-server/routes/proxy-routes.ts
+++ b/src/web-server/routes/proxy-routes.ts
@@ -72,14 +72,20 @@ router.post('/test', async (req: Request, res: Response) => {
   try {
     const { host, port, protocol, authToken, allowSelfSigned } = req.body;
 
-    if (!host || !port) {
-      res.status(400).json({ error: 'Host and port are required' });
+    // Host is required, port is optional (uses protocol defaults)
+    if (!host) {
+      res.status(400).json({ error: 'Host is required' });
       return;
     }
 
+    // Parse port - treat empty string, 0, null as "use default"
+    const parsedPort = port && port !== '' ? parseInt(String(port), 10) : undefined;
+    const effectivePort =
+      parsedPort && !isNaN(parsedPort) && parsedPort > 0 ? parsedPort : undefined;
+
     const status = await testConnection({
       host,
-      port: typeof port === 'number' ? port : parseInt(port, 10),
+      port: effectivePort,
       protocol: protocol || 'http',
       authToken,
       allowSelfSigned: allowSelfSigned || false,

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -166,7 +166,8 @@ export interface RemoteProxyStatus {
 export interface ProxyRemoteConfig {
   enabled: boolean;
   host: string;
-  port: number;
+  /** Port is optional - uses protocol default (443 for HTTPS, 80 for HTTP) */
+  port?: number;
   protocol: 'http' | 'https';
   auth_token: string;
 }
@@ -402,7 +403,8 @@ export const api = {
     /** Test remote proxy connection */
     test: (params: {
       host: string;
-      port: number;
+      /** Port is optional - uses protocol default (443 for HTTPS, 80 for HTTP) */
+      port?: number;
       protocol: 'http' | 'https';
       authToken?: string;
       allowSelfSigned?: boolean;


### PR DESCRIPTION
## Summary
- Fix `TypeError: error.code?.toLowerCase is not a function` when testing remote proxy connection
- Make port optional for remote proxy - defaults to 443 (HTTPS) or 80 (HTTP)
- Smart URL building - omits port when using protocol default (e.g., `https://proxy.example.com` instead of `https://proxy.example.com:443`)

## Changes
- **Bug fix**: Add type guard for `error.code` which can be string, number, or undefined
- **UX improvement**: Port field now optional with dynamic placeholder showing protocol default
- **Validation**: Only host is required; empty port uses smart defaults

## Test plan
- [x] All 544 tests pass
- [x] TypeScript compilation passes
- [x] UI validation passes
- [x] Format checks pass

Closes #142