### PR TITLE
fix(auth): manual callback URL submission for cross-browser OAuth (#417)

### DIFF
--- a/src/cliproxy/auth/auth-types.ts
+++ b/src/cliproxy/auth/auth-types.ts
@@ -163,6 +163,37 @@ export const PROVIDER_TYPE_VALUES: Record<CLIProxyProvider, string[]> = {
 };
 
 /**
+ * Maps CCS provider names to CLIProxyAPI callback provider names
+ * Used when submitting OAuth callbacks to CLIProxyAPI management endpoint
+ */
+export const CLIPROXY_CALLBACK_PROVIDER_MAP: Record<CLIProxyProvider, string> = {
+  gemini: 'gemini',
+  codex: 'codex',
+  agy: 'antigravity',
+  kiro: 'kiro',
+  ghcp: 'copilot',
+  claude: 'anthropic',
+  qwen: 'qwen',
+  iflow: 'iflow',
+};
+
+/**
+ * Maps CCS provider names to CLIProxyAPI auth-url endpoint prefixes.
+ * Used for GET /v0/management/${prefix}-auth-url endpoints.
+ * These differ from callback names for some providers (e.g., gemini-cli vs gemini).
+ */
+export const CLIPROXY_AUTH_URL_PROVIDER_MAP: Record<CLIProxyProvider, string> = {
+  gemini: 'gemini-cli',
+  codex: 'codex',
+  agy: 'antigravity',
+  kiro: 'kiro',
+  ghcp: 'github',
+  claude: 'anthropic',
+  qwen: 'qwen',
+  iflow: 'iflow',
+};
+
+/**
  * Get OAuth config for provider
  */
 export function getOAuthConfig(provider: CLIProxyProvider): ProviderOAuthConfig {
@@ -188,4 +219,6 @@ export interface OAuthOptions {
   noIncognito?: boolean;
   /** If true, skip OAuth and import token from Kiro IDE directly (Kiro only) */
   import?: boolean;
+  /** Enable paste-callback mode: show auth URL and prompt for callback paste */
+  pasteCallback?: boolean;
 }

--- a/src/cliproxy/auth/environment-detector.ts
+++ b/src/cliproxy/auth/environment-detector.ts
@@ -107,13 +107,19 @@ export function getTimeoutTroubleshooting(
   lines.push('');
   lines.push('TROUBLESHOOTING:');
   lines.push('  1. Check browser completed auth (should show success page)');
+  lines.push('  2. Complete OAuth in the same browser session that opened');
 
   if (port) {
-    lines.push(`  2. Check for port conflicts: lsof -ti:${port} or ss -tlnp | grep ${port}`);
-    lines.push(`  3. Try: ccs ${provider} --auth --verbose`);
+    lines.push(`  3. Check for port conflicts: lsof -ti:${port} or ss -tlnp | grep ${port}`);
+    lines.push(`  4. Try: ccs ${provider} --auth --verbose`);
   } else {
-    lines.push(`  2. Try: ccs ${provider} --auth --verbose`);
+    lines.push(`  3. Try: ccs ${provider} --auth --verbose`);
   }
+
+  lines.push('');
+  lines.push('If you copied the URL to another browser:');
+  lines.push('  - OAuth sessions expire after ~10 minutes');
+  lines.push('  - Callback must reach localhost (same machine only)');
 
   return lines;
 }

--- a/src/cliproxy/auth/oauth-process.ts
+++ b/src/cliproxy/auth/oauth-process.ts
@@ -250,6 +250,11 @@ async function handleTokenNotFound(
   console.log(fail('Token not found after authentication'));
   console.log('');
   console.log('The browser showed success but callback was not received.');
+  console.log('');
+  console.log('Common causes:');
+  console.log('  1. OAuth session timed out (sessions expire after ~10 minutes)');
+  console.log('  2. Callback server could not receive the redirect');
+  console.log('  3. Browser did not redirect to localhost properly');
 
   if (process.platform === 'win32') {
     console.log('');
@@ -263,6 +268,11 @@ async function handleTokenNotFound(
     );
   }
 
+  console.log('');
+  console.log('If you copied the OAuth URL to a different browser:');
+  console.log('  - Complete authentication within the timeout window');
+  console.log('  - Ensure you are on the same machine (localhost callback)');
+  console.log('  - Copy the entire URL including all parameters');
   console.log('');
   console.log(`Try: ccs ${provider} --auth --verbose`);
   return null;

--- a/src/cliproxy/cliproxy-executor.ts
+++ b/src/cliproxy/cliproxy-executor.ts
@@ -290,6 +290,7 @@ export async function execClaudeWithCLIProxy(
 
   // 2. Handle special flags (use argsWithoutProxy - proxy flags already stripped)
   const forceAuth = argsWithoutProxy.includes('--auth');
+  const pasteCallback = argsWithoutProxy.includes('--paste-callback');
   const forceHeadless = argsWithoutProxy.includes('--headless');
   const forceLogout = argsWithoutProxy.includes('--logout');
   const forceConfig = argsWithoutProxy.includes('--config');
@@ -521,6 +522,7 @@ export async function execClaudeWithCLIProxy(
         ...(forceHeadless ? { headless: true } : {}),
         ...(setNickname ? { nickname: setNickname } : {}),
         ...(noIncognito ? { noIncognito: true } : {}),
+        ...(pasteCallback ? { pasteCallback: true } : {}),
       });
       if (!authSuccess) {
         throw new Error(`Authentication required for ${providerConfig.displayName}`);
@@ -963,6 +965,7 @@ export async function execClaudeWithCLIProxy(
   // Note: Proxy flags (--proxy-host, etc.) already stripped by resolveProxyConfig()
   const ccsFlags = [
     '--auth',
+    '--paste-callback',
     '--headless',
     '--logout',
     '--config',

--- a/src/commands/help-command.ts
+++ b/src/commands/help-command.ts
@@ -171,6 +171,10 @@ Run ${color('ccs config', 'command')} for web dashboard`.trim();
       ['', ''], // Spacer
       ['ccs <provider> --auth', 'Authenticate only'],
       ['ccs <provider> --auth --add', 'Add another account'],
+      [
+        'ccs <provider> --paste-callback',
+        'Show auth URL and prompt for callback paste (cross-browser)',
+      ],
       ['ccs <provider> --accounts', 'List all accounts'],
       ['ccs <provider> --use <name>', 'Switch to account'],
       ['ccs <provider> --config', 'Change model (agy, gemini)'],

--- a/src/utils/websearch/hook-config.ts
+++ b/src/utils/websearch/hook-config.ts
@@ -134,12 +134,12 @@ export function ensureHookConfig(): boolean {
         return normalized.includes('.ccs/hooks/websearch-transformer');
       });
 
-      // INVARIANT: webSearchHookIndex remains valid after deduplication because:
-      // - findIndex() returns the FIRST matching CCS hook
-      // - deduplicateCcsHooks() keeps the FIRST CCS hook and removes subsequent duplicates
-      // This means the index always points to the preserved hook.
       if (webSearchHookIndex !== -1) {
         // Hook exists - first clean up any duplicates
+        // INVARIANT: webSearchHookIndex remains valid after deduplication because:
+        // - findIndex() returns the FIRST matching CCS hook
+        // - deduplicateCcsHooks() keeps the FIRST CCS hook and removes subsequent duplicates
+        // This means the index always points to the preserved hook.
         const hadDuplicates = deduplicateCcsHooks(settings);
 
         // Then check if it needs updating

--- a/src/web-server/routes/cliproxy-auth-routes.ts
+++ b/src/web-server/routes/cliproxy-auth-routes.ts
@@ -1,7 +1,3 @@
-/**
- * CLIProxy Auth Routes - Authentication and account management for CLIProxy providers
- */
-
 import { Router, Request, Response } from 'express';
 import {
   getAllAuthStatus,
@@ -29,11 +25,19 @@ import {
   PROVIDERS_WITHOUT_EMAIL,
   validateNickname,
 } from '../../cliproxy/account-manager';
-import { getProxyTarget } from '../../cliproxy/proxy-target-resolver';
+import {
+  getProxyTarget,
+  buildProxyUrl,
+  buildManagementHeaders,
+} from '../../cliproxy/proxy-target-resolver';
 import { fetchRemoteAuthStatus } from '../../cliproxy/remote-auth-fetcher';
 import { loadOrCreateUnifiedConfig } from '../../config/unified-config-loader';
 import { tryKiroImport } from '../../cliproxy/auth/kiro-import';
 import { getProviderTokenDir } from '../../cliproxy/auth/token-manager';
+import {
+  CLIPROXY_CALLBACK_PROVIDER_MAP,
+  CLIPROXY_AUTH_URL_PROVIDER_MAP,
+} from '../../cliproxy/auth/auth-types';
 import type { CLIProxyProvider } from '../../cliproxy/types';
 import { CLIPROXY_PROFILES } from '../../auth/profile-detector';
 
@@ -529,6 +533,177 @@ router.post('/kiro/import', async (_req: Request, res: Response): Promise<void> 
     }
   } catch (error) {
     res.status(500).json({ error: (error as Error).message });
+  }
+});
+
+// ==================== Manual Callback Submission ====================
+
+/**
+ * POST /api/cliproxy/auth/:provider/start-url - Start OAuth and return auth URL immediately
+ * Unlike /start which blocks until completion, this returns the URL for manual callback flow
+ */
+router.post('/:provider/start-url', async (req: Request, res: Response): Promise<void> => {
+  const { provider } = req.params;
+
+  // Check remote mode
+  const target = getProxyTarget();
+  if (target.isRemote) {
+    res.status(501).json({ error: 'Manual OAuth flow not available in remote mode' });
+    return;
+  }
+
+  // Validate provider
+  if (!validProviders.includes(provider as CLIProxyProvider)) {
+    res.status(400).json({ error: `Invalid provider: ${provider}` });
+    return;
+  }
+
+  try {
+    const authUrlProvider =
+      CLIPROXY_AUTH_URL_PROVIDER_MAP[provider as CLIProxyProvider] || provider;
+
+    // Call CLIProxyAPI to start OAuth and get auth URL
+    // CLIProxyAPI management routes are under /v0/management prefix
+    const response = await fetch(
+      buildProxyUrl(target, `/v0/management/${authUrlProvider}-auth-url?is_webui=true`),
+      { headers: buildManagementHeaders(target) }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      res.status(response.status).json({ error: error || 'Failed to start OAuth' });
+      return;
+    }
+
+    const data = (await response.json()) as { url?: string; auth_url?: string; state?: string };
+    const authUrl = data.url || data.auth_url;
+
+    if (!authUrl) {
+      res.status(500).json({ error: 'No authorization URL received from CLIProxyAPI' });
+      return;
+    }
+
+    res.json({
+      success: true,
+      authUrl,
+      state: data.state,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to start OAuth';
+    res.status(503).json({ error: `CLIProxyAPI not reachable: ${message}` });
+  }
+});
+
+/**
+ * GET /api/cliproxy/auth/:provider/status - Poll OAuth status
+ * Checks if OAuth has completed for the given state
+ */
+router.get('/:provider/status', async (req: Request, res: Response): Promise<void> => {
+  const { provider } = req.params;
+  const { state } = req.query;
+
+  if (!state || typeof state !== 'string') {
+    res.status(400).json({ error: 'state query parameter required' });
+    return;
+  }
+
+  // Validate provider
+  if (!validProviders.includes(provider as CLIProxyProvider)) {
+    res.status(400).json({ error: `Invalid provider: ${provider}` });
+    return;
+  }
+
+  try {
+    const target = getProxyTarget();
+
+    // CLIProxyAPI management routes are under /v0/management prefix
+    const response = await fetch(
+      buildProxyUrl(target, `/v0/management/get-auth-status?state=${encodeURIComponent(state)}`),
+      { headers: buildManagementHeaders(target) }
+    );
+    const data = (await response.json()) as { status?: string; error?: string };
+
+    res.json(data);
+  } catch {
+    res.status(503).json({ status: 'error', error: 'CLIProxyAPI not reachable' });
+  }
+});
+
+/**
+ * Parse callback URL to extract code and state parameters.
+ */
+function parseCallbackUrl(url: string): { code?: string; state?: string } {
+  try {
+    const parsed = new URL(url);
+    return {
+      code: parsed.searchParams.get('code') || undefined,
+      state: parsed.searchParams.get('state') || undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * POST /api/cliproxy/auth/:provider/submit-callback - Submit OAuth callback URL manually
+ * For cross-browser OAuth flows where callback cannot redirect directly
+ */
+router.post('/:provider/submit-callback', async (req: Request, res: Response): Promise<void> => {
+  const { provider } = req.params;
+  const { redirectUrl } = req.body;
+
+  // Check remote mode
+  const target = getProxyTarget();
+  if (target.isRemote) {
+    res.status(501).json({ error: 'Manual callback not available in remote mode' });
+    return;
+  }
+
+  // Validate provider
+  if (!validProviders.includes(provider as CLIProxyProvider)) {
+    res.status(400).json({ error: `Invalid provider: ${provider}` });
+    return;
+  }
+
+  // Validate redirectUrl
+  if (!redirectUrl || typeof redirectUrl !== 'string') {
+    res.status(400).json({ error: 'redirectUrl is required' });
+    return;
+  }
+
+  const parsed = parseCallbackUrl(redirectUrl);
+  if (!parsed.code) {
+    res.status(400).json({ error: 'Invalid callback URL: missing code parameter' });
+    return;
+  }
+
+  try {
+    const callbackProvider =
+      CLIPROXY_CALLBACK_PROVIDER_MAP[provider as CLIProxyProvider] || provider;
+
+    // Forward to CLIProxyAPI /oauth-callback endpoint (under /v0/management prefix)
+    const response = await fetch(buildProxyUrl(target, '/v0/management/oauth-callback'), {
+      method: 'POST',
+      headers: buildManagementHeaders(target, { 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        provider: callbackProvider,
+        redirect_url: redirectUrl,
+      }),
+    });
+
+    const data = (await response.json()) as { status?: string; error?: string };
+
+    if (!response.ok || data.status === 'error') {
+      res.status(response.status >= 400 ? response.status : 400).json({
+        error: data.error || 'OAuth callback failed',
+      });
+      return;
+    }
+
+    res.json({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to submit callback';
+    res.status(503).json({ error: `CLIProxyAPI not reachable: ${message}` });
   }
 });
 

--- a/tests/unit/utils/websearch/hook-utils.test.ts
+++ b/tests/unit/utils/websearch/hook-utils.test.ts
@@ -1,93 +1,93 @@
-import { expect, test, describe } from "bun:test";
-import { isCcsWebSearchHook, deduplicateCcsHooks } from "../hook-utils";
+import { expect, test, describe } from 'bun:test';
+import { isCcsWebSearchHook, deduplicateCcsHooks } from '../../../../src/utils/websearch/hook-utils';
 
-describe("isCcsWebSearchHook", () => {
-  test("Returns true for CCS hook with forward slashes (Unix path)", () => {
+describe('isCcsWebSearchHook', () => {
+  test('Returns true for CCS hook with forward slashes (Unix path)', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [
         {
-          command: "node /home/user/.ccs/hooks/websearch-transformer/index.js",
+          command: 'node /home/user/.ccs/hooks/websearch-transformer/index.js',
         },
       ],
     };
     expect(isCcsWebSearchHook(hook)).toBe(true);
   });
 
-  test("Returns true for CCS hook with backslashes (Windows path)", () => {
+  test('Returns true for CCS hook with backslashes (Windows path)', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [
         {
-          command: "node C:\\Users\\user\\.ccs\\hooks\\websearch-transformer\\index.js",
+          command: 'node C:\\Users\\user\\.ccs\\hooks\\websearch-transformer\\index.js',
         },
       ],
     };
     expect(isCcsWebSearchHook(hook)).toBe(true);
   });
 
-  test("Returns true for mixed path separators", () => {
+  test('Returns true for mixed path separators', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [
         {
-          command: "node /home/user\\.ccs/hooks\\websearch-transformer/index.js",
+          command: 'node /home/user\\.ccs/hooks\\websearch-transformer/index.js',
         },
       ],
     };
     expect(isCcsWebSearchHook(hook)).toBe(true);
   });
 
-  test("Returns false for non-WebSearch matcher", () => {
+  test('Returns false for non-WebSearch matcher', () => {
     const hook = {
-      matcher: "SomethingElse",
+      matcher: 'SomethingElse',
       hooks: [
         {
-          command: "node /home/user/.ccs/hooks/websearch-transformer/index.js",
+          command: 'node /home/user/.ccs/hooks/websearch-transformer/index.js',
         },
       ],
     };
     expect(isCcsWebSearchHook(hook)).toBe(false);
   });
 
-  test("Returns false for WebSearch with non-CCS hook command", () => {
+  test('Returns false for WebSearch with non-CCS hook command', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [
         {
-          command: "node /some/other/path/custom-hook.js",
+          command: 'node /some/other/path/custom-hook.js',
         },
       ],
     };
     expect(isCcsWebSearchHook(hook)).toBe(false);
   });
 
-  test("Returns false when hooks array is missing", () => {
+  test('Returns false when hooks array is missing', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
     };
     expect(isCcsWebSearchHook(hook)).toBe(false);
   });
 
-  test("Returns false when hooks array is empty", () => {
+  test('Returns false when hooks array is empty', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [],
     };
     expect(isCcsWebSearchHook(hook)).toBe(false);
   });
 
-  test("Returns false when command is missing", () => {
+  test('Returns false when command is missing', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [{}],
     };
     expect(isCcsWebSearchHook(hook)).toBe(false);
   });
 
-  test("Returns false when command is not a string", () => {
+  test('Returns false when command is not a string', () => {
     const hook = {
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [
         {
           command: 123,
@@ -98,14 +98,14 @@ describe("isCcsWebSearchHook", () => {
   });
 });
 
-describe("deduplicateCcsHooks", () => {
-  test("No-op when 0 CCS hooks (returns false)", () => {
+describe('deduplicateCcsHooks', () => {
+  test('No-op when 0 CCS hooks (returns false)', () => {
     const settings = {
       hooks: {
         PreToolUse: [
           {
-            matcher: "SomeOtherMatcher",
-            hooks: [{ command: "other-command" }],
+            matcher: 'SomeOtherMatcher',
+            hooks: [{ command: 'other-command' }],
           },
         ],
       },
@@ -115,15 +115,15 @@ describe("deduplicateCcsHooks", () => {
     expect(settings.hooks.PreToolUse).toHaveLength(1);
   });
 
-  test("No-op when 1 CCS hook (returns false)", () => {
+  test('No-op when 1 CCS hook (returns false)', () => {
     const settings = {
       hooks: {
         PreToolUse: [
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node /home/user/.ccs/hooks/websearch-transformer/index.js",
+                command: 'node /home/user/.ccs/hooks/websearch-transformer/index.js',
               },
             ],
           },
@@ -135,31 +135,31 @@ describe("deduplicateCcsHooks", () => {
     expect(settings.hooks.PreToolUse).toHaveLength(1);
   });
 
-  test("Removes duplicates when 2+ CCS hooks (returns true, keeps first)", () => {
+  test('Removes duplicates when 2+ CCS hooks (returns true, keeps first)', () => {
     const settings = {
       hooks: {
         PreToolUse: [
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node /home/user/.ccs/hooks/websearch-transformer/index.js",
+                command: 'node /home/user/.ccs/hooks/websearch-transformer/index.js',
               },
             ],
           },
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node C:\\Users\\user\\.ccs\\hooks\\websearch-transformer\\index.js",
+                command: 'node C:\\Users\\user\\.ccs\\hooks\\websearch-transformer\\index.js',
               },
             ],
           },
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node /another/path/.ccs/hooks/websearch-transformer/index.js",
+                command: 'node /another/path/.ccs/hooks/websearch-transformer/index.js',
               },
             ],
           },
@@ -170,37 +170,37 @@ describe("deduplicateCcsHooks", () => {
     expect(result).toBe(true);
     expect(settings.hooks.PreToolUse).toHaveLength(1);
     expect(settings.hooks.PreToolUse[0]).toEqual({
-      matcher: "WebSearch",
+      matcher: 'WebSearch',
       hooks: [
         {
-          command: "node /home/user/.ccs/hooks/websearch-transformer/index.js",
+          command: 'node /home/user/.ccs/hooks/websearch-transformer/index.js',
         },
       ],
     });
   });
 
-  test("Preserves non-CCS hooks in array", () => {
+  test('Preserves non-CCS hooks in array', () => {
     const nonCcsHook = {
-      matcher: "SomeOtherMatcher",
-      hooks: [{ command: "other-command" }],
+      matcher: 'SomeOtherMatcher',
+      hooks: [{ command: 'other-command' }],
     };
     const settings = {
       hooks: {
         PreToolUse: [
           nonCcsHook,
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node /home/user/.ccs/hooks/websearch-transformer/index.js",
+                command: 'node /home/user/.ccs/hooks/websearch-transformer/index.js',
               },
             ],
           },
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node C:\\Users\\user\\.ccs\\hooks\\websearch-transformer\\index.js",
+                command: 'node C:\\Users\\user\\.ccs\\hooks\\websearch-transformer\\index.js',
               },
             ],
           },
@@ -213,13 +213,13 @@ describe("deduplicateCcsHooks", () => {
     expect(settings.hooks.PreToolUse[0]).toEqual(nonCcsHook);
   });
 
-  test("Returns false when hooks is undefined", () => {
+  test('Returns false when hooks is undefined', () => {
     const settings = {};
     const result = deduplicateCcsHooks(settings);
     expect(result).toBe(false);
   });
 
-  test("Returns false when PreToolUse is undefined", () => {
+  test('Returns false when PreToolUse is undefined', () => {
     const settings = {
       hooks: {},
     };
@@ -227,31 +227,31 @@ describe("deduplicateCcsHooks", () => {
     expect(result).toBe(false);
   });
 
-  test("Handles multiple non-CCS hooks with duplicates", () => {
+  test('Handles multiple non-CCS hooks with duplicates', () => {
     const settings = {
       hooks: {
         PreToolUse: [
           {
-            matcher: "OtherMatcher1",
-            hooks: [{ command: "command1" }],
+            matcher: 'OtherMatcher1',
+            hooks: [{ command: 'command1' }],
           },
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node /path1/.ccs/hooks/websearch-transformer/index.js",
+                command: 'node /path1/.ccs/hooks/websearch-transformer/index.js',
               },
             ],
           },
           {
-            matcher: "OtherMatcher2",
-            hooks: [{ command: "command2" }],
+            matcher: 'OtherMatcher2',
+            hooks: [{ command: 'command2' }],
           },
           {
-            matcher: "WebSearch",
+            matcher: 'WebSearch',
             hooks: [
               {
-                command: "node /path2/.ccs/hooks/websearch-transformer/index.js",
+                command: 'node /path2/.ccs/hooks/websearch-transformer/index.js',
               },
             ],
           },
@@ -262,12 +262,12 @@ describe("deduplicateCcsHooks", () => {
     expect(result).toBe(true);
     expect(settings.hooks.PreToolUse).toHaveLength(3);
     // First and third should be non-CCS hooks, second should be the first CCS hook
-    expect(settings.hooks.PreToolUse[0].matcher).toBe("OtherMatcher1");
-    expect(settings.hooks.PreToolUse[1].matcher).toBe("WebSearch");
-    expect(settings.hooks.PreToolUse[2].matcher).toBe("OtherMatcher2");
+    expect(settings.hooks.PreToolUse[0].matcher).toBe('OtherMatcher1');
+    expect(settings.hooks.PreToolUse[1].matcher).toBe('WebSearch');
+    expect(settings.hooks.PreToolUse[2].matcher).toBe('OtherMatcher2');
   });
 
-  test("Edge case: Empty PreToolUse array", () => {
+  test('Edge case: Empty PreToolUse array', () => {
     const settings = {
       hooks: {
         PreToolUse: [],

--- a/ui/src/hooks/use-cliproxy-auth-flow.ts
+++ b/ui/src/hooks/use-cliproxy-auth-flow.ts
@@ -1,6 +1,6 @@
 /**
  * OAuth Auth Flow Hook for CLIProxy
- * Triggers backend-managed OAuth authentication flows
+ * Supports both auto-callback and manual callback flows
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo } from 'react';
@@ -13,92 +13,261 @@ interface AuthFlowState {
   provider: string | null;
   isAuthenticating: boolean;
   error: string | null;
+  /** Authorization URL for manual callback flow */
+  authUrl: string | null;
+  /** OAuth state parameter for polling */
+  oauthState: string | null;
+  /** Whether callback is being submitted */
+  isSubmittingCallback: boolean;
 }
+
+interface StartAuthOptions {
+  nickname?: string;
+}
+
+/** Polling interval for OAuth status check (3 seconds) */
+const POLL_INTERVAL = 3000;
+/** Maximum polling duration (5 minutes) */
+const MAX_POLL_DURATION = 5 * 60 * 1000;
 
 export function useCliproxyAuthFlow() {
   const [state, setState] = useState<AuthFlowState>({
     provider: null,
     isAuthenticating: false,
     error: null,
+    authUrl: null,
+    oauthState: null,
+    isSubmittingCallback: false,
   });
 
   const abortControllerRef = useRef<AbortController | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollStartRef = useRef<number>(0);
   const queryClient = useQueryClient();
+
+  // Clear polling
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  }, []);
 
   // Cleanup on unmount
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
+      stopPolling();
     };
-  }, []);
+  }, [stopPolling]);
+
+  // Poll OAuth status
+  const pollStatus = useCallback(
+    async (provider: string, oauthState: string) => {
+      // Check timeout
+      if (Date.now() - pollStartRef.current > MAX_POLL_DURATION) {
+        stopPolling();
+        setState((prev) => ({
+          ...prev,
+          isAuthenticating: false,
+          error: 'Authentication timed out. Please try again.',
+        }));
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/api/cliproxy/auth/${provider}/status?state=${encodeURIComponent(oauthState)}`
+        );
+        const data = await response.json();
+
+        if (data.status === 'ok') {
+          stopPolling();
+          queryClient.invalidateQueries({ queryKey: ['cliproxy-auth'] });
+          queryClient.invalidateQueries({ queryKey: ['account-quota'] });
+          toast.success(`${provider} authentication successful`);
+          setState({
+            provider: null,
+            isAuthenticating: false,
+            error: null,
+            authUrl: null,
+            oauthState: null,
+            isSubmittingCallback: false,
+          });
+        } else if (data.status === 'error') {
+          stopPolling();
+          const errorMsg = data.error || 'Authentication failed';
+          toast.error(errorMsg);
+          setState((prev) => ({
+            ...prev,
+            isAuthenticating: false,
+            error: errorMsg,
+          }));
+        }
+        // status === 'pending' means continue polling
+      } catch {
+        // Network error - continue polling
+      }
+    },
+    [queryClient, stopPolling]
+  );
 
   const startAuth = useCallback(
-    async (provider: string) => {
+    async (provider: string, options?: StartAuthOptions) => {
       if (!isValidProvider(provider)) {
         setState({
           provider: null,
           isAuthenticating: false,
           error: `Unknown provider: ${provider}`,
+          authUrl: null,
+          oauthState: null,
+          isSubmittingCallback: false,
         });
         return;
       }
 
       // Abort any in-progress auth
       abortControllerRef.current?.abort();
-      abortControllerRef.current = new AbortController();
+      stopPolling();
 
-      setState({ provider, isAuthenticating: true, error: null });
+      // Create fresh controller and capture locally to avoid race with cancelAuth
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setState({
+        provider,
+        isAuthenticating: true,
+        error: null,
+        authUrl: null,
+        oauthState: null,
+        isSubmittingCallback: false,
+      });
 
       try {
-        // POST to CCS auth endpoint - backend opens browser and waits
-        const response = await fetch(`/api/cliproxy/auth/${provider}/start`, {
+        // Call start-url to get auth URL immediately (non-blocking)
+        const response = await fetch(`/api/cliproxy/auth/${provider}/start-url`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({}),
-          signal: abortControllerRef.current.signal,
+          body: JSON.stringify({ nickname: options?.nickname }),
+          signal: controller.signal,
         });
 
         const data = await response.json();
 
-        if (response.ok && data.success) {
-          queryClient.invalidateQueries({ queryKey: ['cliproxy-auth'] });
-          queryClient.invalidateQueries({ queryKey: ['account-quota'] });
-          toast.success(`${provider} authentication successful`);
-          setState({ provider: null, isAuthenticating: false, error: null });
-        } else {
-          throw new Error(data.error || 'Authentication failed');
+        if (!response.ok || !data.success) {
+          throw new Error(data.error || 'Failed to start OAuth');
+        }
+
+        // Update state with auth URL
+        setState((prev) => ({
+          ...prev,
+          authUrl: data.authUrl,
+          oauthState: data.state,
+        }));
+
+        // Auto-open auth URL in new browser tab (fallback URL still shown in dialog)
+        if (data.authUrl) {
+          window.open(data.authUrl, '_blank');
+        }
+
+        // Start polling for completion
+        if (data.state) {
+          pollStartRef.current = Date.now();
+          pollIntervalRef.current = setInterval(() => {
+            pollStatus(provider, data.state);
+          }, POLL_INTERVAL);
         }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
-          setState({ provider: null, isAuthenticating: false, error: null });
+          setState({
+            provider: null,
+            isAuthenticating: false,
+            error: null,
+            authUrl: null,
+            oauthState: null,
+            isSubmittingCallback: false,
+          });
           return;
         }
         const message = error instanceof Error ? error.message : 'Authentication failed';
         toast.error(message);
-        setState({ provider: null, isAuthenticating: false, error: message });
+        setState((prev) => ({
+          ...prev,
+          isAuthenticating: false,
+          error: message,
+        }));
       }
     },
-    [queryClient]
+    [pollStatus, stopPolling]
   );
 
   const cancelAuth = useCallback(() => {
     const currentProvider = state.provider;
     abortControllerRef.current?.abort();
-    setState({ provider: null, isAuthenticating: false, error: null });
+    stopPolling();
+    setState({
+      provider: null,
+      isAuthenticating: false,
+      error: null,
+      authUrl: null,
+      oauthState: null,
+      isSubmittingCallback: false,
+    });
     // Also cancel on backend
     if (currentProvider) {
       api.cliproxy.auth.cancel(currentProvider).catch(() => {
         // Ignore errors - session may have already completed
       });
     }
-  }, [state.provider]);
+  }, [state.provider, stopPolling]);
+
+  const submitCallback = useCallback(
+    async (redirectUrl: string) => {
+      if (!state.provider) return;
+
+      setState((prev) => ({ ...prev, isSubmittingCallback: true, error: null }));
+
+      try {
+        const response = await fetch(`/api/cliproxy/auth/${state.provider}/submit-callback`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ redirectUrl }),
+        });
+
+        const data = await response.json();
+
+        if (response.ok && data.success) {
+          stopPolling();
+          queryClient.invalidateQueries({ queryKey: ['cliproxy-auth'] });
+          queryClient.invalidateQueries({ queryKey: ['account-quota'] });
+          toast.success(`${state.provider} authentication successful`);
+          setState({
+            provider: null,
+            isAuthenticating: false,
+            error: null,
+            authUrl: null,
+            oauthState: null,
+            isSubmittingCallback: false,
+          });
+        } else {
+          throw new Error(data.error || 'Callback submission failed');
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Failed to submit callback';
+        toast.error(message);
+        setState((prev) => ({ ...prev, isSubmittingCallback: false, error: message }));
+      }
+    },
+    [state.provider, queryClient, stopPolling]
+  );
 
   return useMemo(
     () => ({
       ...state,
       startAuth,
       cancelAuth,
+      submitCallback,
     }),
-    [state, startAuth, cancelAuth]
+    [state, startAuth, cancelAuth, submitCallback]
   );
 }


