### PR TITLE
fix(docker): add source label to link GHCR package to repository

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,8 @@ RUN test -d dist && test -d lib && echo "[OK] Build artifacts validated"
 # =============================================================================
 FROM node:20-bookworm-slim AS runtime
 
+LABEL org.opencontainers.image.source="https://github.com/kaitranntt/ccs"
+
 SHELL ["/bin/bash", "-lc"]
 
 # Pin bun version for reproducible builds


### PR DESCRIPTION
## Summary
- Adds `org.opencontainers.image.source` label directly in the Dockerfile so GHCR links the package to the repository
- Without this label baked into the image, the package only appears under the user's profile Packages tab instead of the repo's Packages tab
- The `labels` parameter in `docker/build-push-action` sets OCI manifest annotations but GHCR requires the label embedded in the image itself for repo linking

## Test plan
- [ ] Verify next stable release triggers `docker-release.yml` and the resulting image appears under the repo's Packages tab
- [ ] Confirm `docker inspect` on the published image shows the `org.opencontainers.image.source` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)