### PR TITLE
fix(ui): initialize colors early for consistent status output

### DIFF
--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -255,6 +255,13 @@ async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const firstArg = args[0];
 
+  // Initialize UI colors early to ensure consistent colored output
+  // Must happen before any status messages (ok, info, fail, etc.)
+  if (process.stdout.isTTY && !process.env['CI']) {
+    const { initUI } = await import('./utils/ui');
+    await initUI();
+  }
+
   // Trigger update check early for ALL commands except version/help/update
   // Only if TTY and not CI to avoid noise in automated environments
   const skipUpdateCheck = [


### PR DESCRIPTION
## Summary
- Call `initUI()` at the start of `main()` to ensure chalk is loaded before any status messages
- Previously, colors only worked when an update notification was displayed because `showUpdateNotification()` was the only place calling `initUI()`

## Test plan
- [x] Run `ccs agy` without update available → status lines should be colored
- [x] Run `ccs agy` with update available → status lines should still be colored
- [ ] Run in CI/non-TTY → no colors (expected)

Fixes #201
