### PR TITLE
fix(prompt): stdin.pause() to prevent process hang after password input

### DIFF
--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -174,6 +174,7 @@ export class InteractivePrompt {
           process.stdin.setRawMode(false);
         }
         process.stdin.removeListener('data', onData);
+        process.stdin.pause();
       };
 
       const onData = (data: Buffer): void => {


### PR DESCRIPTION
## Summary
- Added `process.stdin.pause()` in password input cleanup to prevent event loop from staying alive

## Root Cause
`InteractivePrompt.password()` calls `process.stdin.resume()` but never pauses stdin in cleanup, keeping Node.js event loop running indefinitely after `ccs api create` completes.

## Fix
Single line addition in `src/utils/prompt.ts:177`:
```typescript
process.stdin.pause();
```

Closes #236

## Test plan
- [x] All 788 tests pass
- [x] `bun run validate` passes