### PR TITLE
fix(backup): create backups only when settings content changes

### DIFF
--- a/src/utils/websearch/profile-hook-injector.ts
+++ b/src/utils/websearch/profile-hook-injector.ts
@@ -123,11 +123,17 @@ export function ensureProfileHooks(profileName: string): boolean {
       // Clean up any duplicates that may have accumulated (Windows path bug fix)
       const hadDuplicates = deduplicateCcsHooks(settings);
       if (hadDuplicates) {
-        fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-        if (process.env.CCS_DEBUG) {
-          console.error(
-            info(`Removed duplicate WebSearch hooks from ${profileName}.settings.json`)
-          );
+        // Re-read file to compare with modified settings (deduplicateCcsHooks mutates in-place)
+        const newContent = JSON.stringify(settings, null, 2);
+        const existingContent = fs.readFileSync(settingsPath, 'utf8');
+        // Only write if content actually changed
+        if (newContent !== existingContent) {
+          fs.writeFileSync(settingsPath, newContent, 'utf8');
+          if (process.env.CCS_DEBUG) {
+            console.error(
+              info(`Removed duplicate WebSearch hooks from ${profileName}.settings.json`)
+            );
+          }
         }
       }
       // Update timeout if needed


### PR DESCRIPTION
## Summary

Fix excessive backup file creation in `~/.ccs/backups/` when settings are saved via Dashboard PUT API.

**Root cause:** The PUT `/api/settings/:profile` endpoint created a backup on every request regardless of whether content actually changed. This led to hundreds of identical backup files accumulating.

## Changes

- **`src/web-server/routes/settings-routes.ts`**: Compare existing content with new content before creating backup. Reuse computed `newContent` for atomic write (DRY).
- **`src/utils/websearch/profile-hook-injector.ts`**: Make hook injection idempotent by checking content before write.

## Test plan

- [x] All 1368 unit tests pass
- [x] `bun run validate` passes (typecheck, lint, format, tests)
- [ ] Manual: Open Dashboard, click Save without changes → verify no backup created
- [ ] Manual: Open Dashboard, modify env var, click Save → verify backup created

Fixes #433
