### PR TITLE
fix(quota): improve 403 error messaging for forbidden accounts

### DIFF
--- a/src/cliproxy/quota-fetcher-codex.ts
+++ b/src/cliproxy/quota-fetcher-codex.ts
@@ -253,13 +253,16 @@ export async function fetchCodexQuota(
     }
 
     if (response.status === 403) {
+      // 403 = account lacks API access (not same as quota exhausted)
+      // Keep success=false with isForbidden flag for UI to show distinct "403" badge
       return {
         success: false,
         windows: [],
         planType: null,
         lastUpdated: Date.now(),
-        error: 'Quota access not available (free plan may not have quota API access)',
+        error: '403 Forbidden - No quota API access',
         accountId,
+        isForbidden: true,
       };
     }
 

--- a/src/cliproxy/quota-fetcher.ts
+++ b/src/cliproxy/quota-fetcher.ts
@@ -407,12 +407,14 @@ async function fetchAvailableModels(accessToken: string, _projectId: string): Pr
     clearTimeout(timeoutId);
 
     if (response.status === 403) {
+      // 403 = account lacks Gemini Code Assist access (not same as quota exhausted)
+      // Keep success=false with isForbidden flag for UI to show distinct "403" badge
       return {
         success: false,
         models: [],
         lastUpdated: Date.now(),
         isForbidden: true,
-        error: 'Quota access forbidden for this account',
+        error: '403 Forbidden - No Gemini Code Assist access',
       };
     }
 

--- a/src/cliproxy/quota-types.ts
+++ b/src/cliproxy/quota-types.ts
@@ -45,6 +45,8 @@ export interface CodexQuotaResult {
   accountId?: string;
   /** True if token is expired and needs re-authentication */
   needsReauth?: boolean;
+  /** True if account lacks quota access (403) - displayed as 0% instead of error */
+  isForbidden?: boolean;
 }
 
 /**

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -180,6 +180,8 @@ export interface CodexQuotaResult {
   needsReauth?: boolean;
   /** True if result was served from cache */
   cached?: boolean;
+  /** True if account lacks quota access (403) - displayed as 0% instead of error */
+  isForbidden?: boolean;
 }
 
 /** Gemini CLI bucket (grouped by model series) */


### PR DESCRIPTION
## Summary
- When Google API returns 403, show clear error message instead of generic "Quota access forbidden"
- **Antigravity:** "403 Forbidden - No Gemini Code Assist access"
- **Codex:** "403 Forbidden - No quota API access"
- Preserves `isForbidden` flag for UI to show distinct "403" badge (similar to Antigravity-Manager)

## Why not show 0%?
403 ≠ 0% exhausted - they are semantically different:
- **403:** Account lacks API access entirely (no reset time)
- **0%:** Account has access but quota is used up (shows reset time like "3d 5h")

The Antigravity-Manager already handles this correctly with a distinct red "403" badge and tooltip explaining "API returned 403 Forbidden, account doesn't have Gemini Code Assist access."

## Changes
- `quota-fetcher.ts`: Clear 403 error message with `isForbidden` flag
- `quota-fetcher-codex.ts`: Clear 403 error message with `isForbidden` flag
- `quota-types.ts`: Add `isForbidden` flag to `CodexQuotaResult`
- `ui/api-client.ts`: Add `isForbidden` flag to UI types

## Test plan
- [x] TypeScript compilation passes
- [x] All 1355 tests pass
- [x] UI validation passes