### PR TITLE
fix(cliproxy): pin version to 6.7.25, add disable-cooling

### DIFF
--- a/src/cliproxy/config-generator.ts
+++ b/src/cliproxy/config-generator.ts
@@ -286,8 +286,9 @@ export function getCliproxyWritablePath(): string {
  * v2: Full-featured config with dashboard, quota mgmt, simplified key
  * v3: Logging disabled by default (user opt-in via ~/.ccs/config.yaml)
  * v4: Added Kiro (AWS) and GitHub Copilot providers
+ * v5: Added disable-cooling: true for stability
  */
-export const CLIPROXY_CONFIG_VERSION = 4;
+export const CLIPROXY_CONFIG_VERSION = 5;
 
 /** Provider display names (static metadata) */
 const PROVIDER_DISPLAY_NAMES: Record<CLIProxyProvider, string> = {
@@ -470,6 +471,9 @@ remote-management:
 # =============================================================================
 # Reliability & Quota Management
 # =============================================================================
+
+# Disable quota cooldown scheduling for stability
+disable-cooling: true
 
 # Auto-retry on transient errors (403, 408, 500, 502, 503, 504)
 request-retry: 0

--- a/src/cliproxy/platform-detector.ts
+++ b/src/cliproxy/platform-detector.ts
@@ -19,13 +19,13 @@ export const BACKEND_CONFIG = {
     repo: 'router-for-me/CLIProxyAPI',
     binaryPrefix: 'CLIProxyAPI',
     executable: 'cli-proxy-api',
-    fallbackVersion: '6.7.8',
+    fallbackVersion: '6.7.25',
   },
   plus: {
     repo: 'router-for-me/CLIProxyAPIPlus',
     binaryPrefix: 'CLIProxyAPIPlus',
     executable: 'cli-proxy-api-plus',
-    fallbackVersion: '6.7.8-0',
+    fallbackVersion: '6.7.25-0',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- Pin CLIProxy fallback versions to 6.7.25 (original) and 6.7.25-0 (plus)
- Add `disable-cooling: true` to generated config for stability
- Bump config version to 5 to trigger regeneration

## Test plan
- [x] `bun run validate` passes (1095 tests)
- [ ] Verify new installs download 6.7.25 binary
- [ ] Verify `disable-cooling: true` appears in regenerated config