### PR TITLE
fix(env): strip ANTHROPIC_* from account/default profiles

### DIFF
--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -13,7 +13,7 @@ import { getWebSearchHookEnv } from './websearch-manager';
  * Used for account/default profiles to prevent stale proxy config from
  * interfering with native Claude API routing.
  */
-function stripAnthropicEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+export function stripAnthropicEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const result: NodeJS.ProcessEnv = {};
   for (const key of Object.keys(env)) {
     if (!key.startsWith('ANTHROPIC_')) {


### PR DESCRIPTION
## Summary

- Strip `ANTHROPIC_*` env vars for account/default profiles before spawning Claude
- Prevents stale proxy config (e.g., from prior CLIProxy sessions) from causing ConnectionRefused errors
- Settings-based profiles already inject their own `ANTHROPIC_*` values, so they're unaffected

## Root Cause

`execClaude()` merges `process.env` first, then overlays `envVars`. Account/default profiles only set `CLAUDE_CONFIG_DIR` and `CCS_*` vars—they don't override/remove `ANTHROPIC_*`. If the parent shell has stale `ANTHROPIC_BASE_URL`, Claude tries to hit that proxy and fails.

## Changes

- Added `stripAnthropicEnv()` helper to filter `ANTHROPIC_*` keys
- Modified `execClaude()` to use stripped env for `account`/`default` profile types

## Test plan

- [x] All 1455 tests pass
- [x] `bun run validate` passes
- [x] Edge case verification via parallel code-reviewers

Closes #474
