### PR TITLE
fix(ui): prevent settings tab truncation with grid layout

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -319,3 +319,26 @@
   display: block !important;
   min-width: 0 !important;
 }
+
+/* Thin scrollbar utility for horizontal tab overflow */
+.scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar {
+  height: 4px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.scrollbar-thin::-webkit-scrollbar-thumb:hover {
+  background: var(--muted-foreground);
+}

--- a/ui/src/pages/settings/components/tab-navigation.tsx
+++ b/ui/src/pages/settings/components/tab-navigation.tsx
@@ -12,34 +12,25 @@ interface TabNavigationProps {
   onTabChange: (tab: SettingsTab) => void;
 }
 
+const tabs = [
+  { value: 'websearch' as const, label: 'Web', icon: Globe },
+  { value: 'globalenv' as const, label: 'Env', icon: Settings2 },
+  { value: 'thinking' as const, label: 'Think', icon: Brain },
+  { value: 'proxy' as const, label: 'Proxy', icon: Server },
+  { value: 'auth' as const, label: 'Auth', icon: KeyRound },
+  { value: 'backups' as const, label: 'Backup', icon: Archive },
+] as const;
+
 export function TabNavigation({ activeTab, onTabChange }: TabNavigationProps) {
   return (
     <Tabs value={activeTab} onValueChange={(v) => onTabChange(v as SettingsTab)}>
-      <TabsList className="w-full">
-        <TabsTrigger value="websearch" className="flex-1 gap-2">
-          <Globe className="w-4 h-4" />
-          WebSearch
-        </TabsTrigger>
-        <TabsTrigger value="globalenv" className="flex-1 gap-2">
-          <Settings2 className="w-4 h-4" />
-          Global Env
-        </TabsTrigger>
-        <TabsTrigger value="thinking" className="flex-1 gap-2">
-          <Brain className="w-4 h-4" />
-          Thinking
-        </TabsTrigger>
-        <TabsTrigger value="proxy" className="flex-1 gap-2">
-          <Server className="w-4 h-4" />
-          Proxy
-        </TabsTrigger>
-        <TabsTrigger value="auth" className="flex-1 gap-2">
-          <KeyRound className="w-4 h-4" />
-          Auth
-        </TabsTrigger>
-        <TabsTrigger value="backups" className="flex-1 gap-2">
-          <Archive className="w-4 h-4" />
-          Backups
-        </TabsTrigger>
+      <TabsList className="grid w-full grid-cols-6">
+        {tabs.map(({ value, label, icon: Icon }) => (
+          <TabsTrigger key={value} value={value} className="gap-1.5 px-1 text-xs">
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{label}</span>
+          </TabsTrigger>
+        ))}
       </TabsList>
     </Tabs>
   );


### PR DESCRIPTION
## Summary
- Use CSS grid (`grid-cols-6`) for even tab distribution in Settings page
- Shorten tab labels ("WebSearch" → "Web", "Global Env" → "Env", etc.) to fit narrow panels
- Add `scrollbar-thin` utility class for horizontal overflow scenarios

## Problem
Settings page tabs were getting truncated (e.g., "Backups" showing as "Back...") when the left panel was at its minimum width (30% viewport).

## Solution
- Replace `flex-1` with `grid grid-cols-6` for predictable equal sizing
- Use shorter, clearer labels that fit within constrained space
- Smaller text (`text-xs`) and icons (`h-3.5 w-3.5`) for compact display

## Test Plan
- [x] Verify tabs display correctly at minimum panel width (30%)
- [x] Verify tabs display correctly at maximum panel width (55%)
- [x] Verify tabs are clickable and switch content correctly
- [x] Build passes (`bun run validate`)