### PR TITLE
feat(oauth): add interactive mode prompt for VPS/headless environments

### DIFF
--- a/src/cliproxy/auth/auth-types.ts
+++ b/src/cliproxy/auth/auth-types.ts
@@ -221,4 +221,6 @@ export interface OAuthOptions {
   import?: boolean;
   /** Enable paste-callback mode: show auth URL and prompt for callback paste */
   pasteCallback?: boolean;
+  /** If true, use port-forwarding mode (skip interactive prompt in headless) */
+  portForward?: boolean;
 }

--- a/src/cliproxy/cliproxy-executor.ts
+++ b/src/cliproxy/cliproxy-executor.ts
@@ -316,7 +316,17 @@ export async function execClaudeWithCLIProxy(
   // 2. Handle special flags (use argsWithoutProxy - proxy flags already stripped)
   const forceAuth = argsWithoutProxy.includes('--auth');
   const pasteCallback = argsWithoutProxy.includes('--paste-callback');
+  const portForward = argsWithoutProxy.includes('--port-forward');
   const forceHeadless = argsWithoutProxy.includes('--headless');
+
+  // Validate conflicting flags
+  if (pasteCallback && portForward) {
+    console.error(fail('Cannot use --paste-callback with --port-forward'));
+    console.error('    --paste-callback: Manually paste OAuth redirect URL');
+    console.error('    --port-forward: Use SSH port forwarding for callback');
+    process.exit(1);
+  }
+
   const forceLogout = argsWithoutProxy.includes('--logout');
   const forceConfig = argsWithoutProxy.includes('--config');
   const addAccount = argsWithoutProxy.includes('--add');
@@ -548,6 +558,7 @@ export async function execClaudeWithCLIProxy(
         ...(setNickname ? { nickname: setNickname } : {}),
         ...(noIncognito ? { noIncognito: true } : {}),
         ...(pasteCallback ? { pasteCallback: true } : {}),
+        ...(portForward ? { portForward: true } : {}),
       });
       if (!authSuccess) {
         throw new Error(`Authentication required for ${providerConfig.displayName}`);
@@ -991,6 +1002,7 @@ export async function execClaudeWithCLIProxy(
   const ccsFlags = [
     '--auth',
     '--paste-callback',
+    '--port-forward',
     '--headless',
     '--logout',
     '--config',

--- a/src/commands/help-command.ts
+++ b/src/commands/help-command.ts
@@ -184,6 +184,7 @@ Run ${color('ccs config', 'command')} for web dashboard`.trim();
       ],
       ['ccs <provider> --logout', 'Clear authentication'],
       ['ccs <provider> --headless', 'Headless auth (for SSH)'],
+      ['ccs <provider> --port-forward', 'Force port-forwarding mode (skip prompt)'],
       ['ccs kiro --import', 'Import token from Kiro IDE'],
       ['ccs kiro --incognito', 'Use incognito browser (default: normal)'],
       ['ccs codex "explain code"', 'Use with prompt'],


### PR DESCRIPTION
## Summary

- Add interactive prompt when headless environment detected, asking users to choose between paste-callback mode (simpler) or port-forwarding mode (advanced)
- Add `--port-forward` flag to skip prompt and force port-forwarding mode
- Handle edge cases: Ctrl+C, invalid input, non-TTY stdin

## Changes

| File | Change |
|------|--------|
| `src/cliproxy/auth/auth-types.ts` | Add `portForward?: boolean` to `OAuthOptions` |
| `src/cliproxy/auth/oauth-handler.ts` | Add `promptOAuthModeChoice()` function |
| `src/cliproxy/cliproxy-executor.ts` | Parse `--port-forward` flag, add conflict detection |
| `src/commands/help-command.ts` | Document `--port-forward` flag |

## Test plan

- [x] Typecheck passes
- [x] Lint passes  
- [x] All 1443 tests pass
- [ ] Manual test on SSH session

Closes #461
