### PR TITLE
docs(repo): add security reporting and issue routing

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -31,9 +31,9 @@ This applies to project spaces, including:
 
 Maintainers may edit or remove content, lock conversations, close threads, reject contributions, or block participants when needed to protect the project and contributors.
 
-For non-sensitive concerns, open a GitHub Discussion or issue.
+For non-sensitive concerns, use the public issue templates.
 
-For sensitive concerns, do not post details publicly. Ask a maintainer for a private reporting path first and keep the initial message minimal.
+For sensitive concerns, do not post details publicly. Use the private reporting path in `SECURITY.md`.
 
 ## Practical Rule
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -9,6 +9,8 @@ body:
       value: |
         Thanks for reporting this. Use as much of this template as you can.
         A partial but useful report is better than no report.
+
+        If this is a suspected security vulnerability, do not file it publicly. Use the private reporting path in `SECURITY.md`.
   - type: dropdown
     id: area
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Questions and discussion
-    url: https://github.com/kaitranntt/ccs/discussions
-    about: Use Discussions for open-ended questions, support requests, and idea shaping.
+  - name: Private security report
+    url: https://github.com/kaitranntt/ccs/security/advisories/new
+    about: Report suspected vulnerabilities privately. Do not open public issues for security reports.
+  - name: Documentation hub
+    url: https://docs.ccs.kaitran.ca
+    about: Installation, provider guides, CLI reference, and troubleshooting.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -60,5 +60,5 @@ body:
     attributes:
       label: Before submitting
       options:
-        - label: I searched existing issues and discussions first.
+        - label: I searched existing issues and docs first.
         - label: This request describes a concrete user problem, not just a broad idea dump.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,58 @@
+name: Question
+description: Ask for setup help, usage clarification, or behavior explanation when docs do not answer it.
+title: "question: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are welcome.
+
+        If this is a suspected security vulnerability, stop here and use the private reporting path in `SECURITY.md` instead of posting details publicly.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Topic
+      options:
+        - Installation or setup
+        - CLI usage
+        - Dashboard or config
+        - Provider or auth flow
+        - API profiles or proxy
+        - Contributor workflow
+        - Other
+  - type: textarea
+    id: question
+    attributes:
+      label: What do you need help with?
+      placeholder: I expected `ccs ...` to do ..., but I am not sure whether I configured it correctly.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Include what you tried, what docs you checked, and what blocked you.
+  - type: input
+    id: version
+    attributes:
+      label: CCS version
+      description: Output of `ccs --version`, if you have it
+      placeholder: 7.56.0
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked the docs and existing issues first.
+        - label: This is not a private security disclosure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ CCS is a Bun + TypeScript CLI with a React dashboard. This guide is the shortest
 - Open PRs against `dev`.
 - Use conventional commits.
 - If you change user-facing behavior, update the docs that describe it.
+- Suspected security vulnerabilities do not go through public issues. Use [SECURITY.md](./SECURITY.md).
 
 If you are new to the project, start with a docs fix, a focused bug fix, or an issue labeled `good first issue`.
 
@@ -191,10 +192,21 @@ Releases are automated with semantic-release.
 - Merges to `main` publish the `@latest` channel.
 - Do not manually bump versions, create tags, or run manual `npm publish`.
 
+## Security Reporting
+
+If you think you found a security vulnerability, do not open a public GitHub issue.
+
+Use the private reporting path in [SECURITY.md](./SECURITY.md):
+
+- https://github.com/kaitranntt/ccs/security/advisories/new
+
+Public issues are fine for normal bugs, regressions, docs problems, and feature requests. They are not fine for exploit details, leaked credentials, or anything that could put users at risk before a fix ships.
+
 ## Need Help?
 
 - Bugs and features: https://github.com/kaitranntt/ccs/issues
-- Questions and discussion: https://github.com/kaitranntt/ccs/discussions
+- Questions: https://github.com/kaitranntt/ccs/issues/new/choose
+- Security reports: https://github.com/kaitranntt/ccs/security/advisories/new
 - Hosted docs: https://docs.ccs.kaitran.ca
 - User-facing docs: [README.md](./README.md)
 - Internal architecture notes: [docs/](./docs)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ Run Claude, Gemini, GLM, and any Anthropic-compatible API - concurrently, withou
 Looking for the full setup guide, command reference, provider guides, or troubleshooting?
 Start at **https://docs.ccs.kaitran.ca**.
 
+## Contribute And Report Safely
+
+- Contributing guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
+- Starter work: [good first issue](https://github.com/kaitranntt/ccs/labels/good%20first%20issue), [help wanted](https://github.com/kaitranntt/ccs/labels/help%20wanted)
+- Questions: [open a question issue](https://github.com/kaitranntt/ccs/issues/new/choose)
+- Security reports: [SECURITY.md](./SECURITY.md) and the [private advisory form](https://github.com/kaitranntt/ccs/security/advisories/new)
+
 ### 1. Install
 
 ```bash
@@ -665,7 +672,7 @@ bun remove -g @kaitranntt/ccs
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md).
+See [CONTRIBUTING.md](./CONTRIBUTING.md). For suspected vulnerabilities, use [SECURITY.md](./SECURITY.md) instead of a public issue.
 
 <br>
 
@@ -683,6 +690,6 @@ MIT License - see [LICENSE](LICENSE).
 
 ---
 
-**[ccs.kaitran.ca](https://ccs.kaitran.ca)** | **[docs.ccs.kaitran.ca](https://docs.ccs.kaitran.ca)** | [Report Issues](https://github.com/kaitranntt/ccs/issues) | [Star on GitHub](https://github.com/kaitranntt/ccs)
+**[ccs.kaitran.ca](https://ccs.kaitran.ca)** | **[docs.ccs.kaitran.ca](https://docs.ccs.kaitran.ca)** | [Issue Templates](https://github.com/kaitranntt/ccs/issues/new/choose) | [Private Security Report](https://github.com/kaitranntt/ccs/security/advisories/new) | [Star on GitHub](https://github.com/kaitranntt/ccs)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest supported release line and the active development branch.
+
+| Branch / channel | Status |
+| --- | --- |
+| `main` / `@latest` | Supported |
+| `dev` / `@dev` | Supported |
+| Older releases | Best effort only |
+
+## Report A Vulnerability
+
+Do not open public GitHub issues for suspected security vulnerabilities.
+
+Use GitHub Private Vulnerability Reporting instead:
+
+- https://github.com/kaitranntt/ccs/security/advisories/new
+
+Include:
+
+- A short description of the issue
+- Affected version, branch, or install method
+- Reproduction steps or proof of concept
+- Impact assessment if you have one
+
+Please avoid posting tokens, cookies, private configs, or exploit details in public issues, discussions, or screenshots.
+
+## What To Expect
+
+- Initial acknowledgement target: within 3 business days
+- Triage and severity assessment after reproduction
+- A coordinated fix and release when the report is confirmed
+
+If you already opened a public issue by mistake, edit it down to a minimal note and ask for a private reporting path instead of posting more detail.


### PR DESCRIPTION
## Summary
- add a root `SECURITY.md` with private vulnerability reporting guidance
- disable blank issues and route reporters to the advisory form/docs instead of disabled Discussions
- add a public question issue form and surface contribution/security entry points earlier in the README and contributing guide
- align `.github` repo-surface wording with the new routing

## Why `main`
These files are consumed from the default branch by GitHub community surfaces. Targeting `dev` would delay the live fix for issue templates and `SECURITY.md`.

## Testing
- `git diff --check`
- parsed issue-template YAML locally
- `git push` pre-push gate passed (`validate:ci-parity`, build, tests)

Fixes #766
