### PR TITLE
fix(deps): add express-rate-limit to production dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "chokidar": "^3.6.0",
         "cli-table3": "^0.6.5",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.2.1",
         "express-session": "^1.18.2",
         "get-port": "^5.1.1",
         "gradient-string": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "chokidar": "^3.6.0",
     "cli-table3": "^0.6.5",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.2.1",
     "express-session": "^1.18.2",
     "get-port": "^5.1.1",
     "gradient-string": "^2.0.2",


### PR DESCRIPTION
## Summary

- Add `express-rate-limit` to production dependencies (was missing from `package.json`)
- Fixes `Cannot find module 'express-rate-limit'` error when running `ccs config`

## Root Cause

`express-rate-limit` is imported in `src/web-server/middleware/auth-middleware.ts:8` but was NOT declared in `package.json` dependencies. Only the `@types/express-rate-limit` was in devDependencies, which doesn't include the runtime package.

## Test Plan

- [x] `bun run build` succeeds
- [x] All 978 tests pass
- [x] `bun run validate` passes
- [ ] Manual test: install globally and run `ccs config`

Closes #333
