### PR TITLE
fix(teams): propagate CLAUDE_CONFIG_DIR to tmux session for agent teammates

### DIFF
--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -4,7 +4,7 @@
  * Cross-platform shell execution utilities for CCS.
  */
 
-import { spawn, ChildProcess, execSync } from 'child_process';
+import { spawn, spawnSync, ChildProcess } from 'child_process';
 import { ErrorManager } from './error-manager';
 import { getWebSearchHookEnv } from './websearch-manager';
 
@@ -89,7 +89,7 @@ export function execClaude(
     for (const key of tmuxPropagateVars) {
       if (envVars[key]) {
         try {
-          execSync(`tmux setenv ${key} ${JSON.stringify(envVars[key])}`, { stdio: 'ignore' });
+          spawnSync('tmux', ['setenv', key, envVars[key] ?? ''], { stdio: 'ignore' });
         } catch {
           // tmux setenv can fail if not in a tmux session; safe to ignore
         }


### PR DESCRIPTION
Based on #481 by @cumanzor — thank you for identifying and fixing the tmux env propagation issue! Rebased on dev and improved execSync to spawnSync (array args) to avoid shell interpretation.

## Changes

- ~15 lines in execClaude() detect tmux session and use tmux setenv to propagate CLAUDE_CONFIG_DIR, CCS_PROFILE_TYPE, and CCS_WEBSEARCH_SKIP
- Uses spawnSync with array args instead of execSync with string interpolation

## Attribution

- Original fix by @cumanzor (commit authorship preserved in git history)
- spawnSync refactor by @kaitranntt

## Test plan

- [x] Typecheck passes
- [x] All 1482 tests pass
- [x] Guarded by process.env.TMUX — no impact outside tmux