### PR TITLE
fix(glmt): gate retry rate limit logs behind verbose flag

### DIFF
--- a/src/glmt/glmt-proxy.ts
+++ b/src/glmt/glmt-proxy.ts
@@ -447,9 +447,11 @@ export class GlmtProxy {
         lastError = err;
         const delay = this.calculateRetryDelay(attempt, retryAfter);
 
-        console.error(
-          `[glmt-proxy] Rate limited, retry ${attempt + 1}/${this.retryConfig.maxRetries} after ${Math.round(delay)}ms`
-        );
+        if (this.verbose) {
+          console.error(
+            `[glmt-proxy] Rate limited, retry ${attempt + 1}/${this.retryConfig.maxRetries} after ${Math.round(delay)}ms`
+          );
+        }
 
         await this.sleep(delay);
       }
@@ -507,9 +509,11 @@ export class GlmtProxy {
         lastError = err;
         const delay = this.calculateRetryDelay(attempt, retryAfter);
 
-        console.error(
-          `[glmt-proxy] Rate limited, retry ${attempt + 1}/${this.retryConfig.maxRetries} after ${Math.round(delay)}ms`
-        );
+        if (this.verbose) {
+          console.error(
+            `[glmt-proxy] Rate limited, retry ${attempt + 1}/${this.retryConfig.maxRetries} after ${Math.round(delay)}ms`
+          );
+        }
 
         await this.sleep(delay);
       }


### PR DESCRIPTION
## Summary
- Rate limit retry messages in glmt-proxy now only appear when `--verbose` is enabled
- Keeps test output clean while preserving debug capability

## Changes
- `src/glmt/glmt-proxy.ts`: Wrapped both retry log statements in `if (this.verbose)` checks

## Test Plan
- [x] `bun run test:all` passes with no `[glmt-proxy] Rate limited` messages in output
- [x] Retry behavior still works correctly (verified via retry-logic.test.ts)
