### PR TITLE
feat(cliproxy): delegate kiro/ghcp token refresh to CLIProxyAPIPlus

### DIFF
--- a/src/cliproxy/auth/token-refresh-worker.ts
+++ b/src/cliproxy/auth/token-refresh-worker.ts
@@ -7,7 +7,7 @@
 
 import { CLIProxyProvider } from '../types';
 import { getAllTokenExpiryInfo, TokenExpiryInfo } from './token-expiry-checker';
-import { refreshToken } from './provider-refreshers';
+import { refreshToken, isRefreshDelegated } from './provider-refreshers';
 
 /** Worker configuration */
 export interface TokenRefreshConfig {
@@ -182,7 +182,10 @@ export class TokenRefreshWorker {
 
     try {
       const tokens = getAllTokenExpiryInfo();
-      const tokensNeedingRefresh = tokens.filter((t) => t.needsRefresh);
+      // Skip CLIProxy-delegated providers — they handle their own refresh
+      const tokensNeedingRefresh = tokens.filter(
+        (t) => t.needsRefresh && !isRefreshDelegated(t.provider)
+      );
 
       if (tokensNeedingRefresh.length === 0) {
         this.log('[OK] All tokens valid, no refresh needed');


### PR DESCRIPTION
## Summary

- Classify providers into CCS-managed (gemini), CLIProxy-delegated (codex, agy, kiro, ghcp, qwen, iflow), and not-implemented (claude)
- Delegated providers return `{ success: true, delegated: true }` instead of "not implemented" error
- Skip `refresh_token` requirement for delegated providers in token expiry checker
- Filter delegated providers from background worker refresh loop

## Context

Follow-up from #267 (identity/collision fix — resolved). Addresses [Section C](https://github.com/kaitranntt/ccs/issues/267#issuecomment-3725171567) of the community comment on token refresh architecture.

CLIProxyAPIPlus already handles background token refresh for kiro (`internal/auth/kiro/background_refresh.go` — every 1 min) and other providers via on-demand OAuth. CCS was returning "Token refresh not yet implemented" errors, causing noisy worker logs and preventing proper token expiry tracking for kiro/ghcp tokens without `refresh_token` field.

## Files Changed

- `src/cliproxy/auth/provider-refreshers/index.ts` — Split providers into 3 categories, export `isRefreshDelegated()`
- `src/cliproxy/auth/token-expiry-checker.ts` — Skip `refresh_token` validation for delegated providers
- `src/cliproxy/auth/token-manager.ts` — Document delegation architecture in `ensureTokenValid()` JSDoc
- `src/cliproxy/auth/token-refresh-worker.ts` — Filter delegated providers from refresh loop

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint:fix` — clean
- [x] `bun run format:check` — passes
- [x] `bun test tests/unit` — 1443 pass, 0 fail
- [ ] Manual: verify kiro token no longer produces worker error logs
- [ ] Manual: verify gemini refresh still works independently

Closes #487
