### PR TITLE
fix(hooks): handle thinking blocks in image analyzer response parsing

### DIFF
--- a/lib/hooks/image-analyzer-transformer.cjs
+++ b/lib/hooks/image-analyzer-transformer.cjs
@@ -12,7 +12,7 @@
  *   CCS_CURRENT_PROVIDER                      - Current CLIProxy provider (e.g., agy, gemini, codex)
  *   CCS_IMAGE_ANALYSIS_TIMEOUT=60             - Timeout in seconds (default: 60)
  *   CCS_PROFILE_TYPE                          - Profile type (account/default skip)
- *   ANTHROPIC_MODEL                           - Fallback model if provider not in mapping
+ *   ANTHROPIC_MODEL                           - Chat model env (not used for image analysis fallback)
  *   CCS_DEBUG=1                               - Enable debug output
  *
  * Exit codes:
@@ -148,6 +148,46 @@ function parseProviderModels(envValue) {
 }
 
 /**
+ * Extract concatenated text content from CLIProxy response blocks.
+ * Skips thinking and other non-text blocks.
+ */
+function extractTextContent(response) {
+  if (!response || !Array.isArray(response.content)) {
+    return null;
+  }
+
+  const textBlocks = response.content
+    .filter((block) => block && block.type === 'text' && typeof block.text === 'string')
+    .map((block) => block.text)
+    .filter((text) => text.trim());
+
+  if (textBlocks.length === 0) {
+    return null;
+  }
+
+  return textBlocks.join('\n\n');
+}
+
+/**
+ * Parse raw CLIProxy response body and extract text content.
+ */
+function parseCliProxyResponse(data) {
+  let response;
+  try {
+    response = JSON.parse(data);
+  } catch (err) {
+    throw new Error(`Failed to parse response: ${err.message}`);
+  }
+
+  const text = extractTextContent(response);
+  if (!text) {
+    throw new Error('No text content in response');
+  }
+
+  return text;
+}
+
+/**
  * Get model for current provider from provider_models mapping
  * Returns primary model only (for display/logging)
  */
@@ -160,13 +200,14 @@ function getModelForProvider() {
 /**
  * Get list of models to try in order:
  * 1. provider_models[current_provider] (if exists)
- * 2. DEFAULT_MODEL
- * 3. ANTHROPIC_MODEL from profile (if different and exists)
+ * 2. DEFAULT_MODEL when no provider-specific vision model is configured
+ *
+ * ANTHROPIC_MODEL is intentionally ignored here because the chat model may
+ * not be vision-capable on the current provider route.
  */
 function getModelsToTry() {
   const currentProvider = process.env.CCS_CURRENT_PROVIDER || '';
   const providerModels = parseProviderModels(process.env.CCS_IMAGE_ANALYSIS_PROVIDER_MODELS);
-  const anthropicModel = process.env.ANTHROPIC_MODEL;
 
   const models = [];
   const seen = new Set();
@@ -184,9 +225,6 @@ function getModelsToTry() {
     models.push(DEFAULT_MODEL);
     seen.add(DEFAULT_MODEL);
   }
-
-  // 3. ANTHROPIC_MODEL fallback — skip, the main chat model is not
-  // necessarily vision-capable and adds unnecessary retry latency
 
   return models;
 }
@@ -381,20 +419,10 @@ function analyzeViaCliProxy(base64Data, mediaType, model, timeoutMs) {
           }
 
           try {
-            const response = JSON.parse(data);
-            // Find the first text block — skip thinking blocks which use
-            // .thinking instead of .text (e.g. codex models with thinking enabled)
-            const textBlock = response.content?.find(b => b.type === 'text' && b.text);
-            const text = textBlock?.text;
-
-            if (!text) {
-              reject(new Error('No text content in response'));
-              return;
-            }
-
+            const text = parseCliProxyResponse(data);
             resolve(text);
           } catch (err) {
-            reject(new Error(`Failed to parse response: ${err.message}`));
+            reject(err);
           }
         });
       }

