### PR TITLE
fix(claude): update base config to Claude 4.5 model IDs

### DIFF
--- a/config/base-claude.settings.json
+++ b/config/base-claude.settings.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/claude",
     "ANTHROPIC_AUTH_TOKEN": "ccs-internal-managed",
-    "ANTHROPIC_MODEL": "claude-sonnet-4-20250514",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-20250514",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-20250514",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-3-5-20241022"
+    "ANTHROPIC_MODEL": "claude-sonnet-4-5-20250929",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5-20251101",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-5-20250929",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5-20251001"
   }
 }


### PR DESCRIPTION
## Summary
- Updated `config/base-claude.settings.json` with current Claude 4.5 model IDs
- Fixes 400 "unknown provider for model" errors when users add Claude accounts

## Problem
When users ran `ccs claude --add`, the base config set outdated model IDs:
- `claude-sonnet-4-20250514` → should be `claude-sonnet-4-5-20250929`
- `claude-opus-4-20250514` → should be `claude-opus-4-5-20251101`
- `claude-haiku-3-5-20241022` → should be `claude-haiku-4-5-20251001`

This caused CLIProxy to reject requests with "unknown provider for model" when users switched to Haiku tier.

## Changes
| Setting | Before (Outdated) | After (Correct) |
|---------|-------------------|-----------------|
| `ANTHROPIC_MODEL` | `claude-sonnet-4-20250514` | `claude-sonnet-4-5-20250929` |
| `ANTHROPIC_DEFAULT_OPUS_MODEL` | `claude-opus-4-20250514` | `claude-opus-4-5-20251101` |
| `ANTHROPIC_DEFAULT_SONNET_MODEL` | `claude-sonnet-4-20250514` | `claude-sonnet-4-5-20250929` |
| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | `claude-haiku-3-5-20241022` | `claude-haiku-4-5-20251001` |

## Test Plan
- [x] `bun run validate` passes (1349 tests)
- [ ] Manual test: `ccs claude --add` → verify correct model IDs set
- [ ] Manual test: Switch to Haiku tier → no 400 errors