### PR TITLE
fix: sync error code docs links

### DIFF
--- a/lib/error-codes.ps1
+++ b/lib/error-codes.ps1
@@ -1,12 +1,14 @@
 # CCS Error Codes
-# Documentation: ../docs/errors/README.md
+# Documentation: https://docs.ccs.kaitran.ca/reference/error-codes
+
+$script:ERROR_CODE_DOCS_BASE_URL = "https://docs.ccs.kaitran.ca/reference/error-codes"
 
 # Configuration Errors (E100-E199)
 $script:E_CONFIG_MISSING = "E101"
 $script:E_CONFIG_INVALID_JSON = "E102"
 $script:E_CONFIG_INVALID_PROFILE = "E103"
 
-# Profile Management Errors (E200-E299)
+# Profile Management Errors (E104-E107)
 $script:E_PROFILE_NOT_FOUND = "E104"
 $script:E_PROFILE_ALREADY_EXISTS = "E105"
 $script:E_PROFILE_CANNOT_DELETE_DEFAULT = "E106"
@@ -37,17 +39,25 @@ $script:E_INVALID_STATE = "E901"
 function Get-ErrorDocUrl {
     param([string]$ErrorCode)
     $LowerCode = $ErrorCode.ToLower()
-    return "https://github.com/kaitranntt/ccs/blob/main/docs/errors/README.md#$LowerCode"
+    return "$script:ERROR_CODE_DOCS_BASE_URL#$LowerCode"
 }
 
 # Get error category from code
 function Get-ErrorCategory {
     param([string]$ErrorCode)
 
+    if (
+        $ErrorCode -eq $script:E_PROFILE_NOT_FOUND -or
+        $ErrorCode -eq $script:E_PROFILE_ALREADY_EXISTS -or
+        $ErrorCode -eq $script:E_PROFILE_CANNOT_DELETE_DEFAULT -or
+        $ErrorCode -eq $script:E_PROFILE_INVALID_NAME
+    ) {
+        return "Profile Management"
+    }
+
     $code = [int]$ErrorCode.Substring(1)
 
     if ($code -ge 100 -and $code -lt 200) { return "Configuration" }
-    elseif ($code -ge 200 -and $code -lt 300) { return "Profile Management" }
     elseif ($code -ge 300 -and $code -lt 400) { return "Claude CLI Detection" }
     elseif ($code -ge 400 -and $code -lt 500) { return "Network/API" }
     elseif ($code -ge 500 -and $code -lt 600) { return "File System" }

--- a/lib/error-codes.sh
+++ b/lib/error-codes.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # CCS Error Codes
-# Documentation: ../docs/errors/README.md
+# Documentation: https://docs.ccs.kaitran.ca/reference/error-codes
+
+readonly ERROR_CODE_DOCS_BASE_URL="https://docs.ccs.kaitran.ca/reference/error-codes"
 
 # Configuration Errors (E100-E199)
 readonly E_CONFIG_MISSING="E101"
 readonly E_CONFIG_INVALID_JSON="E102"
 readonly E_CONFIG_INVALID_PROFILE="E103"
 
-# Profile Management Errors (E200-E299)
+# Profile Management Errors (E104-E107)
 readonly E_PROFILE_NOT_FOUND="E104"
 readonly E_PROFILE_ALREADY_EXISTS="E105"
 readonly E_PROFILE_CANNOT_DELETE_DEFAULT="E106"
@@ -37,7 +39,9 @@ readonly E_INVALID_STATE="E901"
 # Get error documentation URL
 get_error_doc_url() {
   local error_code="$1"
-  echo "https://github.com/kaitranntt/ccs/blob/main/docs/errors/README.md#${error_code,,}"
+  local lowercase_code
+  lowercase_code="$(printf '%s' "$error_code" | tr '[:upper:]' '[:lower:]')"
+  echo "${ERROR_CODE_DOCS_BASE_URL}#${lowercase_code}"
 }
 
 # Get error category from code
@@ -45,10 +49,10 @@ get_error_category() {
   local error_code="$1"
   local code="${error_code#E}"
 
-  if [[ $code -ge 100 && $code -lt 200 ]]; then
-    echo "Configuration"
-  elif [[ $code -ge 200 && $code -lt 300 ]]; then
+  if [[ "$error_code" == "$E_PROFILE_NOT_FOUND" || "$error_code" == "$E_PROFILE_ALREADY_EXISTS" || "$error_code" == "$E_PROFILE_CANNOT_DELETE_DEFAULT" || "$error_code" == "$E_PROFILE_INVALID_NAME" ]]; then
     echo "Profile Management"
+  elif [[ $code -ge 100 && $code -lt 200 ]]; then
+    echo "Configuration"
   elif [[ $code -ge 300 && $code -lt 400 ]]; then
     echo "Claude CLI Detection"
   elif [[ $code -ge 400 && $code -lt 500 ]]; then

--- a/src/utils/error-codes.ts
+++ b/src/utils/error-codes.ts
@@ -1,6 +1,6 @@
 /**
  * CCS Error Codes
- * Documentation: ../../docs/errors/README.md
+ * Documentation: https://docs.ccs.kaitran.ca/reference/error-codes
  */
 
 export const ERROR_CODES = {
@@ -9,7 +9,7 @@ export const ERROR_CODES = {
   CONFIG_INVALID_JSON: 'E102',
   CONFIG_INVALID_PROFILE: 'E103',
 
-  // Profile Management Errors (E200-E299)
+  // Profile Management Errors (E104-E107)
   PROFILE_NOT_FOUND: 'E104',
   PROFILE_ALREADY_EXISTS: 'E105',
   PROFILE_CANNOT_DELETE_DEFAULT: 'E106',
@@ -39,20 +39,30 @@ export const ERROR_CODES = {
 
 export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
 
+const ERROR_CODE_DOCS_BASE_URL = 'https://docs.ccs.kaitran.ca/reference/error-codes';
+
 /**
  * Error code documentation URL generator
  */
 export function getErrorDocUrl(errorCode: ErrorCode): string {
-  return `https://github.com/kaitranntt/ccs/blob/main/docs/errors/README.md#${errorCode.toLowerCase()}`;
+  return `${ERROR_CODE_DOCS_BASE_URL}#${errorCode.toLowerCase()}`;
 }
 
 /**
  * Get error category from code
  */
 export function getErrorCategory(errorCode: ErrorCode): string {
-  const code = parseInt(errorCode.substring(1));
+  if (
+    errorCode === ERROR_CODES.PROFILE_NOT_FOUND ||
+    errorCode === ERROR_CODES.PROFILE_ALREADY_EXISTS ||
+    errorCode === ERROR_CODES.PROFILE_CANNOT_DELETE_DEFAULT ||
+    errorCode === ERROR_CODES.PROFILE_INVALID_NAME
+  ) {
+    return 'Profile Management';
+  }
+
+  const code = parseInt(errorCode.substring(1), 10);
   if (code >= 100 && code < 200) return 'Configuration';
-  if (code >= 200 && code < 300) return 'Profile Management';
   if (code >= 300 && code < 400) return 'Claude CLI Detection';
   if (code >= 400 && code < 500) return 'Network/API';
   if (code >= 500 && code < 600) return 'File System';

--- a/tests/unit/utils/error-codes.test.ts
+++ b/tests/unit/utils/error-codes.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'bun:test';
+import { ERROR_CODES, getErrorCategory, getErrorDocUrl } from '../../../src/utils/error-codes';
+
+describe('error-codes', () => {
+  it('builds live docs URLs with lowercase anchors', () => {
+    expect(getErrorDocUrl(ERROR_CODES.PROFILE_NOT_FOUND)).toBe(
+      'https://docs.ccs.kaitran.ca/reference/error-codes#e104'
+    );
+    expect(getErrorDocUrl(ERROR_CODES.INTERNAL_ERROR)).toBe(
+      'https://docs.ccs.kaitran.ca/reference/error-codes#e900'
+    );
+  });
+
+  it('maps numeric ranges to human-readable categories', () => {
+    expect(getErrorCategory(ERROR_CODES.CONFIG_MISSING)).toBe('Configuration');
+    expect(getErrorCategory(ERROR_CODES.PROFILE_NOT_FOUND)).toBe('Profile Management');
+    expect(getErrorCategory(ERROR_CODES.CLAUDE_NOT_FOUND)).toBe('Claude CLI Detection');
+    expect(getErrorCategory(ERROR_CODES.API_AUTH_FAILED)).toBe('Network/API');
+    expect(getErrorCategory(ERROR_CODES.FS_CANNOT_READ_FILE)).toBe('File System');
+    expect(getErrorCategory(ERROR_CODES.INVALID_STATE)).toBe('Internal');
+  });
+});


### PR DESCRIPTION
## Summary
- point CLI error-code docs links at the live Mintlify reference instead of the removed GitHub markdown path
- align error-category helpers across TypeScript, Bash, and PowerShell so `E104-E107` classify as profile-management codes
- add regression coverage for error-doc URLs and category mapping

## Validation
- `bun test tests/unit/utils/error-codes.test.ts`
- `bun run typecheck`
- `bun run build`
- `node dist/ccs.js asdf` now emits `https://docs.ccs.kaitran.ca/reference/error-codes#e104`
- Bash helper smoke: `source lib/error-codes.sh; get_error_doc_url E104; get_error_category E104`

## Companion Docs
- https://github.com/kaitranntt/ccs-docs/pull/15

Closes #699
