### PR TITLE
feat(cliproxy): add background token refresh worker

### DIFF
--- a/src/cliproxy/auth/provider-refreshers/index.ts
+++ b/src/cliproxy/auth/provider-refreshers/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Provider Token Refreshers
+ *
+ * Exports refresh functions for each OAuth provider.
+ * Currently only Gemini is implemented; others return placeholder errors.
+ */
+
+import { CLIProxyProvider } from '../../types';
+import { refreshGeminiToken } from '../gemini-token-refresh';
+
+/** Token refresh result */
+export interface ProviderRefreshResult {
+  success: boolean;
+  error?: string;
+  expiresAt?: number;
+}
+
+/**
+ * Refresh token for a specific provider and account
+ * @param provider Provider to refresh
+ * @param _accountId Account ID (currently unused, multi-account not yet implemented)
+ * @returns Refresh result with success status and optional error
+ */
+export async function refreshToken(
+  provider: CLIProxyProvider,
+  _accountId: string
+): Promise<ProviderRefreshResult> {
+  switch (provider) {
+    case 'gemini':
+      return await refreshGeminiTokenWrapper();
+
+    case 'codex':
+    case 'agy':
+    case 'qwen':
+    case 'iflow':
+    case 'kiro':
+    case 'ghcp':
+      return {
+        success: false,
+        error: `Token refresh not yet implemented for ${provider}`,
+      };
+
+    default:
+      return {
+        success: false,
+        error: `Unknown provider: ${provider}`,
+      };
+  }
+}
+
+/**
+ * Wrapper for Gemini token refresh
+ * Converts gemini-token-refresh.ts format to provider-refreshers format
+ */
+async function refreshGeminiTokenWrapper(): Promise<ProviderRefreshResult> {
+  const result = await refreshGeminiToken();
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: result.error,
+    };
+  }
+
+  return {
+    success: true,
+    expiresAt: result.expiresAt,
+  };
+}

