### PR TITLE
fix(cliproxy): correct remote proxy URL building for default port

### DIFF
--- a/src/config/unified-config-loader.ts
+++ b/src/config/unified-config-loader.ts
@@ -309,6 +309,27 @@ function generateYamlWithComments(config: UnifiedConfig): string {
   );
   lines.push('');
 
+  // CLIProxy Server section (remote proxy configuration) - placed right after cliproxy
+  if (config.cliproxy_server) {
+    lines.push('# ----------------------------------------------------------------------------');
+    lines.push('# CLIProxy Server: Remote proxy connection settings');
+    lines.push('# Configure via Dashboard (`ccs config`) > Proxy tab.');
+    lines.push('#');
+    lines.push('# remote: Connect to a remote CLIProxyAPI instance');
+    lines.push('# fallback: Use local proxy if remote is unreachable');
+    lines.push('# local: Local proxy settings (port, auto-start)');
+    lines.push('# ----------------------------------------------------------------------------');
+    lines.push(
+      yaml
+        .dump(
+          { cliproxy_server: config.cliproxy_server },
+          { indent: 2, lineWidth: -1, quotingType: '"' }
+        )
+        .trim()
+    );
+    lines.push('');
+  }
+
   // Preferences section
   lines.push('# ----------------------------------------------------------------------------');
   lines.push('# Preferences: User settings');
@@ -370,27 +391,6 @@ function generateYamlWithComments(config: UnifiedConfig): string {
     lines.push('# ----------------------------------------------------------------------------');
     lines.push(
       yaml.dump({ copilot: config.copilot }, { indent: 2, lineWidth: -1, quotingType: '"' }).trim()
-    );
-    lines.push('');
-  }
-
-  // CLIProxy Server section (remote proxy configuration)
-  if (config.cliproxy_server) {
-    lines.push('# ----------------------------------------------------------------------------');
-    lines.push('# CLIProxy Server: Remote proxy connection settings');
-    lines.push('# Configure via Dashboard (`ccs config`) > Proxy tab.');
-    lines.push('#');
-    lines.push('# remote: Connect to a remote CLIProxyAPI instance');
-    lines.push('# fallback: Use local proxy if remote is unreachable');
-    lines.push('# local: Local proxy settings (port, auto-start)');
-    lines.push('# ----------------------------------------------------------------------------');
-    lines.push(
-      yaml
-        .dump(
-          { cliproxy_server: config.cliproxy_server },
-          { indent: 2, lineWidth: -1, quotingType: '"' }
-        )
-        .trim()
     );
     lines.push('');
   }


### PR DESCRIPTION
## Summary
- Move `cliproxy_server` section to be adjacent to `cliproxy` in config.yaml for better organization
- Fix URL building bug where port 8317 was omitted from HTTP URLs (incorrectly treated as "default port")
  - Before: `http://192.168.2.84/v1/models` (hits port 80, fails)
  - After: `http://192.168.2.84:8317/v1/models` (correct port)
- Now only standard web ports (80/443) are omitted; CLIProxyAPI default port 8317 is always included

## Test plan
- [ ] Test connection to remote proxy with explicit port 8317
- [ ] Test connection to remote proxy with empty port field (should default to 8317)
- [ ] Verify config.yaml shows cliproxy_server right after cliproxy section
- [ ] Run `bun test tests/unit/cliproxy/remote-proxy-client.test.ts` (8 tests pass)