### PR TITLE
feat(memory): share project memory across account instances

### DIFF
--- a/src/auth/commands/create-command.ts
+++ b/src/auth/commands/create-command.ts
@@ -42,7 +42,7 @@ export async function handleCreate(ctx: CommandContext, args: string[]): Promise
   try {
     // Create instance directory
     console.log(info(`Creating profile: ${profileName}`));
-    const instancePath = ctx.instanceMgr.ensureInstance(profileName);
+    const instancePath = await ctx.instanceMgr.ensureInstance(profileName);
 
     // Create/update profile entry based on config mode
     if (isUnifiedMode()) {

--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -884,7 +884,7 @@ async function main(): Promise<void> {
       const instanceMgr = new InstanceManager();
 
       // Ensure instance exists (lazy init if needed)
-      const instancePath = instanceMgr.ensureInstance(profileInfo.name);
+      const instancePath = await instanceMgr.ensureInstance(profileInfo.name);
 
       // Update last_used timestamp (check unified config first, fallback to legacy)
       if (registry.hasAccountUnified(profileInfo.name)) {

--- a/src/management/instance-manager.ts
+++ b/src/management/instance-manager.ts
@@ -26,7 +26,7 @@ class InstanceManager {
   /**
    * Ensure instance exists for profile (lazy init only)
    */
-  ensureInstance(profileName: string): string {
+  async ensureInstance(profileName: string): Promise<string> {
     const instancePath = this.getInstancePath(profileName);
 
     // Lazy initialization
@@ -38,7 +38,7 @@ class InstanceManager {
     this.validateInstance(instancePath);
 
     // Keep project memory shared across instances.
-    this.sharedManager.syncProjectMemories(instancePath);
+    await this.sharedManager.syncProjectMemories(instancePath);
 
     return instancePath;
   }

--- a/tests/unit/shared-memory-sync.test.ts
+++ b/tests/unit/shared-memory-sync.test.ts
@@ -45,7 +45,7 @@ describe('SharedManager project memory sync', () => {
     }
   });
 
-  it('migrates existing project memory and replaces it with a shared symlink', () => {
+  it('migrates existing project memory and replaces it with a shared symlink', async () => {
     const ccsDir = getTestCcsDir();
     const instancePath = path.join(ccsDir, 'instances', 'work');
     const projectName = '-tmp-my-project';
@@ -54,7 +54,7 @@ describe('SharedManager project memory sync', () => {
     fs.writeFileSync(path.join(projectMemoryPath, 'MEMORY.md'), 'instance knowledge', 'utf8');
 
     const manager = new SharedManager();
-    manager.syncProjectMemories(instancePath);
+    await manager.syncProjectMemories(instancePath);
 
     const sharedMemoryFile = path.join(ccsDir, 'shared', 'memory', projectName, 'MEMORY.md');
     expect(fs.existsSync(sharedMemoryFile)).toBe(true);
@@ -67,7 +67,7 @@ describe('SharedManager project memory sync', () => {
     expect(resolvedTarget).toBe(path.join(ccsDir, 'shared', 'memory', projectName));
   });
 
-  it('preserves canonical memory and writes conflict copy when contents differ', () => {
+  it('preserves canonical memory and writes conflict copy when contents differ', async () => {
     const ccsDir = getTestCcsDir();
     const instancePath = path.join(ccsDir, 'instances', 'work');
     const projectName = '-tmp-shared-project';
@@ -80,7 +80,7 @@ describe('SharedManager project memory sync', () => {
     fs.writeFileSync(path.join(sharedProjectMemoryPath, 'MEMORY.md'), 'shared memory', 'utf8');
 
     const manager = new SharedManager();
-    manager.syncProjectMemories(instancePath);
+    await manager.syncProjectMemories(instancePath);
 
     const canonicalFile = path.join(sharedProjectMemoryPath, 'MEMORY.md');
     expect(fs.readFileSync(canonicalFile, 'utf8')).toBe('shared memory');
@@ -93,7 +93,7 @@ describe('SharedManager project memory sync', () => {
     expect(linkStats.isSymbolicLink()).toBe(true);
   });
 
-  it('creates shared memory link for projects that do not have memory directory yet', () => {
+  it('creates shared memory link for projects that do not have memory directory yet', async () => {
     const ccsDir = getTestCcsDir();
     const instancePath = path.join(ccsDir, 'instances', 'work');
     const projectName = '-tmp-new-project';
@@ -102,7 +102,7 @@ describe('SharedManager project memory sync', () => {
     fs.mkdirSync(projectPath, { recursive: true });
 
     const manager = new SharedManager();
-    manager.syncProjectMemories(instancePath);
+    await manager.syncProjectMemories(instancePath);
 
     const linkStats = fs.lstatSync(projectMemoryPath);
     expect(linkStats.isSymbolicLink()).toBe(true);


### PR DESCRIPTION
## Summary
- add automatic project-memory sharing for account instances via `~/.ccs/shared/memory/<project>/`
- migrate existing per-instance `projects/*/memory` directories into shared storage
- preserve conflicting files as `.migrated-from-<instance>` copies to avoid data loss
- run memory sync on every `ensureInstance()` so existing and newly discovered projects stay linked
- add unit tests for migration, conflict handling, and missing-memory linking

## Verification
- `bun test tests/unit/shared-memory-sync.test.ts tests/unit/shared-manager.test.ts`
- `bun run typecheck`

Closes #601
