### PR TITLE
fix(ci): isolate concurrency groups by comment author

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,10 +21,12 @@ on:
         required: true
         type: string
 
-# Cancel in-progress runs for same PR + event type (prevents self-cancellation from bot comments)
-# Each event type gets its own concurrency group to prevent cross-event cancellation
+# Concurrency strategy:
+# - For issue_comment: include comment author to isolate bot progress comments from human /review requests
+# - For other events: use event_name + PR number
+# This prevents bot progress comments from cancelling active reviews
 concurrency:
-  group: ai-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  group: ai-review-${{ github.event_name }}-${{ github.event.comment.user.login || 'system' }}-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
Complete fix for self-cancelling AI review workflow by isolating concurrency groups by comment author.

## Problem
Previous fix (PR #321) was incomplete. Both human `/review` comments and bot progress comments are `issue_comment` events, so they still shared the same concurrency group and cancelled each other.

## Solution
Include comment author in concurrency group:

| Trigger | Concurrency Group |
|---------|-------------------|
| Human `/review` | `ai-review-issue_comment-kaitranntt-320` |
| Bot progress | `ai-review-issue_comment-ccs-agy-reviewer[bot]-320` |
| PR opened | `ai-review-pull_request_target-system-320` |
| workflow_dispatch | `ai-review-workflow_dispatch-system-320` |

This completely isolates bot activity from human-triggered reviews.

## Test Plan
- [ ] Trigger `/review` on PR #320 after merge
- [ ] Verify review completes without cancellation