--- a/tests/integration/image-analyzer-hook.test.ts
+++ b/tests/integration/image-analyzer-hook.test.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as http from 'http';
+import * as os from 'os';
+import * as path from 'path';
+
+const HOOK_PATH = path.join(__dirname, '../../lib/hooks/image-analyzer-transformer.cjs');
+const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-image-hook-it-'));
+const TEST_PNG_PATH = path.join(TEST_DIR, 'thinking-block-test.png');
+const CLIPROXY_API_KEY = 'test-api-key-12345';
+
+interface HookResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface MockRequest {
+  method: string;
+  path: string;
+  body: unknown;
+}
+
+interface MockResponse {
+  statusCode: number;
+  body: unknown;
+}
+
+let mockServer: http.Server | null = null;
+let mockPort = 0;
+let requests: MockRequest[] = [];
+let queuedResponses: MockResponse[] = [];
+
+function createTestPng(filepath: string): void {
+  const png = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+    0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00, 0x90,
+    0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8,
+    0xcf, 0xc0, 0x00, 0x00, 0x01, 0x01, 0x01, 0x00, 0x18, 0xdd, 0x8d, 0xb4, 0x00, 0x00, 0x00,
+    0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+  ]);
+  fs.writeFileSync(filepath, png);
+}
+
+function enqueueResponses(...responses: MockResponse[]): void {
+  queuedResponses = responses;
+}
+
+function invokeHook(env: Record<string, string> = {}): Promise<HookResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [HOOK_PATH], {
+      env: {
+        ...process.env,
+        CCS_CLIPROXY_API_KEY: CLIPROXY_API_KEY,
+        CCS_CLIPROXY_PORT: String(mockPort),
+        CCS_IMAGE_ANALYSIS_ENABLED: '1',
+        CCS_PROFILE_TYPE: 'cliproxy',
+        CCS_CURRENT_PROVIDER: 'codex',
+        CCS_IMAGE_ANALYSIS_PROVIDER_MODELS: 'codex:gpt-5.1-codex-mini,agy:gemini-2.5-flash',
+        ...env,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('Hook timed out'));
+    }, 10000);
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? -1, stdout, stderr });
+    });
+
+    child.stdin.end(
+      JSON.stringify({
+        tool_name: 'Read',
+        tool_input: { file_path: TEST_PNG_PATH },
+      })
+    );
+  });
+}
+
+beforeAll(async () => {
+  createTestPng(TEST_PNG_PATH);
+
+  mockServer = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk.toString();
+    });
+
+    req.on('end', () => {
+      requests.push({
+        method: req.method || 'GET',
+        path: req.url || '/',
+        body: body ? JSON.parse(body) : null,
+      });
+
+      const nextResponse = queuedResponses.shift() || {
+        statusCode: 200,
+        body: { content: [{ type: 'text', text: 'default description' }] },
+      };
+
+      res.writeHead(nextResponse.statusCode, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(nextResponse.body));
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    mockServer?.once('error', reject);
+    mockServer?.listen(0, '127.0.0.1', () => {
+      const address = mockServer?.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to resolve mock server port'));
+        return;
+      }
+      mockPort = address.port;
+      resolve();
+    });
+  });
+});
+
+beforeEach(() => {
+  requests = [];
+  enqueueResponses({
+    statusCode: 200,
+    body: { content: [{ type: 'text', text: 'default description' }] },
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => mockServer?.close(() => resolve()));
+  fs.rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('image analyzer hook regression coverage', () => {
+  it('uses the first text block after thinking blocks', async () => {
+    enqueueResponses({
+      statusCode: 200,
+      body: {
+        content: [
+          { type: 'thinking', thinking: 'internal reasoning' },
+          { type: 'text', text: 'blue square with white border' },
+        ],
+      },
+    });
+
+    const result = await invokeHook();
+
+    expect(result.code).toBe(2);
+    expect(requests).toHaveLength(1);
+    const output = JSON.parse(result.stdout);
+    expect(output.hookSpecificOutput.permissionDecisionReason).toContain(
+      'blue square with white border'
+    );
+  });
+
+  it('does not retry onto a cross-provider default model when a provider-specific model is set', async () => {
+    enqueueResponses({
+      statusCode: 500,
+      body: { error: { message: 'mock failure' } },
+    });
+
+    const result = await invokeHook();
+
+    expect(result.code).toBe(2);
+    expect(requests).toHaveLength(1);
+    expect((requests[0].body as { model: string }).model).toBe('gpt-5.1-codex-mini');
+  });
+
+  it('skips analysis before contacting CLIProxy when the current provider has no mapped vision model', async () => {
+    const result = await invokeHook({
+      CCS_CURRENT_PROVIDER: 'unknown-provider',
+      CCS_IMAGE_ANALYSIS_PROVIDER_MODELS: 'agy:gemini-2.5-flash',
+    });
+
+    expect(result.code).toBe(0);
+    expect(requests).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Problem

The image analyzer hook fails with "No text content in response" when the vision model returns thinking blocks (e.g. codex models with `thinking: auto`).

### Root cause 1: `content[0].text` assumes no thinking blocks

When thinking is enabled, the API response is:
```json
{
  "content": [
    { "type": "thinking", "thinking": "..." },
    { "type": "text", "text": "actual description" }
  ]
}
```

Line 385 reads `response.content?.[0]?.text` which is `undefined` for thinking blocks (they have `.thinking`, not `.text`). This triggers the "No text content in response" error, which exits with code 2 (blocking deny), preventing Claude from reading the image at all.

### Root cause 2: Cross-provider model fallback causes 502

`getModelsToTry()` unconditionally appends `DEFAULT_MODEL` (`gemini-2.5-flash`) as a retry model regardless of the current provider. On non-gemini provider routes (e.g. codex at `/api/provider/codex/`), this always 502s with `unknown provider for model gemini-2.5-flash`. This masks the original error and adds 30-60s of wasted retry latency before the hook ultimately fails.

## Reproduction

```bash
# Create test image (10x10 blue square)
python3 -c "
import struct, zlib
def png(w,h,r,g,b):
    def c(t,d): x=t+d; return struct.pack('>I',len(d))+x+struct.pack('>I',zlib.crc32(x)&0xffffffff)
    raw=b''.join(b'\x00'+bytes([r,g,b])*w for _ in range(h))
    return b'\x89PNG\r\n\x1a\n'+c(b'IHDR',struct.pack('>IIBBBBB',w,h,8,2,0,0,0))+c(b'IDAT',zlib.compress(raw))+c(b'IEND',b'')
open('/tmp/test.png','wb').write(png(10,10,0,100,255))
"

# Run hook with codex provider (thinking enabled)
echo '{"tool_name":"Read","tool_input":{"file_path":"/tmp/test.png"}}' | \
  CCS_IMAGE_ANALYSIS_ENABLED=1 CCS_IMAGE_ANALYSIS_SKIP=0 \
  CCS_IMAGE_ANALYSIS_PROVIDER_MODELS="codex:gpt-5.1-codex" \
  CCS_CURRENT_PROVIDER=codex CCS_IMAGE_ANALYSIS_TIMEOUT=30 CCS_DEBUG=1 \
  node ~/.ccs/hooks/image-analyzer-transformer.cjs
```

### Before fix (v7.51.0)

```
[CCS Hook] Starting image analysis
  model: gpt-5.1-codex
  modelsToTry: gpt-5.1-codex -> gemini-2.5-flash    <-- cross-provider fallback
[CCS Hook] Trying model 1/2
  model: gpt-5.1-codex
[CCS Hook] Model failed, trying next
  model: gpt-5.1-codex
  error: No text content in response                  <-- content[0] is thinking block
  nextModel: gemini-2.5-flash
[CCS Hook] Trying model 2/2
  model: gemini-2.5-flash
[CCS Hook] Analysis failed, no more retries
  error: API_ERROR:502:{"error":{"message":"unknown provider for model gemini-2.5-flash"}}
                                                       <-- gemini model on codex route
Exit code: 2 (deny - blocks Read tool entirely)
```

The API response proves the issue. `content[0]` is a thinking block with no `.text`:

```
API response:
  content[0]: type=thinking, .text=None       <-- what content[0].text reads
  content[1]: type=text, .text="Blue"         <-- actual description
```

### After fix

```
[CCS Hook] Starting image analysis
  model: gpt-5.1-codex
  modelsToTry: gpt-5.1-codex                          <-- no cross-provider fallback
[CCS Hook] Trying model 1/1
  model: gpt-5.1-codex
[CCS Hook] Analysis complete
  responseLength: 824 chars
  model: gpt-5.1-codex
Exit code: 0 (image analyzed successfully)
```

## Fix

1. Replace `response.content?.[0]?.text` with `response.content?.find(b => b.type === "text" && b.text)?.text` to skip thinking blocks
2. Only add `DEFAULT_MODEL` as fallback when no provider-specific model is configured (prevents cross-provider 502s)
3. Remove `ANTHROPIC_MODEL` fallback (chat model is not necessarily vision-capable)

Ref: #511
