### PR TITLE
feat(agy): promote gemini-claude-sonnet-4-5 as default Haiku model

### DIFF
--- a/config/base-agy.settings.json
+++ b/config/base-agy.settings.json
@@ -5,6 +5,6 @@
     "ANTHROPIC_MODEL": "gemini-3-pro-preview",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "gemini-3-pro-preview",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "gemini-3-pro-preview",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-3-flash-preview"
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gemini-claude-sonnet-4-5"
   }
 }


### PR DESCRIPTION
## Summary

- Replace `gemini-3-flash-preview` with `gemini-claude-sonnet-4-5` as default Haiku model for `ccs agy`

Closes #270

## Test plan

- [x] All 888 tests pass
- [ ] Verify `ccs agy` uses correct model when Haiku is selected
