### PR TITLE
fix(cliproxy): ensure version sync after binary update

### DIFF
--- a/src/utils/port-utils.ts
+++ b/src/utils/port-utils.ts
@@ -182,6 +182,32 @@ export interface BindingTestResult {
 }
 
 /**
+ * Wait for a port to become free (no process listening)
+ * @param port Port number to wait for
+ * @param timeoutMs Maximum time to wait in milliseconds (default: 5000)
+ * @param pollIntervalMs Interval between checks in milliseconds (default: 200)
+ * @returns True if port became free, false if timeout
+ */
+export async function waitForPortFree(
+  port: number,
+  timeoutMs = 5000,
+  pollIntervalMs = 200
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    const process = await getPortProcess(port);
+    if (!process) {
+      return true; // Port is free
+    }
+    // Wait before next check
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  return false; // Timeout reached
+}
+
+/**
  * Test if we can bind to localhost on a specific port
  * This verifies network stack is working and port is actually available
  */


### PR DESCRIPTION
## Summary

Fixes CLIProxy version mismatch issue where old proxy continues running after binary update.

**Root cause:** Binary update only replaced the file on disk; running process (loaded in memory) was unaffected.

### Changes

- **SIGKILL escalation** - After 3s SIGTERM timeout, escalate to SIGKILL for reliable termination
- **Auto-stop on update** - Stop running proxy before binary replacement, wait for port release
- **Version mismatch detection** - On startup, compare running vs installed version and auto-restart if mismatched
- **Version tracking** - Store version in session lock file for fast detection

### Files Changed

| File | Change |
|------|--------|
| `session-tracker.ts` | SIGKILL escalation, version in lock, `getRunningProxyVersion()` |
| `port-utils.ts` | `waitForPortFree()` utility |
| `binary-manager.ts` | Auto-stop proxy before update |
| `cliproxy-executor.ts` | Version mismatch detection, auto-restart |
| `proxy-detector.ts` | Version field in `ProxyStatus` |

## Test plan

- [x] 788 unit tests pass
- [x] Typecheck, lint, format pass
- [ ] Manual test: `ccs cliproxy --latest` while proxy running
- [ ] Manual test: Verify version syncs after update