### PR TITLE
fix(ui): use wss:// for WebSocket on HTTPS pages

### DIFF
--- a/ui/src/hooks/use-websocket.ts
+++ b/ui/src/hooks/use-websocket.ts
@@ -69,7 +69,8 @@ export function useWebSocket() {
     }
 
     setStatus('connecting');
-    const ws = new WebSocket(`ws://${window.location.host}`);
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${window.location.host}`);
     wsRef.current = ws;
 
     ws.onopen = () => {


### PR DESCRIPTION
## Summary

When the dashboard is served over HTTPS (e.g., behind a reverse proxy with TLS termination), the WebSocket connection fails with a Mixed Content error because it tries to connect using `ws://` instead of `wss://`.

**Error:**
```
Mixed Content: The page at 'https://example.com/' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://example.com/'. This request has been blocked; this endpoint must be available over WSS.
```

## Changes

- Detect page protocol (`https:` vs `http:`) and use the appropriate WebSocket protocol (`wss:` vs `ws:`)

## Test Plan

- [x] Tested locally with HTTPS reverse proxy (Traefik)
- [x] Verified WebSocket connects successfully on HTTPS
- [x] Verified WebSocket still works on HTTP (localhost development)