### PR TITLE
fix(cliproxy): use correct default port for remote HTTP connections

### DIFF
--- a/src/cliproxy/remote-proxy-client.ts
+++ b/src/cliproxy/remote-proxy-client.ts
@@ -6,6 +6,7 @@
  */
 
 import * as https from 'https';
+import { getRemoteDefaultPort, validateRemotePort } from './config-generator';
 
 /** Error codes for remote proxy status */
 export type RemoteProxyErrorCode =
@@ -53,17 +54,6 @@ export interface RemoteProxyClientConfig {
 const DEFAULT_TIMEOUT_MS = 2000;
 
 /**
- * Get default port for CLIProxyAPI based on protocol.
- * - HTTP: 8317 (CLIProxyAPI default for local/dev scenarios)
- * - HTTPS: 443 (standard SSL port for production remote servers)
- *
- * This matches the UI labels shown to users.
- */
-function getDefaultPort(protocol: 'http' | 'https'): number {
-  return protocol === 'https' ? 443 : 8317;
-}
-
-/**
  * Get standard web port for protocol (for URL display omission)
  * These are the ports that browsers/HTTP clients use by default.
  * HTTP: 80, HTTPS: 443
@@ -74,10 +64,11 @@ function getStandardWebPort(protocol: 'http' | 'https'): number {
 
 /**
  * Get effective port for CLIProxyAPI connection.
- * If port is provided, use it. Otherwise use protocol-based default.
+ * Validates port and uses protocol-based default for invalid/undefined values.
  */
 function getEffectivePort(port: number | undefined, protocol: 'http' | 'https'): number {
-  return port ?? getDefaultPort(protocol);
+  const validatedPort = validateRemotePort(port);
+  return validatedPort ?? getRemoteDefaultPort(protocol);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes inconsistent default port handling for remote CLIProxyAPI configuration:
- Test Connection used 8317 (correct) but actual API calls used 80 (wrong)
- Added centralized `getRemoteDefaultPort()` helper for DRY compliance
- Fixed 3 locations using wrong default port

## Issues Fixed

1. **Port empty → :80 instead of :8317**: Dashboard Test Connection passed but actual /auth calls failed
2. **BASEURL construction wrong**: `ccs gemini` routed to Claude instead of remote proxy
3. **CLIProxy Plus auth fetch failed**: Dashboard showed local auth instead of remote

## Changes

| File | Change |
|------|--------|
| `config-generator.ts` | Added `getRemoteDefaultPort()` helper, fixed `rewriteLocalhostUrls()` and `getRemoteEnvVars()` |
| `proxy-target-resolver.ts` | Updated to use shared helper |
| `remote-proxy-client.ts` | Removed duplicate logic, uses shared helper |

## Test Plan

- [x] `bun run format` - passed
- [x] `bun run lint:fix` - passed
- [x] `bun run typecheck` - passed
- [x] `bun run build` - passed
- [x] `bun run test:unit` - 746 tests pass