### PR TITLE
fix(cliproxy): update lastUsedAt on normal execution

### DIFF
--- a/src/cliproxy/cliproxy-executor.ts
+++ b/src/cliproxy/cliproxy-executor.ts
@@ -462,6 +462,13 @@ export async function execClaudeWithCLIProxy(
     if (tokenResult.refreshed) {
       log('Token was refreshed proactively');
     }
+
+    // 3a-1. Update lastUsedAt for the account being used
+    // This ensures dashboard shows accurate "Last used" timestamps
+    const usedAccount = getDefaultAccount(provider);
+    if (usedAccount) {
+      touchAccount(provider, usedAccount.id);
+    }
   }
 
   // 3b. Preflight quota check - auto-switch to account with quota before launch


### PR DESCRIPTION
## Summary
- Fix dashboard showing stale "Last used 15h ago" for accounts despite active usage

## Changes
- Add `touchAccount()` call after OAuth token validation
- Applies to all OAuth providers (gemini, codex, agy, kiro, ghcp)
- Updates `lastUsedAt` timestamp on every normal execution

## Root Cause
`touchAccount()` was only called when:
1. Using `--use <account>` flag
2. Auto-switching due to quota exhaustion

Normal execution path never updated `lastUsedAt`.

## Test Plan
- [ ] Run `ccs agy` (or any OAuth provider)
- [ ] Check dashboard - "Last used" should reflect current time