--- a/src/cliproxy/auth/token-expiry-checker.ts
+++ b/src/cliproxy/auth/token-expiry-checker.ts
@@ -1,0 +1,131 @@
+/**
+ * Token Expiry Checker
+ *
+ * Inspects token files to determine expiry times and refresh requirements.
+ * Supports expiry_date field with fallback to file modification time.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { CLIProxyProvider } from '../types';
+import { getProviderAccounts, getAccountTokenPath } from '../account-manager';
+
+/** Preemptive refresh time: refresh tokens 45 minutes before expiry */
+export const PREEMPTIVE_REFRESH_MINUTES = 45;
+
+/** Fallback expiry: assume 50 minutes if no expiry_date field */
+export const FALLBACK_EXPIRY_MINUTES = 50;
+
+/** Maximum token file size in bytes (1MB) - prevent DoS from huge files */
+const MAX_TOKEN_FILE_SIZE = 1024 * 1024;
+
+/** Token expiry information for a single account */
+export interface TokenExpiryInfo {
+  /** Provider name */
+  provider: CLIProxyProvider;
+  /** Account ID */
+  accountId: string;
+  /** Path to token file */
+  tokenFile: string;
+  /** Expiry timestamp (Unix ms) */
+  expiresAt: number;
+  /** Whether token needs refresh (within preemptive window) */
+  needsRefresh: boolean;
+  /** Token file last modified time */
+  lastModified: Date;
+}
+
+/**
+ * Token file structure
+ */
+interface TokenData {
+  access_token?: string;
+  refresh_token?: string;
+  expiry_date?: number; // Unix timestamp ms
+  type?: string;
+}
+
+/**
+ * Get token expiry info for a specific account
+ * @returns null if token file doesn't exist or is invalid
+ */
+export function getTokenExpiryInfo(
+  provider: CLIProxyProvider,
+  accountId: string
+): TokenExpiryInfo | null {
+  const tokenPath = getAccountTokenPath(provider, accountId);
+  if (!tokenPath || !fs.existsSync(tokenPath)) {
+    return null;
+  }
+
+  try {
+    const stats = fs.statSync(tokenPath);
+
+    // Prevent DoS from huge token files
+    if (stats.size > MAX_TOKEN_FILE_SIZE) {
+      return null;
+    }
+
+    const content = fs.readFileSync(tokenPath, 'utf-8');
+    const data: TokenData = JSON.parse(content);
+
+    // Validate refresh_token exists (required for refresh)
+    if (!data.refresh_token || typeof data.refresh_token !== 'string') {
+      return null;
+    }
+
+    // Calculate expiry time with validation
+    let expiresAt: number;
+    if (
+      data.expiry_date &&
+      typeof data.expiry_date === 'number' &&
+      Number.isFinite(data.expiry_date) &&
+      data.expiry_date > 0
+    ) {
+      // Use expiry_date field if valid
+      expiresAt = data.expiry_date;
+    } else {
+      // Fallback: use file mtime + 50 minutes
+      expiresAt = stats.mtime.getTime() + FALLBACK_EXPIRY_MINUTES * 60 * 1000;
+    }
+
+    // Check if needs refresh (within preemptive window)
+    const now = Date.now();
+    const timeUntilExpiry = expiresAt - now;
+    const preemptiveMs = PREEMPTIVE_REFRESH_MINUTES * 60 * 1000;
+    const needsRefresh = timeUntilExpiry < preemptiveMs;
+
+    return {
+      provider,
+      accountId,
+      tokenFile: path.basename(tokenPath),
+      expiresAt,
+      needsRefresh,
+      lastModified: stats.mtime,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get token expiry info for all accounts across all providers
+ * @returns Array of token expiry info, excluding invalid tokens
+ */
+export function getAllTokenExpiryInfo(): TokenExpiryInfo[] {
+  const providers: CLIProxyProvider[] = ['gemini', 'codex', 'agy', 'qwen', 'iflow', 'kiro', 'ghcp'];
+  const results: TokenExpiryInfo[] = [];
+
+  for (const provider of providers) {
+    const accounts = getProviderAccounts(provider);
+
+    for (const account of accounts) {
+      const info = getTokenExpiryInfo(provider, account.id);
+      if (info) {
+        results.push(info);
+      }
+    }
+  }
+
+  return results;
+}

--- a/src/cliproxy/auth/token-refresh-config.ts
+++ b/src/cliproxy/auth/token-refresh-config.ts
@@ -1,0 +1,31 @@
+/**
+ * Token Refresh Configuration
+ *
+ * Loads token refresh worker settings from unified config.
+ * Returns null if disabled or not configured.
+ */
+
+import { loadOrCreateUnifiedConfig } from '../../config/unified-config-loader';
+import type { TokenRefreshSettings } from '../../config/unified-config-types';
+
+/**
+ * Get token refresh configuration from unified config
+ * @returns Config if enabled, null if disabled or not configured
+ */
+export function getTokenRefreshConfig(): TokenRefreshSettings | null {
+  const config = loadOrCreateUnifiedConfig();
+
+  // Return null if not configured or explicitly disabled
+  if (!config.cliproxy?.token_refresh?.enabled) {
+    return null;
+  }
+
+  // Return config with defaults
+  return {
+    enabled: true,
+    interval_minutes: config.cliproxy.token_refresh.interval_minutes ?? 30,
+    preemptive_minutes: config.cliproxy.token_refresh.preemptive_minutes ?? 45,
+    max_retries: config.cliproxy.token_refresh.max_retries ?? 3,
+    verbose: config.cliproxy.token_refresh.verbose ?? false,
+  };
+}

--- a/src/cliproxy/auth/token-refresh-worker.ts
+++ b/src/cliproxy/auth/token-refresh-worker.ts
@@ -1,0 +1,280 @@
+/**
+ * Token Refresh Worker
+ *
+ * Background worker that periodically checks and refreshes OAuth tokens
+ * before they expire. Runs as interval loop with retry logic.
+ */
+
+import { CLIProxyProvider } from '../types';
+import { getAllTokenExpiryInfo, TokenExpiryInfo } from './token-expiry-checker';
+import { refreshToken } from './provider-refreshers';
+
+/** Worker configuration */
+export interface TokenRefreshConfig {
+  /** Refresh check interval in minutes (default: 30) */
+  refreshInterval: number;
+  /** Preemptive refresh time in minutes (default: 45) */
+  preemptiveTime: number;
+  /** Maximum retry attempts per token (default: 3) */
+  maxRetries: number;
+  /** Base delay for exponential backoff in ms (default: 1000) */
+  retryBaseDelay: number;
+  /** Timeout for refresh operations in ms (default: 10000) */
+  refreshTimeout: number;
+  /** Enable verbose logging */
+  verbose: boolean;
+}
+
+/** Result of a token refresh attempt */
+export interface RefreshResult {
+  provider: CLIProxyProvider;
+  accountId: string;
+  success: boolean;
+  error?: string;
+  refreshedAt?: Date;
+  nextExpiry?: number;
+}
+
+/** Default worker configuration */
+const DEFAULT_CONFIG: TokenRefreshConfig = {
+  refreshInterval: 30,
+  preemptiveTime: 45,
+  maxRetries: 3,
+  retryBaseDelay: 1000,
+  refreshTimeout: 10000,
+  verbose: false,
+};
+
+/** Minimum config values to prevent infinite loops */
+const MIN_REFRESH_INTERVAL = 1; // 1 minute minimum
+const MIN_RETRY_BASE_DELAY = 100; // 100ms minimum
+
+/** Unrecoverable error patterns - don't retry these */
+const UNRECOVERABLE_ERRORS = [
+  'No refresh token',
+  'Invalid client',
+  'Invalid grant',
+  'Token has been revoked',
+  'Token not found',
+];
+
+/** Validate and sanitize config values */
+function sanitizeConfig(config: TokenRefreshConfig): TokenRefreshConfig {
+  return {
+    refreshInterval: Math.max(
+      MIN_REFRESH_INTERVAL,
+      config.refreshInterval || DEFAULT_CONFIG.refreshInterval
+    ),
+    preemptiveTime: Math.max(0, config.preemptiveTime || DEFAULT_CONFIG.preemptiveTime),
+    maxRetries: Math.max(1, config.maxRetries || DEFAULT_CONFIG.maxRetries),
+    retryBaseDelay: Math.max(
+      MIN_RETRY_BASE_DELAY,
+      config.retryBaseDelay || DEFAULT_CONFIG.retryBaseDelay
+    ),
+    refreshTimeout: Math.max(1000, config.refreshTimeout || DEFAULT_CONFIG.refreshTimeout),
+    verbose: config.verbose ?? DEFAULT_CONFIG.verbose,
+  };
+}
+
+/** Promise with timeout */
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, errorMsg: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => setTimeout(() => reject(new Error(errorMsg)), timeoutMs)),
+  ]);
+}
+
+/**
+ * Background token refresh worker
+ * Manages periodic token refresh checks with retry logic
+ */
+export class TokenRefreshWorker {
+  private config: TokenRefreshConfig;
+  private intervalId: NodeJS.Timeout | null = null;
+  private running = false;
+  private lastResults: RefreshResult[] = [];
+  private exitHandler: (() => void) | null = null;
+
+  constructor(config: Partial<TokenRefreshConfig> = {}) {
+    this.config = sanitizeConfig({ ...DEFAULT_CONFIG, ...config });
+  }
+
+  /**
+   * Start the worker
+   * Runs refresh loop immediately, then on interval
+   */
+  start(): void {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    this.log('[i] Token refresh worker started');
+
+    // Register process exit handlers for cleanup
+    this.exitHandler = () => this.stop();
+    process.on('SIGINT', this.exitHandler);
+    process.on('SIGTERM', this.exitHandler);
+    process.on('beforeExit', this.exitHandler);
+
+    // Run immediately on start
+    void this.refreshLoop();
+
+    // Then run on interval
+    const intervalMs = this.config.refreshInterval * 60 * 1000;
+    this.intervalId = setInterval(() => {
+      void this.refreshLoop();
+    }, intervalMs);
+  }
+
+  /**
+   * Stop the worker
+   */
+  stop(): void {
+    if (!this.running) {
+      return;
+    }
+
+    this.running = false;
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    // Remove process exit handlers
+    if (this.exitHandler) {
+      process.off('SIGINT', this.exitHandler);
+      process.off('SIGTERM', this.exitHandler);
+      process.off('beforeExit', this.exitHandler);
+      this.exitHandler = null;
+    }
+
+    this.log('[i] Token refresh worker stopped');
+  }
+
+  /**
+   * Check if worker is active
+   */
+  isActive(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Manually trigger refresh check now
+   */
+  async refreshNow(): Promise<RefreshResult[]> {
+    return await this.refreshLoop();
+  }
+
+  /**
+   * Get results from last refresh cycle
+   */
+  getLastRefreshResults(): RefreshResult[] {
+    return [...this.lastResults];
+  }
+
+  /**
+   * Main refresh loop
+   * Checks all tokens and refreshes those needing refresh
+   */
+  private async refreshLoop(): Promise<RefreshResult[]> {
+    const results: RefreshResult[] = [];
+
+    try {
+      const tokens = getAllTokenExpiryInfo();
+      const tokensNeedingRefresh = tokens.filter((t) => t.needsRefresh);
+
+      if (tokensNeedingRefresh.length === 0) {
+        this.log('[OK] All tokens valid, no refresh needed');
+        this.lastResults = [];
+        return results;
+      }
+
+      this.log(`[i] Refreshing ${tokensNeedingRefresh.length} token(s)...`);
+
+      for (const token of tokensNeedingRefresh) {
+        const result = await this.refreshWithRetry(token);
+        results.push(result);
+
+        if (result.success) {
+          this.log(`[OK] ${token.provider}/${token.accountId} refreshed`);
+        } else {
+          this.log(`[X] ${token.provider}/${token.accountId} failed: ${result.error}`);
+        }
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      this.log(`[X] Refresh loop error: ${msg}`);
+    }
+
+    this.lastResults = results;
+    return results;
+  }
+
+  /**
+   * Refresh a single token with retry logic
+   * Uses exponential backoff on failures
+   */
+  private async refreshWithRetry(token: TokenExpiryInfo): Promise<RefreshResult> {
+    let lastError = 'Unknown error';
+
+    for (let attempt = 0; attempt < this.config.maxRetries; attempt++) {
+      try {
+        // Apply timeout to refresh operation
+        const result = await withTimeout(
+          refreshToken(token.provider, token.accountId),
+          this.config.refreshTimeout,
+          `Refresh timeout after ${this.config.refreshTimeout}ms`
+        );
+
+        if (result.success) {
+          return {
+            provider: token.provider,
+            accountId: token.accountId,
+            success: true,
+            refreshedAt: new Date(),
+            nextExpiry: result.expiresAt,
+          };
+        }
+
+        lastError = result.error || 'Refresh failed';
+
+        // Don't retry if error indicates unrecoverable issue
+        if (this.isUnrecoverableError(lastError)) {
+          break;
+        }
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : 'Unknown error';
+      }
+
+      // Exponential backoff before retry
+      if (attempt < this.config.maxRetries - 1) {
+        const delay = this.config.retryBaseDelay * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    return {
+      provider: token.provider,
+      accountId: token.accountId,
+      success: false,
+      error: lastError,
+    };
+  }
+
+  /**
+   * Check if error is unrecoverable (should not retry)
+   */
+  private isUnrecoverableError(error: string): boolean {
+    return UNRECOVERABLE_ERRORS.some((pattern) => error.includes(pattern));
+  }
+
+  /**
+   * Log message if verbose enabled
+   */
+  private log(msg: string): void {
+    if (this.config.verbose) {
+      console.error(`[token-refresh] ${msg}`);
+    }
+  }
+}

--- a/src/config/unified-config-types.ts
+++ b/src/config/unified-config-types.ts
@@ -94,6 +94,23 @@ export interface CLIProxyLoggingConfig {
 }
 
 /**
+ * Token refresh configuration.
+ * Manages background token refresh worker settings.
+ */
+export interface TokenRefreshSettings {
+  /** Enable background token refresh (default: false) */
+  enabled?: boolean;
+  /** Refresh check interval in minutes (default: 30) */
+  interval_minutes?: number;
+  /** Preemptive refresh time in minutes (default: 45) */
+  preemptive_minutes?: number;
+  /** Maximum retry attempts per token (default: 3) */
+  max_retries?: number;
+  /** Enable verbose logging (default: false) */
+  verbose?: boolean;
+}
+
+/**
  * CLIProxy configuration section.
  */
 export interface CLIProxyConfig {
@@ -109,6 +126,8 @@ export interface CLIProxyConfig {
   kiro_no_incognito?: boolean;
   /** Global auth configuration for CLIProxyAPI */
   auth?: CLIProxyAuthConfig;
+  /** Background token refresh worker settings */
+  token_refresh?: TokenRefreshSettings;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add background worker that proactively refreshes OAuth tokens before expiry
- Prevents "context canceled" errors during long-running requests
- Configurable via `cliproxy.token_refresh` in unified config

## Changes
- **token-refresh-worker.ts** (280 lines): Background worker with interval loop, retry logic, exponential backoff
- **token-expiry-checker.ts** (131 lines): Multi-provider token inspection with expiry detection
- **provider-refreshers/index.ts** (69 lines): Provider abstraction layer (Gemini implemented)
- **token-refresh-config.ts** (31 lines): Config loader from unified config
- **service-manager.ts** (+77 lines): Lifecycle integration (start/stop with proxy)
- **unified-config-types.ts** (+19 lines): TokenRefreshSettings schema
- **gemini-token-refresh.ts** (+5 lines): Return expiresAt from refresh

## Edge Case Protections
- expiry_date validation (>0, finite, number)
- refresh_token validation
- File size limit (1MB max)
- Process exit handlers (SIGINT/SIGTERM/beforeExit)
- Timeout wrapper for refresh operations
- Config sanitization (min values)
- Unrecoverable error detection (5 patterns)

## Test plan
- [x] All 888 existing tests pass
- [ ] Manual test with Gemini token refresh
- [ ] Verify worker starts/stops with proxy lifecycle