### PR TITLE
fix(cliproxy): normalize codex model and provider routing

### DIFF
--- a/tests/unit/cliproxy/codex-reasoning-proxy-extended-context.test.ts
+++ b/tests/unit/cliproxy/codex-reasoning-proxy-extended-context.test.ts
@@ -1,0 +1,144 @@
+import * as http from 'http';
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  buildCodexModelEffortMap,
+  CodexReasoningProxy,
+  getEffortForModel,
+} from '../../../src/cliproxy/codex-reasoning-proxy';
+
+type JsonRecord = Record<string, unknown>;
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+function listenOnRandomPort(server: http.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address !== 'object' || !address) {
+        reject(new Error('Failed to resolve server address'));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function postJson(
+  url: string,
+  body: JsonRecord
+): Promise<{ statusCode: number; body: JsonRecord }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const payload = JSON.stringify(body);
+
+    const req = http.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port,
+        path: parsed.pathname + parsed.search,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let responseBody = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          responseBody += chunk;
+        });
+        res.on('end', () => {
+          let parsedResponse: JsonRecord = {};
+          try {
+            parsedResponse = responseBody ? (JSON.parse(responseBody) as JsonRecord) : {};
+          } catch {
+            parsedResponse = {};
+          }
+          resolve({ statusCode: res.statusCode ?? 0, body: parsedResponse });
+        });
+      }
+    );
+
+    req.on('error', reject);
+    req.write(payload);
+    req.end();
+  });
+}
+
+describe('CodexReasoningProxy extended-context compatibility', () => {
+  const cleanupServers: http.Server[] = [];
+
+  afterEach(async () => {
+    while (cleanupServers.length > 0) {
+      const server = cleanupServers.pop();
+      if (server) {
+        await closeServer(server);
+      }
+    }
+  });
+
+  it('normalizes [1m] suffixes in effort map lookups', () => {
+    const map = buildCodexModelEffortMap({
+      defaultModel: 'gpt-5.3-codex-xhigh[1m]',
+      sonnetModel: 'gpt-5.3-codex-high[1m]',
+      haikuModel: 'gpt-5-mini-medium[1m]',
+    });
+
+    expect(getEffortForModel('gpt-5.3-codex-high', map, 'medium')).toBe('high');
+    expect(getEffortForModel('gpt-5-mini-medium', map, 'high')).toBe('medium');
+  });
+
+  it('strips [1m] and codex effort suffixes before forwarding upstream', async () => {
+    let capturedBody: JsonRecord | null = null;
+    let capturedPath = '';
+
+    const upstream = http.createServer((req, res) => {
+      let rawBody = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        rawBody += chunk;
+      });
+      req.on('end', () => {
+        capturedPath = req.url || '';
+        capturedBody = rawBody ? (JSON.parse(rawBody) as JsonRecord) : {};
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    cleanupServers.push(upstream);
+
+    const upstreamPort = await listenOnRandomPort(upstream);
+    const proxy = new CodexReasoningProxy({
+      upstreamBaseUrl: `http://127.0.0.1:${upstreamPort}`,
+      modelMap: {
+        defaultModel: 'gpt-5.3-codex-xhigh[1m]',
+        opusModel: 'gpt-5.3-codex-xhigh[1m]',
+        sonnetModel: 'gpt-5.3-codex-high[1m]',
+        haikuModel: 'gpt-5-mini-medium[1m]',
+      },
+      defaultEffort: 'medium',
+    });
+
+    const proxyPort = await proxy.start();
+    const response = await postJson(
+      `http://127.0.0.1:${proxyPort}/api/provider/codex/v1/messages`,
+      {
+        model: 'gpt-5.3-codex-high[1m]',
+        messages: [],
+      }
+    );
+
+    proxy.stop();
+
+    expect(response.statusCode).toBe(200);
+    expect(capturedPath).toBe('/api/provider/codex/v1/messages');
+    expect(capturedBody?.model).toBe('gpt-5.3-codex');
+    expect((capturedBody?.reasoning as JsonRecord | undefined)?.effort).toBe('high');
+  });
+});

--- a/tests/unit/cliproxy/env-builder-provider-url.test.ts
+++ b/tests/unit/cliproxy/env-builder-provider-url.test.ts
@@ -1,0 +1,74 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { getEffectiveEnvVars } from '../../../src/cliproxy/config/env-builder';
+
+interface EnvSettings {
+  ANTHROPIC_BASE_URL: string;
+  ANTHROPIC_AUTH_TOKEN: string;
+  ANTHROPIC_MODEL: string;
+  ANTHROPIC_DEFAULT_OPUS_MODEL: string;
+  ANTHROPIC_DEFAULT_SONNET_MODEL: string;
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: string;
+}
+
+function writeCodexSettings(settingsPath: string, env: EnvSettings): void {
+  fs.writeFileSync(settingsPath, JSON.stringify({ env }, null, 2));
+}
+
+describe('getEffectiveEnvVars local provider URL normalization', () => {
+  let tempHome: string;
+  let settingsPath: string;
+
+  beforeEach(() => {
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-env-url-'));
+    settingsPath = path.join(tempHome, 'codex.settings.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it('rewrites local root URL to provider endpoint', () => {
+    writeCodexSettings(settingsPath, {
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:8317',
+      ANTHROPIC_AUTH_TOKEN: 'ccs-internal-managed',
+      ANTHROPIC_MODEL: 'gpt-5.3-codex-xhigh',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.3-codex-xhigh',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.3-codex-high',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5-mini-medium',
+    });
+
+    const env = getEffectiveEnvVars('codex', 8317, settingsPath);
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:8317/api/provider/codex');
+  });
+
+  it('rewrites wrong local provider path to the requested provider', () => {
+    writeCodexSettings(settingsPath, {
+      ANTHROPIC_BASE_URL: 'http://localhost:8317/api/provider/my-codex-variant?debug=1',
+      ANTHROPIC_AUTH_TOKEN: 'ccs-internal-managed',
+      ANTHROPIC_MODEL: 'gpt-5.3-codex-xhigh',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.3-codex-xhigh',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.3-codex-high',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5-mini-medium',
+    });
+
+    const env = getEffectiveEnvVars('codex', 8317, settingsPath);
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://localhost:8317/api/provider/codex');
+  });
+
+  it('does not rewrite localhost URLs targeting non-cliproxy ports', () => {
+    writeCodexSettings(settingsPath, {
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+      ANTHROPIC_AUTH_TOKEN: 'ccs-internal-managed',
+      ANTHROPIC_MODEL: 'gpt-5.3-codex-xhigh',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.3-codex-xhigh',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.3-codex-high',
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5-mini-medium',
+    });
+
+    const env = getEffectiveEnvVars('codex', 8317, settingsPath);
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:11434');
+  });
+});

--- a/ui/src/components/cliproxy/provider-editor/index.tsx
+++ b/ui/src/components/cliproxy/provider-editor/index.tsx
@@ -79,6 +79,8 @@ export function ProviderEditor({
     );
   }, [modelsData, modelFilterProvider]);
 
+  const providerRoute = (baseProvider || provider).toLowerCase();
+
   const {
     data,
     isLoading,
@@ -119,7 +121,7 @@ export function ProviderEditor({
   const handleApplyPreset = (updates: Record<string, string>) => {
     const effectivePort = port ?? CLIPROXY_DEFAULT_PORT;
     updateEnvValues({
-      ANTHROPIC_BASE_URL: `http://127.0.0.1:${effectivePort}/api/provider/${provider}`,
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${effectivePort}/api/provider/${providerRoute}`,
       ANTHROPIC_AUTH_TOKEN: effectiveApiKey,
       ...updates,
     });
@@ -129,7 +131,7 @@ export function ProviderEditor({
   const handleCustomPresetApply = (values: ModelMappingValues, presetName?: string) => {
     const effectivePort = port ?? CLIPROXY_DEFAULT_PORT;
     updateEnvValues({
-      ANTHROPIC_BASE_URL: `http://127.0.0.1:${effectivePort}/api/provider/${provider}`,
+      ANTHROPIC_BASE_URL: `http://127.0.0.1:${effectivePort}/api/provider/${providerRoute}`,
       ANTHROPIC_AUTH_TOKEN: effectiveApiKey,
       ANTHROPIC_MODEL: values.default,
       ANTHROPIC_DEFAULT_OPUS_MODEL: values.opus,


### PR DESCRIPTION
## Summary
- normalize codex reasoning proxy model aliases by stripping  extended-context suffix before effort mapping and upstream forwarding
- normalize local  to provider-pinned  for active local cliproxy port
- fix provider editor preset apply path to use base provider route for variants
- add regression tests for codex  model handling and provider URL normalization

## Validation
- bun run validate
- cd ui && bun run validate