### PR TITLE
fix(ui): restore API profile dialog scrolling for Minimax setup

### DIFF
--- a/ui/src/components/profiles/profile-create-dialog.tsx
+++ b/ui/src/components/profiles/profile-create-dialog.tsx
@@ -11,7 +11,6 @@ import * as z from 'zod';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   Select,
   SelectContent,
@@ -271,7 +270,7 @@ export function ProfileCreateDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[700px] p-0 gap-0 overflow-hidden max-h-[90vh] flex flex-col">
+      <DialogContent className="sm:max-w-[700px] p-0 gap-0 overflow-hidden max-h-[90vh] !flex !flex-col">
         <DialogHeader className="p-6 pb-4 border-b">
           <DialogTitle className="flex items-center gap-2">
             <Plus className="w-5 h-5 text-primary" />
@@ -359,7 +358,7 @@ export function ProfileCreateDialog({
               </TabsList>
             </div>
 
-            <ScrollArea className="flex-1 min-h-0">
+            <div className="flex-1 min-h-0 overflow-y-auto">
               <TabsContent value="basic" className="p-6 space-y-4 mt-0">
                 {/* Profile Name */}
                 <div className="space-y-1.5">
@@ -603,7 +602,7 @@ export function ProfileCreateDialog({
                   </div>
                 </div>
               </TabsContent>
-            </ScrollArea>
+            </div>
 
             <DialogFooter className="p-6 pt-4 border-t bg-muted/10">
               <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>


### PR DESCRIPTION
## Summary
- force the API profile create dialog container to use flex layout (`!flex !flex-col`) so body sizing is stable
- replace Radix `ScrollArea` with native `overflow-y-auto` in the dialog body
- keep existing form structure unchanged; only scrolling behavior is adjusted

## Validation
- `cd ui && bun run format && bun run validate`
- pre-push CI parity gate (build + validate + tests) passed

Closes #648
