### PR TITLE
fix(cliproxy): propagate backend parameter to version check functions

### DIFF
--- a/src/cliproxy/binary-manager.ts
+++ b/src/cliproxy/binary-manager.ts
@@ -198,9 +198,9 @@ export async function installCliproxyVersion(
 }
 
 /** Fetch the latest CLIProxyAPI version from GitHub API */
-export async function fetchLatestCliproxyVersion(): Promise<string> {
-  const backend = getConfiguredBackend();
-  const result = await new BinaryManager({}, backend).checkForUpdates();
+export async function fetchLatestCliproxyVersion(backend?: CLIProxyBackend): Promise<string> {
+  const effectiveBackend = backend ?? getConfiguredBackend();
+  const result = await new BinaryManager({}, effectiveBackend).checkForUpdates();
   return result.latestVersion;
 }
 
@@ -221,9 +221,11 @@ export interface CliproxyUpdateCheckResult {
 }
 
 /** Check for CLIProxyAPI binary updates */
-export async function checkCliproxyUpdate(): Promise<CliproxyUpdateCheckResult> {
-  const backend = getConfiguredBackend();
-  const result = await new BinaryManager({}, backend).checkForUpdates();
+export async function checkCliproxyUpdate(
+  backend?: CLIProxyBackend
+): Promise<CliproxyUpdateCheckResult> {
+  const effectiveBackend = backend ?? getConfiguredBackend();
+  const result = await new BinaryManager({}, effectiveBackend).checkForUpdates();
 
   // Import isNewerVersion for stability check
   const { isNewerVersion } = await import('./binary/version-checker');
@@ -232,11 +234,11 @@ export async function checkCliproxyUpdate(): Promise<CliproxyUpdateCheckResult> 
     ? undefined
     : `v${result.currentVersion} has known stability issues. Max stable: v${CLIPROXY_MAX_STABLE_VERSION}`;
 
-  const backendLabel = backend === 'plus' ? 'CLIProxy Plus' : 'CLIProxy';
+  const backendLabel = effectiveBackend === 'plus' ? 'CLIProxy Plus' : 'CLIProxy';
 
   return {
     ...result,
-    backend,
+    backend: effectiveBackend,
     backendLabel,
     isStable,
     maxStableVersion: CLIPROXY_MAX_STABLE_VERSION,

--- a/src/cliproxy/services/binary-service.ts
+++ b/src/cliproxy/services/binary-service.ts
@@ -77,7 +77,7 @@ export async function checkLatestVersion(backend?: CLIProxyBackend): Promise<Lat
   try {
     // Use checkCliproxyUpdate which is backend-aware (uses correct GitHub repo)
     const { checkCliproxyUpdate } = await import('../binary-manager');
-    const updateResult = await checkCliproxyUpdate();
+    const updateResult = await checkCliproxyUpdate(effectiveBackend);
     const latestVersion = updateResult.latestVersion;
     const currentVersion = getInstalledCliproxyVersion(effectiveBackend);
     const updateAvailable = latestVersion !== currentVersion;
@@ -151,7 +151,7 @@ export async function installLatest(
     backend ?? loadOrCreateUnifiedConfig().cliproxy?.backend ?? DEFAULT_BACKEND;
 
   try {
-    const latestVersion = await fetchLatestCliproxyVersion();
+    const latestVersion = await fetchLatestCliproxyVersion(effectiveBackend);
     const currentVersion = getInstalledCliproxyVersion(effectiveBackend);
     const wasPinned = isVersionPinned(effectiveBackend);
 

--- a/src/web-server/routes/cliproxy-stats-routes.ts
+++ b/src/web-server/routes/cliproxy-stats-routes.ts
@@ -216,7 +216,8 @@ router.post('/proxy-stop', async (_req: Request, res: Response): Promise<void> =
  */
 router.get('/update-check', async (_req: Request, res: Response): Promise<void> => {
   try {
-    const result = await checkCliproxyUpdate();
+    const backend = getConfiguredBackend();
+    const result = await checkCliproxyUpdate(backend);
     res.json(result);
   } catch (error) {
     res.status(500).json({ error: (error as Error).message });
@@ -625,7 +626,8 @@ router.post('/install', async (req: Request, res: Response): Promise<void> => {
     await new Promise((r) => setTimeout(r, 500));
 
     // Install the version
-    await installCliproxyVersion(version, true);
+    const backend = getConfiguredBackend();
+    await installCliproxyVersion(version, true, backend);
 
     res.json({
       success: true,


### PR DESCRIPTION
## Summary

Fixes inconsistent backend reporting when user selects CLIProxyAPI (original) in dashboard but `ccs cliproxy --update` shows CLIProxy Plus version.

**Root cause:** `fetchLatestCliproxyVersion()` and `checkCliproxyUpdate()` ignored the caller's explicit backend parameter, always re-computing from config via `getConfiguredBackend()`. This caused race conditions when config wasn't synced.

**Changes:**
- Add optional `backend` param to `fetchLatestCliproxyVersion()`
- Add optional `backend` param to `checkCliproxyUpdate()`
- Pass `effectiveBackend` in `binary-service.ts` calls
- Pass `backend` in `cliproxy-stats-routes.ts` web endpoints

## Test plan

- [ ] Select "CLIProxyAPI" (original) in dashboard
- [ ] Run `ccs cliproxy --update`
- [ ] Verify output shows "CLIProxy version" not "CLIProxy Plus version"
- [ ] Repeat with "CLIProxyAPIPlus" selected