### PR TITLE
feat(ui): add auth profile management to Dashboard

### DIFF
--- a/ui/src/components/account/create-auth-profile-dialog.tsx
+++ b/ui/src/components/account/create-auth-profile-dialog.tsx
@@ -1,0 +1,124 @@
+/**
+ * Create Auth Profile Dialog
+ * Shows CLI command for creating auth profiles (Dashboard cannot spawn Claude login directly)
+ */
+
+import { useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Copy, Check, Terminal } from 'lucide-react';
+
+interface CreateAuthProfileDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CreateAuthProfileDialog({ open, onClose }: CreateAuthProfileDialogProps) {
+  const [profileName, setProfileName] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  // Validate profile name: alphanumeric, dash, underscore only
+  const isValidName = /^[a-zA-Z][a-zA-Z0-9_-]*$/.test(profileName);
+  const command = profileName ? `ccs auth create ${profileName}` : 'ccs auth create <name>';
+
+  const handleCopy = async () => {
+    if (!isValidName) return;
+    await navigator.clipboard.writeText(command);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleClose = () => {
+    setProfileName('');
+    setCopied(false);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Create New Account</DialogTitle>
+          <DialogDescription>
+            Auth profiles require Claude CLI login. Run the command below in your terminal.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="profile-name">Profile Name</Label>
+            <Input
+              id="profile-name"
+              value={profileName}
+              onChange={(e) => setProfileName(e.target.value)}
+              placeholder="e.g., work, personal, client"
+              autoComplete="off"
+            />
+            {profileName && !isValidName && (
+              <p className="text-xs text-destructive">
+                Name must start with a letter and contain only letters, numbers, dashes, or
+                underscores.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>Command</Label>
+            <div className="flex items-center gap-2 p-3 bg-muted rounded-md font-mono text-sm">
+              <Terminal className="w-4 h-4 text-muted-foreground shrink-0" />
+              <code className="flex-1 break-all">{command}</code>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="shrink-0 h-8 px-2"
+                onClick={handleCopy}
+                disabled={!isValidName}
+              >
+                {copied ? (
+                  <Check className="w-4 h-4 text-green-500" />
+                ) : (
+                  <Copy className="w-4 h-4" />
+                )}
+              </Button>
+            </div>
+          </div>
+
+          <div className="text-sm text-muted-foreground space-y-1">
+            <p>After running the command:</p>
+            <ol className="list-decimal list-inside pl-2 space-y-0.5">
+              <li>Complete the Claude login in your browser</li>
+              <li>Return here and refresh to see the new account</li>
+            </ol>
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={handleClose}>
+              Close
+            </Button>
+            <Button onClick={handleCopy} disabled={!isValidName}>
+              {copied ? (
+                <>
+                  <Check className="w-4 h-4 mr-2" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-4 h-4 mr-2" />
+                  Copy Command
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/account/index.ts
+++ b/ui/src/components/account/index.ts
@@ -5,6 +5,7 @@
 // Main components
 export { AccountsTable } from './accounts-table';
 export { AddAccountDialog } from './add-account-dialog';
+export { CreateAuthProfileDialog } from './create-auth-profile-dialog';
 
 // Flow visualization (from subdirectory)
 export { AccountFlowViz } from './flow-viz';

--- a/ui/src/hooks/use-accounts.ts
+++ b/ui/src/hooks/use-accounts.ts
@@ -1,6 +1,6 @@
 /**
  * React Query hooks for accounts (profiles.json)
- * Phase 03: REST API Routes & CRUD
+ * Dashboard parity: Full CRUD operations for auth profiles
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -22,6 +22,36 @@ export function useSetDefaultAccount() {
     onSuccess: (_data, name) => {
       queryClient.invalidateQueries({ queryKey: ['accounts'] });
       toast.success(`Default account set to "${name}"`);
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+}
+
+export function useResetDefaultAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => api.accounts.resetDefault(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      toast.success('Default account reset to CCS');
+    },
+    onError: (error: Error) => {
+      toast.error(error.message);
+    },
+  });
+}
+
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (name: string) => api.accounts.delete(name),
+    onSuccess: (_data, name) => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] });
+      toast.success(`Account "${name}" deleted`);
     },
     onError: (error: Error) => {
       toast.error(error.message);

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -351,6 +351,8 @@ export const api = {
         method: 'POST',
         body: JSON.stringify({ name }),
       }),
+    resetDefault: () => request('/accounts/reset-default', { method: 'DELETE' }),
+    delete: (name: string) => request(`/accounts/${name}`, { method: 'DELETE' }),
   },
   // Unified config API
   config: {

--- a/ui/src/pages/accounts.tsx
+++ b/ui/src/pages/accounts.tsx
@@ -1,13 +1,18 @@
 /**
  * Accounts Page
- * Phase 03: REST API Routes & CRUD
+ * Dashboard parity: Auth profile CRUD operations
  */
 
+import { useState } from 'react';
+import { Plus } from 'lucide-react';
 import { AccountsTable } from '@/components/account/accounts-table';
+import { CreateAuthProfileDialog } from '@/components/account/create-auth-profile-dialog';
+import { Button } from '@/components/ui/button';
 import { useAccounts } from '@/hooks/use-accounts';
 
 export function AccountsPage() {
-  const { data, isLoading } = useAccounts();
+  const { data, isLoading, refetch } = useAccounts();
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   return (
     <div className="p-6 max-w-6xl mx-auto space-y-8">
@@ -18,22 +23,23 @@ export function AccountsPage() {
             Manage multi-account Claude sessions (profiles.json)
           </p>
         </div>
+        <Button onClick={() => setCreateDialogOpen(true)}>
+          <Plus className="w-4 h-4 mr-2" />
+          Create Account
+        </Button>
       </div>
 
       {isLoading ? (
         <div className="text-muted-foreground">Loading accounts...</div>
       ) : (
-        <AccountsTable data={data?.accounts || []} defaultAccount={data?.default ?? null} />
+        <AccountsTable
+          data={data?.accounts || []}
+          defaultAccount={data?.default ?? null}
+          onRefresh={refetch}
+        />
       )}
 
-      <div className="text-sm text-muted-foreground border-t pt-4 mt-4">
-        <p>
-          Accounts are isolated Claude instances with separate sessions.
-          <br />
-          Use <code className="bg-muted px-1 rounded">ccs auth create &lt;name&gt;</code> to add new
-          accounts via CLI.
-        </p>
-      </div>
+      <CreateAuthProfileDialog open={createDialogOpen} onClose={() => setCreateDialogOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements CLI/Dashboard parity for auth profile management per the updated design philosophy.

- Add "Create Account" button with dialog showing CLI command to copy
- Add delete profile button with confirmation dialog
- Add "Reset to CCS Default" button
- Add backend DELETE endpoints for accounts

## Changes

| File | Description |
|------|-------------|
| `create-auth-profile-dialog.tsx` | New dialog for creating profiles via CLI command copy |
| `accounts-table.tsx` | Added delete button, reset default button, confirmation dialogs |
| `use-accounts.ts` | Added `useDeleteAccount` and `useResetDefaultAccount` hooks |
| `api-client.ts` | Added `delete` and `resetDefault` API methods |
| `account-routes.ts` | Added DELETE endpoints for `/accounts/:name` and `/accounts/reset-default` |

## Test plan

- [ ] Navigate to Accounts page
- [ ] Click "Create Account" → dialog shows CLI command
- [ ] Copy command and verify it's correct format
- [ ] Test delete button on non-default account → confirmation appears
- [ ] Confirm delete → account removed from list
- [ ] Test "Reset to CCS Default" button
- [ ] Verify default account cannot be deleted (button disabled)
- [ ] Run `bun run validate` in both main and UI projects

## Related

- Refs: plans/251227-0114-ccs-cli-dashboard-parity-audit