### PR TITLE
fix(cliproxy): codex 5.3 model mapping fallback without reasoning proxy

### DIFF
--- a/tests/unit/cliproxy/env-resolver-codex-fallback.test.ts
+++ b/tests/unit/cliproxy/env-resolver-codex-fallback.test.ts
@@ -1,0 +1,95 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { buildClaudeEnvironment } from '../../../src/cliproxy/executor/env-resolver';
+
+const tempDirs: string[] = [];
+
+function createCodexSettingsFile(models: {
+  defaultModel: string;
+  opusModel: string;
+  sonnetModel: string;
+  haikuModel: string;
+}): string {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-codex-fallback-'));
+  tempDirs.push(tempDir);
+
+  const settingsPath = path.join(tempDir, 'codex-test.settings.json');
+  fs.writeFileSync(
+    settingsPath,
+    JSON.stringify(
+      {
+        env: {
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:8317/api/provider/codex',
+          ANTHROPIC_AUTH_TOKEN: 'test-token',
+          ANTHROPIC_MODEL: models.defaultModel,
+          ANTHROPIC_DEFAULT_OPUS_MODEL: models.opusModel,
+          ANTHROPIC_DEFAULT_SONNET_MODEL: models.sonnetModel,
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: models.haikuModel,
+        },
+      },
+      null,
+      2
+    ) + '\n'
+  );
+
+  return settingsPath;
+}
+
+describe('buildClaudeEnvironment codex fallback normalization', () => {
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      const tempDir = tempDirs.pop();
+      if (tempDir) {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('normalizes codex effort aliases when reasoning proxy is unavailable', () => {
+    const settingsPath = createCodexSettingsFile({
+      defaultModel: 'gpt-5.3-codex-high',
+      opusModel: 'gpt-5.3-codex-xhigh',
+      sonnetModel: 'gpt-5.3-codex-high',
+      haikuModel: 'gpt-5-mini-medium',
+    });
+
+    const env = buildClaudeEnvironment({
+      provider: 'codex',
+      useRemoteProxy: false,
+      localPort: 8317,
+      customSettingsPath: settingsPath,
+      verbose: false,
+    });
+
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex(high)');
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex(xhigh)');
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex(high)');
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini(medium)');
+  });
+
+  it('keeps codex effort aliases when reasoning proxy is active', () => {
+    const settingsPath = createCodexSettingsFile({
+      defaultModel: 'gpt-5.3-codex-high',
+      opusModel: 'gpt-5.3-codex-xhigh',
+      sonnetModel: 'gpt-5.3-codex-high',
+      haikuModel: 'gpt-5-mini-medium',
+    });
+
+    const env = buildClaudeEnvironment({
+      provider: 'codex',
+      useRemoteProxy: false,
+      localPort: 8317,
+      customSettingsPath: settingsPath,
+      codexReasoningPort: 9444,
+      verbose: false,
+    });
+
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex-high');
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex-xhigh');
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex-high');
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini-medium');
+    expect(env.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:9444/api/provider/codex');
+  });
+});


### PR DESCRIPTION
## Summary
- add Codex fallback normalization in env resolver when codex reasoning proxy is unavailable
- convert codex model aliases from `-medium/-high/-xhigh` to upstream-compatible `(medium|high|xhigh)`
- add regression tests for fallback-on and fallback-off (proxy-active) paths

## Problem
Codex model mapping values like `gpt-5.3-codex-high` can reach CLIProxyAPI unchanged when the local codex reasoning proxy is not active, which causes upstream provider resolution to fail with `unknown provider for model ...`.

## Validation
- bun test tests/unit/cliproxy/env-resolver-codex-fallback.test.ts
- bun test tests/unit/cliproxy/codex-reasoning-proxy-extended-context.test.ts

Closes #603