### PR TITLE
fix(cliproxy): guard against empty upstream SSE responses in agy profile

### DIFF
--- a/src/cliproxy/tool-sanitization-proxy.ts
+++ b/src/cliproxy/tool-sanitization-proxy.ts
@@ -446,7 +446,11 @@ export class ToolSanitizationProxy {
           const isSuccessResponse =
             (upstreamRes.statusCode || 200) >= 200 && (upstreamRes.statusCode || 200) < 300;
 
-          // If no changes were made, intercept to detect empty responses
+          // If no changes were made, intercept to detect empty responses.
+          // In the real failure case (issue #350), upstream sends message_start but
+          // NOT message_delta/message_stop, so the synthetic response completes the
+          // stream. If upstream DID send message_stop, Claude Code treats the second
+          // synthetic block as additional content in the same conversation turn.
           if (!mapper.hasChanges()) {
             upstreamRes.on('data', (chunk: Buffer) => {
               hasReceivedData = true;

--- a/tests/unit/cliproxy/tool-sanitization-proxy-integration.test.ts
+++ b/tests/unit/cliproxy/tool-sanitization-proxy-integration.test.ts
@@ -613,5 +613,85 @@ describe('ToolSanitizationProxy Integration', () => {
         proxy.stop();
       }
     });
+
+    it('injects synthetic response via SSE processing path (with sanitized tool names)', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      // Upstream returns empty content — no content_block_start events
+      // Using sanitized tool name ('foo__bar__bar' → 'foo__bar') triggers the SSE processing path
+      mockResponse = {
+        status: 200,
+        stream: true,
+        body: [
+          'event: message_start\n',
+          'data: {"type":"message_start","message":{"id":"msg_sse","type":"message","role":"assistant","content":[],"model":"test","stop_reason":null}}\n\n',
+          'event: message_delta\n',
+          'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":10,"output_tokens":0}}\n\n',
+          'event: message_stop\n',
+          'data: {"type":"message_stop"}\n\n',
+        ],
+      };
+
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            stream: true,
+            tools: [{ name: 'foo__bar__bar' }], // Triggers sanitization → SSE processing path
+          }),
+        });
+
+        const text = await response.text();
+        expect(text).toContain('[Proxy Error]');
+        expect(text).toContain('content_block_start');
+        const messageStartCount = (text.match(/"type":"message_start"/g) || []).length;
+        expect(messageStartCount).toBe(1);
+      } finally {
+        proxy.stop();
+      }
+    });
+
+    it('injects synthetic response when upstream sends only message_start (real failure mode)', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      // Real failure: upstream sends message_start then abruptly ends — no message_delta or message_stop
+      mockResponse = {
+        status: 200,
+        stream: true,
+        body: [
+          'event: message_start\n',
+          'data: {"type":"message_start","message":{"id":"msg_abrupt","type":"message","role":"assistant","content":[],"model":"test","stop_reason":null}}\n\n',
+        ],
+      };
+
+      try {
+        const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            stream: true,
+            tools: [{ name: 'valid_tool' }],
+          }),
+        });
+
+        const text = await response.text();
+        expect(text).toContain('[Proxy Error]');
+        expect(text).toContain('content_block_start');
+        expect(text).toContain('message_delta');
+        expect(text).toContain('message_stop');
+        // Only 1 message_start — upstream's original
+        const messageStartCount = (text.match(/"type":"message_start"/g) || []).length;
+        expect(messageStartCount).toBe(1);
+      } finally {
+        proxy.stop();
+      }
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Detects when CLIProxyAPIPlus returns empty SSE streams (no content blocks) during sub-agent execution on `ccs agy`
- Injects a synthetic minimal valid SSE response to prevent Claude Code CLI from crashing with "No assistant message found"
- Applies to both the pipe-through and SSE-processing paths in the tool sanitization proxy

## Root Cause
CLIProxyAPIPlus (`antigravity_claude_response.go:310-313`) drops unsigned thinking blocks. When no text/tool_use content accompanies them, `HasContent` stays `false`, causing the response to end without `message_delta`/`message_stop` events. This is a defensive CCS-side fix; the upstream fix should happen in CLIProxyAPIPlus.

## Test plan
- [x] All 758 cliproxy tests pass (0 failures)
- [x] All 86 delegation tests pass
- [x] Pre-commit hooks pass (typecheck, eslint, prettier)
- [ ] Manual test: `ccs agy -p "use the Task tool to explore codebase"` no longer crashes with empty response

Closes #350