### PR TITLE
fix(docker): add index annotations to link GHCR package to repository

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -121,5 +121,8 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.revision=${{ steps.meta.outputs.revision }}
+          annotations: |
+            index:org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            index:org.opencontainers.image.description=CCS Dashboard container image
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Multi-platform builds create a manifest index pointing to per-platform images
- The existing `labels` parameter only sets labels on per-platform image configs, but GHCR reads annotations from the **manifest index** for repository auto-linking
- Adds `index:`-prefixed `annotations` so the package appears under the repo Packages tab instead of only the user profile

## Test plan
- [ ] Verify next stable release triggers `docker-release.yml` and the resulting package appears under the repo's Packages tab
- [ ] `docker buildx imagetools inspect ghcr.io/kaitranntt/ccs-dashboard:latest` should show `org.opencontainers.image.source` in the index annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)