### PR TITLE
fix(teams): propagate CLAUDE_CONFIG_DIR to tmux session for agent teammates

### DIFF
--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -4,7 +4,7 @@
  * Cross-platform shell execution utilities for CCS.
  */
 
-import { spawn, ChildProcess } from 'child_process';
+import { spawn, ChildProcess, execSync } from 'child_process';
 import { ErrorManager } from './error-manager';
 import { getWebSearchHookEnv } from './websearch-manager';
 
@@ -56,6 +56,21 @@ export function execClaude(
   const env = envVars
     ? { ...process.env, ...envVars, ...webSearchEnv }
     : { ...process.env, ...webSearchEnv };
+
+  // propagate key env vars to tmux session so agent team teammates
+  // (spawned via tmux split-window) inherit the correct config dir
+  if (process.env.TMUX && envVars) {
+    const tmuxPropagateVars = ['CLAUDE_CONFIG_DIR', 'CCS_PROFILE_TYPE', 'CCS_WEBSEARCH_SKIP'];
+    for (const key of tmuxPropagateVars) {
+      if (envVars[key]) {
+        try {
+          execSync(`tmux setenv ${key} ${JSON.stringify(envVars[key])}`, { stdio: 'ignore' });
+        } catch {
+          // tmux setenv can fail if not in a tmux session; safe to ignore
+        }
+      }
+    }
+  }
 
   let child: ChildProcess;
   if (needsShell) {


### PR DESCRIPTION
## Summary

- Fixes [Claude Code Agent Teams](https://code.claude.com/docs/en/agent-teams) teammate isolation when running CCS under tmux (split-pane display mode)
- Propagates `CLAUDE_CONFIG_DIR` (and other CCS env vars) into the tmux session environment via `tmux setenv` so that teammates spawned via `tmux split-window` inherit the correct instance path

## Problem

When CCS launches Claude with `CLAUDE_CONFIG_DIR=~/.ccs/instances/{profile}/`, the lead session works correctly. However, Claude Code's [agent teams](https://code.claude.com/docs/en/agent-teams) feature spawns teammates by running raw `claude` binaries in new tmux panes via `split-window`. These new panes inherit tmux's session environment — not the parent process's env — so teammates fall back to `~/.claude/` and can't see the lead's tasks, teams, or mailbox.

This causes:
- Split-brain task lists (lead writes to `~/.ccs/`, teammates read from `~/.claude/`)
- Broken inter-agent messaging
- Failed shutdown coordination
- `TeamDelete` failures

**Note:** In-process display mode is unaffected — teammates are spawned as direct child processes via Node.js `spawn()`, which inherits `process.env` (including `CLAUDE_CONFIG_DIR`) automatically. This fix specifically addresses the tmux split-pane display mode where new panes get tmux's session environment instead of the parent process's env.

## Fix

Added ~15 lines in `execClaude()` that detect a tmux session and use `tmux setenv` to propagate `CLAUDE_CONFIG_DIR`, `CCS_PROFILE_TYPE`, and `CCS_WEBSEARCH_SKIP` into the tmux session environment before spawning Claude.

## Test plan

- [x] Verified `tmux setenv` propagates correctly to new panes via `tmux split-window`
- [x] Tested full agent team lifecycle under CCS (split-pane mode): team creation, teammate spawning, task execution, messaging, shutdown, and cleanup — all working with fix applied
- [x] Confirmed no impact when not running under tmux (`process.env.TMUX` guard)
- [x] In-process mode unaffected (uses normal process env inheritance, not tmux)
- [ ] Cross-platform: fix is guarded by `process.env.TMUX` so Windows is unaffected