### PR TITLE
feat(auth): add opt-in shared context groups for account profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,18 @@ ccs work "implement feature"    # Terminal 1
 ccs  "review code"              # Terminal 2 (personal account)
 ```
 
+Need continuity between two accounts for the same project? Opt in to shared context:
+
+```bash
+# Share context with default group
+ccs auth create backup --share-context
+
+# Or isolate by named group (only accounts in this group share context)
+ccs auth create backup2 --context-group sprint-a
+```
+
+Isolation remains the default. Shared context only links project workspace data; credentials stay per-account.
+
 <br>
 
 ## Maintenance

--- a/src/auth/account-context.ts
+++ b/src/auth/account-context.ts
@@ -1,0 +1,164 @@
+/**
+ * Account context policy helpers.
+ *
+ * Controls whether account instances keep project context isolated, or share
+ * project workspace context with other accounts in the same context group.
+ */
+
+export type AccountContextMode = 'isolated' | 'shared';
+
+export interface AccountContextMetadata {
+  context_mode?: AccountContextMode;
+  context_group?: string;
+}
+
+export interface AccountContextPolicy {
+  mode: AccountContextMode;
+  group?: string;
+}
+
+export interface CreateAccountContextInput {
+  shareContext: boolean;
+  contextGroup?: string;
+}
+
+export interface ResolvedCreateAccountContext {
+  policy: AccountContextPolicy;
+  error?: string;
+}
+
+export const DEFAULT_ACCOUNT_CONTEXT_MODE: AccountContextMode = 'isolated';
+export const DEFAULT_ACCOUNT_CONTEXT_GROUP = 'default';
+
+const CONTEXT_GROUP_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
+
+/**
+ * Normalize context group names so paths and config stay consistent.
+ */
+export function normalizeContextGroupName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Validate context group naming constraints.
+ */
+export function isValidContextGroupName(value: string): boolean {
+  return CONTEXT_GROUP_PATTERN.test(value);
+}
+
+/**
+ * Runtime type guard for account context metadata payloads.
+ */
+export function isAccountContextMetadata(value: unknown): value is AccountContextMetadata {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const mode = candidate['context_mode'];
+  const group = candidate['context_group'];
+
+  const modeValid = mode === undefined || mode === 'isolated' || mode === 'shared';
+  const groupValid = group === undefined || typeof group === 'string';
+
+  return modeValid && groupValid;
+}
+
+/**
+ * Resolve create-command flags into a valid context policy.
+ */
+export function resolveCreateAccountContext(
+  input: CreateAccountContextInput
+): ResolvedCreateAccountContext {
+  const hasGroupFlag = input.contextGroup !== undefined;
+
+  if (hasGroupFlag) {
+    if (!input.contextGroup || input.contextGroup.trim().length === 0) {
+      return {
+        policy: { mode: 'isolated' },
+        error: 'Context group name is required after --context-group',
+      };
+    }
+
+    const normalizedGroup = normalizeContextGroupName(input.contextGroup);
+    if (!isValidContextGroupName(normalizedGroup)) {
+      return {
+        policy: { mode: 'isolated' },
+        error:
+          'Invalid context group. Use letters/numbers/dash/underscore and start with a letter.',
+      };
+    }
+
+    return {
+      policy: {
+        mode: 'shared',
+        group: normalizedGroup,
+      },
+    };
+  }
+
+  if (input.shareContext) {
+    return {
+      policy: {
+        mode: 'shared',
+        group: DEFAULT_ACCOUNT_CONTEXT_GROUP,
+      },
+    };
+  }
+
+  return {
+    policy: { mode: DEFAULT_ACCOUNT_CONTEXT_MODE },
+  };
+}
+
+/**
+ * Resolve persisted metadata into runtime policy with safe defaults.
+ */
+export function resolveAccountContextPolicy(
+  metadata?: AccountContextMetadata | null
+): AccountContextPolicy {
+  const mode: AccountContextMode = metadata?.context_mode === 'shared' ? 'shared' : 'isolated';
+
+  if (mode === 'shared') {
+    const rawGroup = metadata?.context_group;
+    if (rawGroup && rawGroup.trim().length > 0) {
+      const normalized = normalizeContextGroupName(rawGroup);
+      if (isValidContextGroupName(normalized)) {
+        return { mode: 'shared', group: normalized };
+      }
+    }
+
+    return { mode: 'shared', group: DEFAULT_ACCOUNT_CONTEXT_GROUP };
+  }
+
+  return { mode: 'isolated' };
+}
+
+/**
+ * Convert runtime policy back to persisted metadata.
+ */
+export function policyToAccountContextMetadata(
+  policy: AccountContextPolicy
+): AccountContextMetadata {
+  if (policy.mode === 'shared') {
+    return {
+      context_mode: 'shared',
+      context_group: policy.group || DEFAULT_ACCOUNT_CONTEXT_GROUP,
+    };
+  }
+
+  return {
+    context_mode: 'isolated',
+  };
+}
+
+/**
+ * User-facing summary for display/help output.
+ */
+export function formatAccountContextPolicy(policy: AccountContextPolicy): string {
+  if (policy.mode === 'shared') {
+    return `shared (${policy.group || DEFAULT_ACCOUNT_CONTEXT_GROUP})`;
+  }
+
+  return 'isolated';
+}

--- a/src/auth/auth-commands.ts
+++ b/src/auth/auth-commands.ts
@@ -79,6 +79,12 @@ class AuthCommands {
     console.log(`  ${dim('# Create & login to work profile')}`);
     console.log(`  ${color('ccs auth create work', 'command')}`);
     console.log('');
+    console.log(`  ${dim('# Create account with shared project context (default group)')}`);
+    console.log(`  ${color('ccs auth create work2 --share-context', 'command')}`);
+    console.log('');
+    console.log(`  ${dim('# Share context only within a specific group')}`);
+    console.log(`  ${color('ccs auth create backup --context-group sprint-a', 'command')}`);
+    console.log('');
     console.log(`  ${dim('# Set work as default')}`);
     console.log(`  ${color('ccs auth default work', 'command')}`);
     console.log('');
@@ -96,6 +102,12 @@ class AuthCommands {
       `  ${color('--force', 'command')}                   Allow overwriting existing profile (create)`
     );
     console.log(
+      `  ${color('--share-context', 'command')}           Share project workspace context across accounts`
+    );
+    console.log(
+      `  ${color('--context-group <name>', 'command')}    Share context only within a named group`
+    );
+    console.log(
       `  ${color('--yes, -y', 'command')}                 Skip confirmation prompts (remove)`
     );
     console.log(
@@ -111,6 +123,9 @@ class AuthCommands {
     );
     console.log(
       `  Use ${color('ccs auth default <profile>', 'command')} to change the default profile.`
+    );
+    console.log(
+      `  Account profiles stay isolated unless you opt in with ${color('--share-context', 'command')}.`
     );
     console.log('');
   }

--- a/src/auth/commands/show-command.ts
+++ b/src/auth/commands/show-command.ts
@@ -7,6 +7,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { initUI, header, color, fail, table } from '../../utils/ui';
+import { resolveAccountContextPolicy, formatAccountContextPolicy } from '../account-context';
 import { exitWithError } from '../../errors';
 import { ExitCode } from '../../errors/exit-codes';
 import { CommandContext, ProfileOutput, parseArgs } from './types';
@@ -35,6 +36,7 @@ export async function handleShow(ctx: CommandContext, args: string[]): Promise<v
     const defaultProfile = ctx.registry.getDefaultResolved();
     const isDefault = profileName === defaultProfile;
     const instancePath = ctx.instanceMgr.getInstancePath(profileName);
+    const contextPolicy = resolveAccountContextPolicy(profile);
 
     // Count sessions
     let sessionCount = 0;
@@ -56,6 +58,8 @@ export async function handleShow(ctx: CommandContext, args: string[]): Promise<v
         is_default: isDefault,
         created: profile.created,
         last_used: profile.last_used || null,
+        context_mode: contextPolicy.mode,
+        context_group: contextPolicy.group || null,
         instance_path: instancePath,
         session_count: sessionCount,
       };
@@ -74,6 +78,7 @@ export async function handleShow(ctx: CommandContext, args: string[]): Promise<v
       ['Instance', instancePath],
       ['Created', new Date(profile.created).toLocaleString()],
       ['Last Used', profile.last_used ? new Date(profile.last_used).toLocaleString() : 'Never'],
+      ['Context', formatAccountContextPolicy(contextPolicy)],
       ['Sessions', `${sessionCount}`],
     ];
 

--- a/src/auth/profile-detector.ts
+++ b/src/auth/profile-detector.ts
@@ -200,6 +200,8 @@ class ProfileDetector {
           type: 'account',
           created: account.created,
           last_used: account.last_used,
+          context_mode: account.context_mode,
+          context_group: account.context_group,
         },
       };
     }

--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -589,6 +589,8 @@ async function main(): Promise<void> {
   const InstanceManager = InstanceManagerModule.default;
   const ProfileRegistryModule = await import('./auth/profile-registry');
   const ProfileRegistry = ProfileRegistryModule.default;
+  const AccountContextModule = await import('./auth/account-context');
+  const { resolveAccountContextPolicy, isAccountContextMetadata } = AccountContextModule;
 
   const detector = new ProfileDetector();
 
@@ -882,9 +884,13 @@ async function main(): Promise<void> {
       // All platforms: Use instance isolation with CLAUDE_CONFIG_DIR
       const registry = new ProfileRegistry();
       const instanceMgr = new InstanceManager();
+      const accountMetadata = isAccountContextMetadata(profileInfo.profile)
+        ? profileInfo.profile
+        : undefined;
+      const contextPolicy = resolveAccountContextPolicy(accountMetadata);
 
       // Ensure instance exists (lazy init if needed)
-      const instancePath = await instanceMgr.ensureInstance(profileInfo.name);
+      const instancePath = await instanceMgr.ensureInstance(profileInfo.name, contextPolicy);
 
       // Update last_used timestamp (check unified config first, fallback to legacy)
       if (registry.hasAccountUnified(profileInfo.name)) {

--- a/src/commands/help-command.ts
+++ b/src/commands/help-command.ts
@@ -150,7 +150,7 @@ Run ${color('ccs config', 'command')} for web dashboard`.trim();
     ['Run multiple Claude accounts concurrently'],
     [
       ['ccs auth --help', 'Show account management commands'],
-      ['ccs auth create <name>', 'Create new account profile'],
+      ['ccs auth create <name>', 'Create account profile (supports context sharing flags)'],
       ['ccs auth list', 'List all account profiles'],
       ['ccs auth default <name>', 'Set default profile'],
       ['ccs auth reset-default', 'Restore original CCS default'],

--- a/src/config/unified-config-types.ts
+++ b/src/config/unified-config-types.ts
@@ -40,6 +40,10 @@ export interface AccountConfig {
   created: string;
   /** ISO timestamp of last usage, null if never used */
   last_used: string | null;
+  /** Context mode for project workspace data */
+  context_mode?: 'isolated' | 'shared';
+  /** Context-sharing group when context_mode='shared' */
+  context_group?: string;
 }
 
 /**

--- a/src/management/instance-manager.ts
+++ b/src/management/instance-manager.ts
@@ -9,6 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import SharedManager from './shared-manager';
+import { AccountContextPolicy, DEFAULT_ACCOUNT_CONTEXT_MODE } from '../auth/account-context';
 import { getCcsDir } from '../utils/config-manager';
 
 /**
@@ -26,7 +27,10 @@ class InstanceManager {
   /**
    * Ensure instance exists for profile (lazy init only)
    */
-  async ensureInstance(profileName: string): Promise<string> {
+  async ensureInstance(
+    profileName: string,
+    contextPolicy: AccountContextPolicy = { mode: DEFAULT_ACCOUNT_CONTEXT_MODE }
+  ): Promise<string> {
     const instancePath = this.getInstancePath(profileName);
 
     // Lazy initialization
@@ -37,8 +41,8 @@ class InstanceManager {
     // Validate structure (auto-fix missing dirs)
     this.validateInstance(instancePath);
 
-    // Keep project memory shared across instances.
-    await this.sharedManager.syncProjectMemories(instancePath);
+    // Apply context policy (isolated by default, optional shared group).
+    await this.sharedManager.syncProjectContext(instancePath, contextPolicy);
 
     return instancePath;
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -87,6 +87,10 @@ export interface ProfileMetadata {
   type?: string; // Profile type (e.g., 'account')
   created: string; // Creation time
   last_used?: string | null; // Last usage time
+  /** Context mode for project workspace data */
+  context_mode?: 'isolated' | 'shared';
+  /** Context-sharing group when context_mode='shared' */
+  context_group?: string;
 }
 
 export interface ProfilesRegistry {

--- a/src/web-server/routes/account-routes.ts
+++ b/src/web-server/routes/account-routes.ts
@@ -53,6 +53,8 @@ router.get('/', (_req: Request, res: Response): void => {
         type: string;
         created: string;
         last_used: string | null;
+        context_mode?: 'isolated' | 'shared';
+        context_group?: string;
         provider?: string;
         displayName?: string;
       }
@@ -64,6 +66,8 @@ router.get('/', (_req: Request, res: Response): void => {
         type: meta.type || 'account',
         created: meta.created,
         last_used: meta.last_used || null,
+        context_mode: meta.context_mode,
+        context_group: meta.context_group,
       };
     }
 
@@ -73,6 +77,8 @@ router.get('/', (_req: Request, res: Response): void => {
         type: 'account',
         created: account.created,
         last_used: account.last_used,
+        context_mode: account.context_mode,
+        context_group: account.context_group,
       };
     }
 

--- a/tests/unit/auth-command-args.test.ts
+++ b/tests/unit/auth-command-args.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { parseArgs } from '../../src/auth/commands/types';
+
+describe('auth command args parsing', () => {
+  it('parses create with explicit shared context', () => {
+    const parsed = parseArgs(['work', '--share-context']);
+
+    expect(parsed.profileName).toBe('work');
+    expect(parsed.shareContext).toBe(true);
+    expect(parsed.contextGroup).toBeUndefined();
+  });
+
+  it('parses context group with separate value', () => {
+    const parsed = parseArgs(['work', '--context-group', 'sprint-a']);
+
+    expect(parsed.profileName).toBe('work');
+    expect(parsed.shareContext).toBe(false);
+    expect(parsed.contextGroup).toBe('sprint-a');
+  });
+
+  it('parses context group with equals form', () => {
+    const parsed = parseArgs(['--context-group=sprint-a', 'work']);
+
+    expect(parsed.profileName).toBe('work');
+    expect(parsed.contextGroup).toBe('sprint-a');
+  });
+
+  it('flags missing context group value as empty string', () => {
+    const parsed = parseArgs(['work', '--context-group']);
+
+    expect(parsed.profileName).toBe('work');
+    expect(parsed.contextGroup).toBe('');
+  });
+});

--- a/tests/unit/shared-context-policy.test.ts
+++ b/tests/unit/shared-context-policy.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import SharedManager from '../../src/management/shared-manager';
+import type { AccountContextPolicy } from '../../src/auth/account-context';
+
+function getTestCcsDir(): string {
+  if (!process.env.CCS_HOME) {
+    throw new Error('CCS_HOME must be set in tests');
+  }
+  return path.join(path.resolve(process.env.CCS_HOME), '.ccs');
+}
+
+describe('SharedManager context policy', () => {
+  let tempRoot = '';
+  let originalHome: string | undefined;
+  let originalCcsHome: string | undefined;
+  let originalCcsDir: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-context-policy-test-'));
+    originalHome = process.env.HOME;
+    originalCcsHome = process.env.CCS_HOME;
+    originalCcsDir = process.env.CCS_DIR;
+
+    const isolatedHome = path.join(tempRoot, 'home');
+    fs.mkdirSync(isolatedHome, { recursive: true });
+    process.env.HOME = isolatedHome;
+    process.env.CCS_HOME = tempRoot;
+    delete process.env.CCS_DIR;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) process.env.HOME = originalHome;
+    else delete process.env.HOME;
+
+    if (originalCcsHome !== undefined) process.env.CCS_HOME = originalCcsHome;
+    else delete process.env.CCS_HOME;
+
+    if (originalCcsDir !== undefined) process.env.CCS_DIR = originalCcsDir;
+    else delete process.env.CCS_DIR;
+
+    if (tempRoot && fs.existsSync(tempRoot)) {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  async function applyPolicy(policy: AccountContextPolicy): Promise<{ instancePath: string; ccsDir: string }> {
+    const ccsDir = getTestCcsDir();
+    const instancePath = path.join(ccsDir, 'instances', 'work');
+    fs.mkdirSync(instancePath, { recursive: true });
+
+    const manager = new SharedManager();
+    await manager.syncProjectContext(instancePath, policy);
+
+    return { instancePath, ccsDir };
+  }
+
+  it('keeps projects isolated by default', async () => {
+    const { instancePath } = await applyPolicy({ mode: 'isolated' });
+    const projectsPath = path.join(instancePath, 'projects');
+
+    expect(fs.existsSync(projectsPath)).toBe(true);
+    expect(fs.lstatSync(projectsPath).isDirectory()).toBe(true);
+  });
+
+  it('migrates local projects into shared context group', async () => {
+    const ccsDir = getTestCcsDir();
+    const instancePath = path.join(ccsDir, 'instances', 'work');
+    const localProjectsPath = path.join(instancePath, 'projects');
+    const localFile = path.join(localProjectsPath, '-tmp-project', 'notes.md');
+
+    fs.mkdirSync(path.dirname(localFile), { recursive: true });
+    fs.writeFileSync(localFile, 'local context', 'utf8');
+
+    const manager = new SharedManager();
+    await manager.syncProjectContext(instancePath, { mode: 'shared', group: 'sprint-a' });
+
+    const linkStats = fs.lstatSync(localProjectsPath);
+    expect(linkStats.isSymbolicLink()).toBe(true);
+
+    const sharedFile = path.join(
+      ccsDir,
+      'shared',
+      'context-groups',
+      'sprint-a',
+      'projects',
+      '-tmp-project',
+      'notes.md'
+    );
+    expect(fs.existsSync(sharedFile)).toBe(true);
+    expect(fs.readFileSync(sharedFile, 'utf8')).toBe('local context');
+  });
+
+  it('switches from shared mode back to isolated without data loss', async () => {
+    const { instancePath, ccsDir } = await applyPolicy({ mode: 'shared', group: 'sprint-a' });
+    const sharedFile = path.join(
+      ccsDir,
+      'shared',
+      'context-groups',
+      'sprint-a',
+      'projects',
+      '-tmp-project',
+      'history.md'
+    );
+
+    fs.mkdirSync(path.dirname(sharedFile), { recursive: true });
+    fs.writeFileSync(sharedFile, 'shared history', 'utf8');
+
+    const manager = new SharedManager();
+    await manager.syncProjectContext(instancePath, { mode: 'isolated' });
+
+    const projectsPath = path.join(instancePath, 'projects');
+    const projectFile = path.join(projectsPath, '-tmp-project', 'history.md');
+
+    expect(fs.lstatSync(projectsPath).isDirectory()).toBe(true);
+    expect(fs.existsSync(projectFile)).toBe(true);
+    expect(fs.readFileSync(projectFile, 'utf8')).toBe('shared history');
+  });
+});

--- a/ui/src/components/account/accounts-table.tsx
+++ b/ui/src/components/account/accounts-table.tsx
@@ -88,6 +88,24 @@ export function AccountsTable({ data, defaultAccount }: AccountsTableProps) {
       },
     },
     {
+      id: 'context',
+      header: 'Context',
+      size: 170,
+      cell: ({ row }) => {
+        if (row.original.type === 'cliproxy') {
+          return <span className="text-muted-foreground/50">-</span>;
+        }
+
+        const mode = row.original.context_mode || 'isolated';
+        if (mode === 'shared') {
+          const group = row.original.context_group || 'default';
+          return <span className="text-muted-foreground">shared ({group})</span>;
+        }
+
+        return <span className="text-muted-foreground">isolated</span>;
+      },
+    },
+    {
       id: 'actions',
       header: 'Actions',
       size: 180,
@@ -154,6 +172,7 @@ export function AccountsTable({ data, defaultAccount }: AccountsTableProps) {
                         type: 'w-[100px]',
                         created: 'w-[150px]',
                         last_used: 'w-[150px]',
+                        context: 'w-[170px]',
                         actions: 'w-[180px]',
                       }[header.id] || 'w-auto';
 

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -445,6 +445,8 @@ export interface Account {
   type?: string;
   created: string;
   last_used?: string | null;
+  context_mode?: 'isolated' | 'shared';
+  context_group?: string;
 }
 
 // Unified config types


### PR DESCRIPTION
## Summary
- add explicit account context policy with `isolated` (default) and `shared` modes
- keep `ccs auth` account isolation unchanged by default for clean work/personal separation
- add opt-in flags to `ccs auth create`: `--share-context` and `--context-group <name>`
- persist and apply policy in both legacy and unified config models (`context_mode`, `context_group`)
- route shared mode to group-scoped paths (`shared/context-groups/<group>/projects`) while credentials remain isolated per account instance
- expose context mode/group in API + dashboard create/list/show flows

## Why
Issue #624 asks for continuity when switching accounts. This keeps the original isolation intent intact and only shares project context when users explicitly opt in.

## Validation
- `bun run typecheck`
- `bun test tests/unit/auth-command-args.test.ts tests/unit/shared-context-policy.test.ts tests/unit/shared-memory-sync.test.ts`
- `cd ui && bun run validate`
- pre-push CI parity gate (`bun run validate:ci-parity`) passed, including full test suite (`2268 pass, 0 fail`)

## Notes
- README and CLI help were updated for the new auth-create flags.
- New tests: `tests/unit/auth-command-args.test.ts`, `tests/unit/shared-context-policy.test.ts`

Refs #624
