### PR TITLE
refactor(cliproxy): add faulty version range infrastructure

### DIFF
--- a/src/cliproxy/platform-detector.ts
+++ b/src/cliproxy/platform-detector.ts
@@ -21,6 +21,13 @@ export const CLIPROXY_FALLBACK_VERSION = '6.6.40-0';
  */
 export const CLIPROXY_MAX_STABLE_VERSION = '6.6.80-0';
 
+/**
+ * Faulty version range - versions with known critical bugs
+ * v81+ have context cancellation bugs causing intermittent 500 errors
+ * When a stable version is found, update MAX_STABLE and set faulty range accordingly
+ */
+export const CLIPROXY_FAULTY_RANGE = { min: '6.6.81-0', max: '6.6.999-0' };
+
 /** @deprecated Use CLIPROXY_FALLBACK_VERSION instead */
 export const CLIPROXY_VERSION = CLIPROXY_FALLBACK_VERSION;
 


### PR DESCRIPTION
## Summary
- Add `CLIPROXY_FAULTY_RANGE` constant for marking known buggy CLIProxyAPI versions
- Add `isVersionFaulty()` helper function to version-checker
- Update lifecycle warnings to distinguish faulty vs experimental versions
- Include `faultyRange` in `/api/cliproxy/versions` response
- Skip faulty versions when calculating `latestStable`

## Changes
| File | Change |
|------|--------|
| `platform-detector.ts` | Add `CLIPROXY_FAULTY_RANGE` constant |
| `version-checker.ts` | Add `isVersionFaulty()` helper |
| `lifecycle.ts` | Faulty version → upgrade suggestion; experimental → warning |
| `cliproxy-checks.ts` | Separate "(faulty)" vs "(experimental)" health status |
| `cliproxy-stats-routes.ts` | Include faultyRange in API, check in install endpoint |

## Current Configuration
- **Stable**: v80 and below
- **Faulty**: v81+ (context cancellation bugs, issue #269)

## Future Use
When a stable version is found, update:
1. `CLIPROXY_MAX_STABLE_VERSION` → new stable
2. `CLIPROXY_FAULTY_RANGE.max` → version before new stable

## Test Plan
- [x] All 899 unit tests pass
- [x] Typecheck, lint, format pass