### PR TITLE
fix(cliproxy): restore AGY legacy model lookup compatibility

### DIFF
--- a/src/cliproxy/model-catalog.ts
+++ b/src/cliproxy/model-catalog.ts
@@ -6,7 +6,11 @@
  */
 
 import { CLIProxyProvider } from './types';
-import { normalizeModelIdForProvider } from './model-id-normalizer';
+import {
+  isAntigravityProvider,
+  migrateDeniedAntigravityModelAliases,
+  normalizeModelIdForProvider,
+} from './model-id-normalizer';
 
 /**
  * Thinking support configuration for a model.
@@ -309,6 +313,14 @@ export function findModel(provider: CLIProxyProvider, modelId: string): ModelEnt
     .trim()
     .toLowerCase();
   const lookupCandidates = new Set([normalizedId, providerNormalizedId]);
+  if (isAntigravityProvider(provider)) {
+    const migratedRaw = migrateDeniedAntigravityModelAliases(normalizedId).trim().toLowerCase();
+    const migratedProvider = migrateDeniedAntigravityModelAliases(providerNormalizedId)
+      .trim()
+      .toLowerCase();
+    lookupCandidates.add(migratedRaw);
+    lookupCandidates.add(migratedProvider);
+  }
 
   return catalog.models.find((m) => lookupCandidates.has(m.id.toLowerCase()));
 }


### PR DESCRIPTION
## Summary
- restore AGY model-catalog compatibility lookup for legacy `claude-*-4.5*` IDs by adding migrated lookup candidates (`4.5 -> 4.6`) in `findModel`
- keep denylist enforcement unchanged for write/update flows (settings/routes still reject deprecated AGY 4.5 models)
- fixes legacy profile behavior where compatibility lookup returned `undefined` for old AGY model IDs

## Validation
- `bun test tests/unit/cliproxy/model-catalog-compat.test.ts`
- `bun test tests/unit/cliproxy/model-id-normalizer.test.ts tests/unit/web-server/route-helpers-model-denylist.test.ts tests/unit/web-server/settings-routes-model-canonicalization.test.ts tests/unit/cliproxy/tool-sanitization-proxy-integration.test.ts`
- pre-commit checks (typecheck/lint/format) via hooks
- pre-push CI parity gate passed

Closes #664

Docs impact: none
Action: no update needed — internal compatibility lookup fix, no CLI/help/user workflow changes.