### PR DESCRIPTION
## Summary
Implements GitHub Issue #417 - Manual Callback URL Submission for OAuth.

When OAuth callback fails (cross-browser, headless server, firewall blocking), users can now:
- **Dashboard**: See the auth URL with Copy/Open buttons, and paste the callback URL manually
- **CLI**: Use `--paste-callback` flag to display auth URL and enter callback URL interactively

## Changes

### Backend (3 new endpoints)
- `POST /api/cliproxy/auth/:provider/start-url` - Returns auth URL immediately (non-blocking)
- `GET /api/cliproxy/auth/:provider/status` - Polls OAuth completion status
- `POST /api/cliproxy/auth/:provider/submit-callback` - Accepts manual callback URL

### Dashboard
- Updated `useCliproxyAuthFlow` hook with polling-based OAuth flow
- Updated `AddAccountDialog` to display auth URL and callback input during auth

### CLI
- Added `--paste-callback` flag to `ccs cliproxy auth` command
- Displays auth URL prominently, prompts for callback URL via readline

## Test Plan
- [ ] Start OAuth from Dashboard, verify auth URL displays with Copy/Open buttons
- [ ] Complete auth in different browser, paste callback URL, verify token saved
- [ ] Use `ccs cliproxy auth gemini --paste-callback` in CLI
- [ ] Verify normal OAuth flow still works when callback succeeds

Closes #417