### PR TITLE
feat(cliproxy): expose codex weekly reset schedule in quota views

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Re-creates symlinks for shared commands, skills, and settings.
 
 ```bash
 ccs cliproxy doctor     # Check quota status for all agy accounts
+ccs cliproxy quota      # Show agy/codex/gemini quotas (Codex: 5h + weekly reset schedule)
 ```
 
 **Auto-Failover**: When an Antigravity account runs out of quota, CCS automatically switches to another account with remaining capacity. Shared GCP project accounts are excluded (pooled quota).

--- a/src/cliproxy/quota-fetcher-codex.ts
+++ b/src/cliproxy/quota-fetcher-codex.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import { getAuthDir } from './config-generator';
 import { getProviderAccounts, getPausedDir } from './account-manager';
 import { sanitizeEmail, isTokenExpired } from './auth-utils';
-import type { CodexQuotaResult, CodexQuotaWindow } from './quota-types';
+import type { CodexQuotaResult, CodexQuotaWindow, CodexCoreUsageSummary } from './quota-types';
 
 /** ChatGPT backend API base URL */
 const CODEX_API_BASE = 'https://chatgpt.com/backend-api';
@@ -55,6 +55,99 @@ interface CodexWindowData {
   usedPercent?: number;
   reset_after_seconds?: number | null;
   resetAfterSeconds?: number | null;
+}
+
+type CodexWindowKind =
+  | 'usage-5h'
+  | 'usage-weekly'
+  | 'code-review-5h'
+  | 'code-review-weekly'
+  | 'code-review'
+  | 'unknown';
+
+function getCodexWindowKind(label: string): CodexWindowKind {
+  const lower = (label || '').toLowerCase();
+  const isCodeReview = lower.includes('code review') || lower.includes('code_review');
+  const isPrimary = lower.includes('primary');
+  const isSecondary = lower.includes('secondary');
+
+  if (isCodeReview) {
+    if (isPrimary) return 'code-review-5h';
+    if (isSecondary) return 'code-review-weekly';
+    return 'code-review';
+  }
+
+  if (isPrimary) return 'usage-5h';
+  if (isSecondary) return 'usage-weekly';
+  return 'unknown';
+}
+
+/**
+ * Build explicit 5h + weekly usage summary from raw Codex windows.
+ * Falls back to shortest/longest reset windows if API labels change.
+ */
+export function buildCodexCoreUsageSummary(windows: CodexQuotaWindow[]): CodexCoreUsageSummary {
+  if (!windows || windows.length === 0) {
+    return { fiveHour: null, weekly: null };
+  }
+
+  let fiveHourWindow: CodexQuotaWindow | null = null;
+  let weeklyWindow: CodexQuotaWindow | null = null;
+  const nonCodeReviewWindows: CodexQuotaWindow[] = [];
+
+  for (const window of windows) {
+    const kind = getCodexWindowKind(window.label);
+    if (kind === 'usage-5h') {
+      if (!fiveHourWindow) fiveHourWindow = window;
+      nonCodeReviewWindows.push(window);
+      continue;
+    }
+    if (kind === 'usage-weekly') {
+      if (!weeklyWindow) weeklyWindow = window;
+      nonCodeReviewWindows.push(window);
+      continue;
+    }
+    if (kind === 'unknown') {
+      nonCodeReviewWindows.push(window);
+    }
+  }
+
+  if ((!fiveHourWindow || !weeklyWindow) && nonCodeReviewWindows.length > 0) {
+    const withReset = nonCodeReviewWindows
+      .filter(
+        (w) =>
+          typeof w.resetAfterSeconds === 'number' &&
+          isFinite(w.resetAfterSeconds) &&
+          w.resetAfterSeconds >= 0
+      )
+      .sort((a, b) => (a.resetAfterSeconds || 0) - (b.resetAfterSeconds || 0));
+
+    if (!fiveHourWindow) {
+      fiveHourWindow = withReset[0] || nonCodeReviewWindows[0] || null;
+    }
+
+    if (!weeklyWindow) {
+      weeklyWindow =
+        withReset.length > 1
+          ? withReset[withReset.length - 1]
+          : nonCodeReviewWindows.find((w) => w !== fiveHourWindow) || null;
+    }
+  }
+
+  const mapWindow = (window: CodexQuotaWindow | null): CodexCoreUsageSummary['fiveHour'] => {
+    if (!window) return null;
+    return {
+      label: window.label,
+      remainingPercent: window.remainingPercent,
+      resetAfterSeconds: window.resetAfterSeconds,
+      resetAt: window.resetAt,
+    };
+  };
+
+  return {
+    fiveHour: mapWindow(fiveHourWindow),
+    weekly: mapWindow(weeklyWindow),
+  };
 }
 
 /**
@@ -295,6 +388,7 @@ export async function fetchCodexQuota(
 
       const data = (await response.json()) as CodexUsageResponse;
       const windows = buildCodexQuotaWindows(data);
+      const coreUsage = buildCodexCoreUsageSummary(windows);
 
       // Extract plan type
       const planTypeRaw = data.plan_type || data.planType;
@@ -311,6 +405,7 @@ export async function fetchCodexQuota(
       return {
         success: true,
         windows,
+        coreUsage,
         planType,
         lastUpdated: Date.now(),
         accountId,

--- a/src/cliproxy/quota-types.ts
+++ b/src/cliproxy/quota-types.ts
@@ -27,6 +27,26 @@ export interface CodexQuotaWindow {
   resetAt: string | null;
 }
 
+/** Core Codex usage window (5h/weekly) extracted from raw windows */
+export interface CodexCoreUsageWindow {
+  /** Source window label */
+  label: string;
+  /** Percentage remaining (0-100) */
+  remainingPercent: number;
+  /** Seconds until quota resets, null if unknown */
+  resetAfterSeconds: number | null;
+  /** ISO timestamp when quota resets, null if unknown */
+  resetAt: string | null;
+}
+
+/** Core Codex usage summary with explicit 5h and weekly windows */
+export interface CodexCoreUsageSummary {
+  /** Short-cycle usage limit window (typically 5h) */
+  fiveHour: CodexCoreUsageWindow | null;
+  /** Long-cycle usage limit window (typically weekly) */
+  weekly: CodexCoreUsageWindow | null;
+}
+
 /**
  * Codex quota fetch result
  */
