### PR TITLE
fix(cliproxy): warn gemini and agy users about issue 509

### DIFF
--- a/src/cliproxy/executor/index.ts
+++ b/src/cliproxy/executor/index.ts
@@ -67,6 +67,7 @@ import { checkOrJoinProxy, registerProxySession, setupCleanupHandlers } from './
 import { parseThinkingOverride } from './thinking-arg-parser';
 import {
   warnCrossProviderDuplicates,
+  warnOAuthBanRisk,
   cleanupStaleAutoPauses,
   enforceProviderIsolation,
   restoreAutoPausedAccounts,
@@ -187,6 +188,7 @@ export async function execClaudeWithCLIProxy(
 
   const providerConfig = getProviderConfig(provider);
   log(`Provider: ${providerConfig.displayName}`);
+  warnOAuthBanRisk(provider);
 
   // Check remote proxy if configured
   let useRemoteProxy = false;

--- a/src/cliproxy/executor/retry-handler.ts
+++ b/src/cliproxy/executor/retry-handler.ts
@@ -10,7 +10,7 @@
 
 import { fail, warn, info } from '../../utils/ui';
 import { CLIProxyProvider } from '../types';
-import { handleBanDetection } from '../account-safety';
+import { handleBanDetection, warnPossible403Ban } from '../account-safety';
 import { CompositeTierConfig } from '../../config/unified-config-types';
 
 /**
@@ -59,6 +59,7 @@ export async function handleTokenExpiration(
       if (account) {
         handleBanDetection(provider, account.id, tokenResult.error);
       }
+      warnPossible403Ban(provider, tokenResult.error);
     }
 
     // Token expired and refresh failed - trigger re-auth

--- a/ui/src/pages/cliproxy.tsx
+++ b/ui/src/pages/cliproxy.tsx
@@ -8,9 +8,10 @@ import { useState, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Check, X, RefreshCw, Sparkles, Zap, GitBranch, Trash2 } from 'lucide-react';
+import { Check, X, RefreshCw, Sparkles, Zap, GitBranch, Trash2, AlertTriangle } from 'lucide-react';
 import { QuickSetupWizard } from '@/components/quick-setup-wizard';
 import { AddAccountDialog } from '@/components/account/add-account-dialog';
 import { ProviderEditor } from '@/components/cliproxy/provider-editor';
@@ -243,6 +244,10 @@ export function CliproxyPage() {
   const parentAuthForVariant = selectedVariantData
     ? providers.find((p) => p.provider === selectedVariantData.provider)
     : undefined;
+  const warningProvider = (selectedVariantData?.provider || selectedStatus?.provider || '')
+    .toLowerCase()
+    .trim();
+  const showAccountSafetyWarning = warningProvider === 'gemini' || warningProvider === 'agy';
 
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['cliproxy'] });
@@ -389,6 +394,30 @@ export function CliproxyPage() {
 
       {/* Right Panel */}
       <div className="flex-1 flex flex-col min-w-0 bg-background">
+        {showAccountSafetyWarning && (
+          <div className="px-4 pt-4">
+            <Alert variant="warning" className="py-2">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Account Safety Warning (Issue #509)</AlertTitle>
+              <AlertDescription>
+                Using the same Google account in both <code className="font-mono">ccs gemini</code>{' '}
+                and <code className="font-mono">ccs agy</code> can trigger suspension. If CLI shows{' '}
+                <code className="font-mono">403 Forbidden</code>, treat it as likely account
+                disable/ban and switch accounts.{' '}
+                <a
+                  href="https://github.com/kaitranntt/ccs/issues/509"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline font-medium"
+                >
+                  Read issue #509
+                </a>
+                .
+              </AlertDescription>
+            </Alert>
+          </div>
+        )}
+
         {selectedVariantData && parentAuthForVariant ? (
           // Variant selected - show ProviderEditor with variant profile name
           <ProviderEditor


### PR DESCRIPTION
## Summary
- add account safety warning in CLIProxy dashboard, scoped to Gemini and Antigravity tabs only
- add CLI warning for gemini/agy startup and OAuth flows about shared Google account risk
- add explicit 403/Forbidden warning path as likely account disable/ban signal, linked to issue #509

## Validation
- bun run validate
- cd ui && bun run validate

Closes #509