### PR TITLE
fix(cliproxy): keep canonical codex model ids in settings

### DIFF
--- a/config/base-codex.settings.json
+++ b/config/base-codex.settings.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/codex",
     "ANTHROPIC_AUTH_TOKEN": "ccs-internal-managed",
-    "ANTHROPIC_MODEL": "gpt-5.3-codex-xhigh",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.3-codex-xhigh",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.3-codex-high",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini-medium"
+    "ANTHROPIC_MODEL": "gpt-5.3-codex",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.3-codex",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.3-codex",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5-mini"
   }
 }

--- a/src/cliproxy/model-config.ts
+++ b/src/cliproxy/model-config.ts
@@ -21,13 +21,9 @@ function stripCodexEffortSuffix(model: string, provider: CLIProxyProvider): stri
   return model.replace(CODEX_EFFORT_SUFFIX_REGEX, '');
 }
 
-function normalizeCodexTierModel(
-  provider: CLIProxyProvider,
-  model: string,
-  fallbackEffort: 'medium' | 'high' | 'xhigh'
-): string {
+function normalizeCodexTierModel(provider: CLIProxyProvider, model: string): string {
   if (provider !== 'codex') return model;
-  return CODEX_EFFORT_SUFFIX_REGEX.test(model) ? model : `${model}-${fallbackEffort}`;
+  return stripCodexEffortSuffix(model, provider);
 }
 
 /**
@@ -160,13 +156,12 @@ export async function configureProviderModel(
 
   // Get base env vars for defaults
   const baseEnv = getClaudeEnvVars(provider);
-  const selectedDefaultModel = normalizeCodexTierModel(provider, selectedModel, 'xhigh');
-  const selectedOpusModel = normalizeCodexTierModel(provider, selectedModel, 'xhigh');
-  const selectedSonnetModel = normalizeCodexTierModel(provider, selectedModel, 'high');
+  const selectedDefaultModel = normalizeCodexTierModel(provider, selectedModel);
+  const selectedOpusModel = normalizeCodexTierModel(provider, selectedModel);
+  const selectedSonnetModel = normalizeCodexTierModel(provider, selectedModel);
   const selectedHaikuModel = normalizeCodexTierModel(
     provider,
-    baseEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL || selectedModel,
-    'medium'
+    baseEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL || selectedModel
   );
 
   // Read existing settings to preserve user customizations

--- a/tests/unit/cliproxy/variant-update-service.test.ts
+++ b/tests/unit/cliproxy/variant-update-service.test.ts
@@ -100,10 +100,10 @@ cliproxy:
     };
 
     expect(settings.env.ANTHROPIC_BASE_URL).toContain('/api/provider/codex');
-    expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.1-codex-mini-xhigh');
-    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.1-codex-mini-xhigh');
-    expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.1-codex-mini-high');
-    expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini-medium');
+    expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.1-codex-mini');
+    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.1-codex-mini');
+    expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.1-codex-mini');
+    expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini');
     expect(settings.env.CUSTOM_FLAG).toBe('keep-me');
     expect(settings.hooks.PreToolUse.length).toBe(1);
 
@@ -122,10 +122,10 @@ cliproxy:
     let settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as {
       env: Record<string, string>;
     };
-    expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex-xhigh');
-    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex-xhigh');
-    expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex-high');
-    expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini-medium');
+    expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex');
+    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex');
+    expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
+    expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini');
 
     const modelOnly = updateVariant('demo', { model: 'gpt-5.3-codex' });
     expect(modelOnly.success).toBe(true);
@@ -133,9 +133,9 @@ cliproxy:
     settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8')) as {
       env: Record<string, string>;
     };
-    expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex-xhigh');
-    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex-xhigh');
-    expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex-high');
-    expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini-medium');
+    expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex');
+    expect(settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex');
+    expect(settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
+    expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5-mini');
   });
 });


### PR DESCRIPTION
## Summary
- stop appending codex effort suffixes (`-xhigh/-high/-medium`) when generating or updating settings files
- keep canonical codex model IDs in settings (`ANTHROPIC_MODEL` and tier model env vars)
- normalize existing codex haiku model values by stripping persisted effort suffixes
- update codex base defaults and unit expectations for canonical settings values

## Verification
- `bun test tests/unit/cliproxy/variant-update-service.test.ts`
- `bun test tests/unit/cliproxy/env-builder-provider-url.test.ts`

Closes #602