@@ -35,6 +55,8 @@ export interface CodexQuotaResult {
   success: boolean;
   /** Quota windows (primary, secondary, code review) */
   windows: CodexQuotaWindow[];
+  /** Explicit core usage windows (5h + weekly) for easier reset display */
+  coreUsage?: CodexCoreUsageSummary;
   /** Plan type: free, plus, team, or null if unknown */
   planType: 'free' | 'plus' | 'team' | null;
   /** Timestamp of fetch */

--- a/src/commands/cliproxy/help-subcommand.ts
+++ b/src/commands/cliproxy/help-subcommand.ts
@@ -54,7 +54,7 @@ export async function showHelp(): Promise<void> {
         ['default <account>', 'Set default account for rotation'],
         ['pause <account>', 'Pause account (skip in rotation)'],
         ['resume <account>', 'Resume paused account'],
-        ['quota', 'Show quota status for all providers'],
+        ['quota', 'Show quota status for all providers (Codex includes 5h + weekly reset)'],
         ['quota --provider <name>', 'Filter by provider (agy|codex|gemini)'],
       ],
     ],

--- a/ui/src/components/shared/quota-tooltip-content.tsx
+++ b/ui/src/components/shared/quota-tooltip-content.tsx
@@ -68,6 +68,8 @@ export function QuotaTooltipContent({ quota, resetTime }: QuotaTooltipContentPro
   if (isCodexQuotaResult(quota)) {
     const { fiveHourWindow, weeklyWindow, codeReviewWindows, unknownWindows } =
       getCodexQuotaBreakdown(quota.windows);
+    const fiveHourResetAt = quota.coreUsage?.fiveHour?.resetAt ?? fiveHourWindow?.resetAt ?? null;
+    const weeklyResetAt = quota.coreUsage?.weekly?.resetAt ?? weeklyWindow?.resetAt ?? null;
     const orderedWindows = [fiveHourWindow, weeklyWindow, ...codeReviewWindows, ...unknownWindows]
       .filter((w): w is NonNullable<typeof w> => !!w)
       .filter(
@@ -92,7 +94,11 @@ export function QuotaTooltipContent({ quota, resetTime }: QuotaTooltipContentPro
             <span className="font-mono">{w.remainingPercent}%</span>
           </div>
         ))}
-        <ResetTimeIndicator resetTime={resetTime} />
+        <CodexResetIndicators
+          fiveHourResetTime={fiveHourResetAt}
+          weeklyResetTime={weeklyResetAt}
+          fallbackResetTime={resetTime}
+        />
       </div>
     );
   }
