### PR TITLE
fix(websearch): add shell option for Windows spawnSync compatibility

### DIFF
--- a/lib/hooks/websearch-transformer.cjs
+++ b/lib/hooks/websearch-transformer.cjs
@@ -27,6 +27,18 @@
 const { spawnSync } = require('child_process');
 
 // ============================================================================
+// PLATFORM DETECTION
+// ============================================================================
+
+/**
+ * Windows platform flag - used for shell option in spawnSync calls.
+ * On Windows, globally installed CLI tools via npm/pnpm are .cmd/.bat files,
+ * which require shell: true to execute properly.
+ * @see https://github.com/kaitranntt/ccs/issues/378
+ */
+const isWindows = process.platform === 'win32';
+
+// ============================================================================
 // CONFIGURATION - Edit these for prompt engineering
 // ============================================================================
 
@@ -154,7 +166,6 @@ process.stdin.on('error', () => {
  */
 function isCliAvailable(cmd) {
   try {
-    const isWindows = process.platform === 'win32';
     const whichCmd = isWindows ? 'where.exe' : 'which';
 
     const result = spawnSync(whichCmd, [cmd], {
@@ -292,6 +303,7 @@ function tryGeminiSearch(query, timeoutSec = DEFAULT_TIMEOUT_SEC) {
         timeout: timeoutMs,
         maxBuffer: 1024 * 1024 * 2,
         stdio: ['pipe', 'pipe', 'pipe'],
+        shell: isWindows,
       }
     );
 
@@ -358,6 +370,7 @@ function tryOpenCodeSearch(query, timeoutSec = DEFAULT_TIMEOUT_SEC) {
         timeout: timeoutMs,
         maxBuffer: 1024 * 1024 * 2,
         stdio: ['pipe', 'pipe', 'pipe'],
+        shell: isWindows,
       }
     );
 
@@ -417,6 +430,7 @@ function tryGrokSearch(query, timeoutSec = DEFAULT_TIMEOUT_SEC) {
       timeout: timeoutMs,
       maxBuffer: 1024 * 1024 * 2,
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: isWindows,
     });
 
     if (spawnResult.error) {


### PR DESCRIPTION
On Windows, globally installed CLI tools via npm/pnpm are .cmd/.bat batch files, not real .exe executables. Node.js spawnSync() without the shell option cannot execute these files and returns ENOENT error.

Changes:
- Extract isWindows as a global constant at file top
- Add shell: isWindows to all CLI execution spawnSync calls
- Remove duplicate isWindows declaration in isCliAvailable()

Fixes #378