### PR TITLE
fix(cliproxy): use os.homedir() for cross-platform path expansion

### DIFF
--- a/src/cliproxy/cliproxy-executor.ts
+++ b/src/cliproxy/cliproxy-executor.ts
@@ -14,6 +14,7 @@
 
 import { spawn, ChildProcess } from 'child_process';
 import * as net from 'net';
+import * as os from 'os';
 import { ProgressIndicator } from '../utils/progress-indicator';
 import { ok, fail, info, warn } from '../utils/ui';
 import { escapeShellArg } from '../utils/shell-executor';
@@ -925,9 +926,7 @@ export async function execClaudeWithCLIProxy(
           upstreamBaseUrl: postSanitizationBaseUrl,
           verbose,
           defaultEffort: 'medium',
-          traceFilePath: traceEnabled
-            ? `${process.env.HOME || process.cwd()}/.ccs/codex-reasoning-proxy.log`
-            : '',
+          traceFilePath: traceEnabled ? `${os.homedir()}/.ccs/codex-reasoning-proxy.log` : '',
           modelMap: {
             defaultModel: envVars.ANTHROPIC_MODEL,
             opusModel: envVars.ANTHROPIC_DEFAULT_OPUS_MODEL,
@@ -1028,7 +1027,7 @@ export async function execClaudeWithCLIProxy(
   // Get profile settings path for hooks (WebSearch, etc.)
   // Use custom settings path for CLIProxy variants, otherwise use default provider path
   const settingsPath = cfg.customSettingsPath
-    ? cfg.customSettingsPath.replace(/^~/, process.env.HOME || '')
+    ? cfg.customSettingsPath.replace(/^~/, os.homedir())
     : getProviderSettingsPath(provider);
 
   let claude: ChildProcess;


### PR DESCRIPTION
## Summary

- Replace `process.env.HOME || ''` with `os.homedir()` for custom settings path expansion
- Fixes Windows path syntax error after CLIProxy initialization

## Root Cause

On Windows, `process.env.HOME` is undefined. When a CLIProxy variant has a custom settings path like `~/.ccs/variant.settings.json`, the tilde expansion produces `/.ccs/variant.settings.json` (invalid Unix-style path on Windows).

## Test Plan

- [x] All 681 cliproxy tests pass
- [x] Build succeeds
- [x] Typecheck passes
- [ ] Manual test on Windows with CLIProxy variants

Closes #445
