### PR TITLE
Codex: inject OpenAI reasoning.effort per tier

### DIFF
--- a/src/cliproxy/cliproxy-executor.ts
+++ b/src/cliproxy/cliproxy-executor.ts
@@ -712,35 +712,39 @@ export async function execClaudeWithCLIProxy(
   // - Unknown → medium
   let codexReasoningProxy: CodexReasoningProxy | null = null;
   let codexReasoningPort: number | null = null;
-  if (provider === 'codex' && envVars.ANTHROPIC_BASE_URL) {
-    try {
-      const traceEnabled =
-        process.env.CCS_CODEX_REASONING_TRACE === '1' ||
-        process.env.CCS_CODEX_REASONING_TRACE === 'true';
-      codexReasoningProxy = new CodexReasoningProxy({
-        upstreamBaseUrl: envVars.ANTHROPIC_BASE_URL,
-        verbose,
-        defaultEffort: 'medium',
-        traceFilePath: traceEnabled
-          ? `${process.env.HOME || ''}/.ccs/codex-reasoning-proxy.log`
-          : '',
-        modelMap: {
-          defaultModel: envVars.ANTHROPIC_MODEL,
-          opusModel: envVars.ANTHROPIC_DEFAULT_OPUS_MODEL,
-          sonnetModel: envVars.ANTHROPIC_DEFAULT_SONNET_MODEL,
-          haikuModel: envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL,
-        },
-      });
-      codexReasoningPort = await codexReasoningProxy.start();
-      log(
-        `Codex reasoning proxy active: http://127.0.0.1:${codexReasoningPort}/api/provider/codex`
-      );
-    } catch (error) {
-      const err = error as Error;
-      codexReasoningProxy = null;
-      codexReasoningPort = null;
-      if (verbose) {
-        console.error(warn(`Codex reasoning proxy disabled: ${err.message}`));
+  if (provider === 'codex') {
+    if (!envVars.ANTHROPIC_BASE_URL) {
+      log('ANTHROPIC_BASE_URL not set for Codex, reasoning proxy disabled');
+    } else {
+      try {
+        const traceEnabled =
+          process.env.CCS_CODEX_REASONING_TRACE === '1' ||
+          process.env.CCS_CODEX_REASONING_TRACE === 'true';
+        codexReasoningProxy = new CodexReasoningProxy({
+          upstreamBaseUrl: envVars.ANTHROPIC_BASE_URL,
+          verbose,
+          defaultEffort: 'medium',
+          traceFilePath: traceEnabled
+            ? `${process.env.HOME || process.cwd()}/.ccs/codex-reasoning-proxy.log`
+            : '',
+          modelMap: {
+            defaultModel: envVars.ANTHROPIC_MODEL,
+            opusModel: envVars.ANTHROPIC_DEFAULT_OPUS_MODEL,
+            sonnetModel: envVars.ANTHROPIC_DEFAULT_SONNET_MODEL,
+            haikuModel: envVars.ANTHROPIC_DEFAULT_HAIKU_MODEL,
+          },
+        });
+        codexReasoningPort = await codexReasoningProxy.start();
+        log(
+          `Codex reasoning proxy active: http://127.0.0.1:${codexReasoningPort}/api/provider/codex`
+        );
+      } catch (error) {
+        const err = error as Error;
+        codexReasoningProxy = null;
+        codexReasoningPort = null;
+        if (verbose) {
+          console.error(warn(`Codex reasoning proxy disabled: ${err.message}`));
+        }
       }
     }
   }

--- a/tests/unit/cliproxy/codex-reasoning-proxy.test.js
+++ b/tests/unit/cliproxy/codex-reasoning-proxy.test.js
@@ -30,12 +30,27 @@ describe('Codex Reasoning Proxy', () => {
 
       assert.strictEqual(map.get('same'), 'medium');
     });
+
+    it('returns empty map when all models undefined', () => {
+      const map = buildCodexModelEffortMap({});
+      assert.strictEqual(map.size, 0);
+    });
+
+    it('ignores empty string models', () => {
+      const map = buildCodexModelEffortMap({ defaultModel: '', opusModel: '  ' });
+      assert.strictEqual(map.size, 0);
+    });
   });
 
   describe('getEffortForModel', () => {
     it('defaults to medium for unknown model', () => {
       const map = buildCodexModelEffortMap({ opusModel: 'm1' });
       assert.strictEqual(getEffortForModel('unknown', map, 'medium'), 'medium');
+    });
+
+    it('handles null model', () => {
+      const map = buildCodexModelEffortMap({ opusModel: 'm1' });
+      assert.strictEqual(getEffortForModel(null, map, 'high'), 'high');
     });
   });
 
@@ -50,6 +65,11 @@ describe('Codex Reasoning Proxy', () => {
 
     it('leaves non-object bodies unchanged', () => {
       assert.strictEqual(injectReasoningEffortIntoBody('x', 'medium'), 'x');
+    });
+
+    it('leaves array bodies unchanged (not treated as record)', () => {
+      const arr = [1, 2, 3];
+      assert.deepStrictEqual(injectReasoningEffortIntoBody(arr, 'high'), arr);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add a Codex-only local proxy that injects OpenAI Responses-style `reasoning.effort` into outgoing requests routed via `ccs codex`.
- Support optional “model suffix aliases” (`-xhigh/-high/-medium`) so tier selection can control effort while keeping a valid upstream model id.
- Provide a local verification endpoint to confirm injected effort without logging prompt content.

## Implementation
- `src/cliproxy/codex-reasoning-proxy.ts`
  - HTTP proxy that buffers JSON requests, optionally strips `-xhigh/-high/-medium` suffixes from `model`, injects/overrides `reasoning.effort`, and forwards/streams responses unchanged.
  - Tier→effort mapping derived from effective env vars: opus/default→xhigh, sonnet→high, haiku→medium, unknown→medium.
  - Adds `GET /__ccs/reasoning` for in-memory verification (counts + recent injections).
  - Optional file trace when `CCS_CODEX_REASONING_TRACE=1`.
- `src/cliproxy/cliproxy-executor.ts`
  - Starts the proxy only when provider is `codex`, rewrites `ANTHROPIC_BASE_URL` for the spawned Claude Code process, and stops the proxy on exit/error/signals.
- `tests/unit/cliproxy/codex-reasoning-proxy.test.js`
  - Unit coverage for tier mapping and `reasoning.effort` injection behavior.

## Usage
- Run: `ccs codex`
- Optional tier aliases in `~/.ccs/codex.settings.json`:
  - `ANTHROPIC_DEFAULT_OPUS_MODEL: gpt-5.2-codex-xhigh`
  - `ANTHROPIC_DEFAULT_SONNET_MODEL: gpt-5.2-codex-high`
  - `ANTHROPIC_DEFAULT_HAIKU_MODEL: gpt-5.2-codex-medium`
  - Proxy forwards upstream as `model=gpt-5.2-codex` and injects the selected effort.
- Verify injected effort:
  - `curl http://127.0.0.1:<proxyPort>/__ccs/reasoning`

## Test Plan
- `bun run build`
- `bun test tests/unit/cliproxy/codex-reasoning-proxy.test.js`