@@ -129,6 +135,43 @@ function ResetTimeIndicator({ resetTime }: { resetTime: string | null }) {
     <div className="flex items-center gap-1.5 pt-1 border-t border-border/50">
       <Clock className="w-3 h-3 text-blue-400" />
       <span className="text-blue-400 font-medium">Resets {formatResetTime(resetTime)}</span>
+    </div>
+  );
+}
+
+function CodexResetIndicators({
+  fiveHourResetTime,
+  weeklyResetTime,
+  fallbackResetTime,
+}: {
+  fiveHourResetTime: string | null;
+  weeklyResetTime: string | null;
+  fallbackResetTime: string | null;
+}) {
+  const hasSpecificReset = !!fiveHourResetTime || !!weeklyResetTime;
+  if (!hasSpecificReset && !fallbackResetTime) return null;
+
+  return (
+    <div className="pt-1 border-t border-border/50 space-y-1">
+      {fiveHourResetTime && (
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-3 h-3 text-blue-400" />
+          <span className="text-blue-400 font-medium">
+            5h resets {formatResetTime(fiveHourResetTime)}
+          </span>
+        </div>
+      )}
+      {weeklyResetTime && (
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-3 h-3 text-indigo-400" />
+          <span className="text-indigo-400 font-medium">
+            Weekly resets {formatResetTime(weeklyResetTime)}
+          </span>
+        </div>
+      )}
+      {!hasSpecificReset && fallbackResetTime && (
+        <ResetTimeIndicator resetTime={fallbackResetTime} />
+      )}
     </div>
   );
 }

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -183,12 +183,34 @@ export interface CodexQuotaWindow {
   resetAt: string | null;
 }
 
+/** Core Codex usage window (5h/weekly) extracted from raw windows */
+export interface CodexCoreUsageWindow {
+  /** Source window label */
+  label: string;
+  /** Percentage remaining (0-100) */
+  remainingPercent: number;
+  /** Seconds until quota resets, null if unknown */
+  resetAfterSeconds: number | null;
+  /** ISO timestamp when quota resets, null if unknown */
+  resetAt: string | null;
+}
+
+/** Core Codex usage summary with explicit 5h and weekly windows */
+export interface CodexCoreUsageSummary {
+  /** Short-cycle usage limit window (typically 5h) */
+  fiveHour: CodexCoreUsageWindow | null;
+  /** Long-cycle usage limit window (typically weekly) */
+  weekly: CodexCoreUsageWindow | null;
+}
+
 /** Codex quota result */
 export interface CodexQuotaResult {
   /** Whether fetch succeeded */
   success: boolean;
   /** Quota windows (primary, secondary, code review) */
   windows: CodexQuotaWindow[];
+  /** Explicit core usage windows (5h + weekly) for easier reset display */
+  coreUsage?: CodexCoreUsageSummary;
   /** Plan type: free, plus, team, or null if unknown */
   planType: 'free' | 'plus' | 'team' | null;
   /** Timestamp of fetch */


### PR DESCRIPTION
## Summary
- add explicit Codex core usage reset summary (5h + weekly) in quota fetch responses
- show reset schedule line in Quota Status