### PR TITLE
fix(doctor): use cmd.exe compatible quoting for Windows shell execution

### DIFF
--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -28,6 +28,7 @@ export function escapeShellArg(arg: string): string {
         .replace(/[\r\n\t]/g, ' ') // Replace newlines/tabs with space
         .replace(/%/g, '%%') // Escape percent signs
         .replace(/\^/g, '^^') // Escape carets
+        .replace(/!/g, '^^!') // Escape exclamation marks (delayed expansion)
         .replace(/"/g, '""') + // Escape quotes
       '"'
     );

--- a/tests/unit/utils/shell-executor.test.ts
+++ b/tests/unit/utils/shell-executor.test.ts
@@ -75,5 +75,10 @@ describe('escapeShellArg', () => {
       const { escapeShellArg } = await import('../../../src/utils/shell-executor');
       expect(escapeShellArg('C:\\Program Files\\App')).toBe('"C:\\Program Files\\App"');
     });
+
+    it('escapes exclamation marks for delayed expansion', async () => {
+      const { escapeShellArg } = await import('../../../src/utils/shell-executor');
+      expect(escapeShellArg('hello!')).toBe('"hello^^!"');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed Windows shell escaping that caused `ccs doctor` to report Claude CLI as "not found or not working" even when Claude was installed
- Changed `escapeShellArg` to use double quotes instead of single quotes for cmd.exe compatibility

## Root Cause
The `escapeShellArg` function was using PowerShell-style single quotes (`'arg'`), but `spawn({ shell: true })` on Windows uses `cmd.exe` by default. cmd.exe does not recognize single quotes as string delimiters, causing commands like `'claude' '--version'` to fail.

## Test plan
- [x] Tested on Windows machine with Claude CLI installed
- [x] `ccs doctor` now correctly detects Claude CLI: `[OK] Claude CLI v2.1.31`
- [x] All 1404 unit tests pass