### PR TITLE
fix(websearch): use 'where' command on Windows for CLI detection

### DIFF
--- a/lib/hooks/websearch-transformer.cjs
+++ b/lib/hooks/websearch-transformer.cjs
@@ -154,7 +154,10 @@ process.stdin.on('error', () => {
  */
 function isCliAvailable(cmd) {
   try {
-    const result = spawnSync('which', [cmd], {
+    const isWindows = process.platform === 'win32';
+    const whichCmd = isWindows ? 'where.exe' : 'which';
+
+    const result = spawnSync(whichCmd, [cmd], {
       encoding: 'utf8',
       timeout: 2000,
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- Fixes #273
- WebSearch hook now uses `where` command on Windows instead of hardcoded `which`
- Platform detection via `process.platform === 'win32'`

## Changes
- `lib/hooks/websearch-transformer.cjs`: Added Windows platform detection in `isCliAvailable()` function

## Test plan
- [x] All tests pass (888 pass, 6 skip)
- [ ] Manual test on Windows machine
