### PR TITLE
hotfix(ci): fix AI review performance and reliability

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -127,7 +127,7 @@ jobs:
     name: Claude Code Review
     needs: prepare
     if: needs.prepare.result == 'success'
-    timeout-minutes: 20
+    timeout-minutes: 15
     runs-on: ${{ fromJSON(needs.prepare.outputs.runs_on) }}
     permissions:
       contents: read
@@ -147,7 +147,7 @@ jobs:
       DISABLE_ERROR_REPORTING: '1'
       DISABLE_TELEMETRY: '1'
       CLAUDE_CODE_MAX_OUTPUT_TOKENS: '64000'
-      MAX_THINKING_TOKENS: '32000'
+      MAX_THINKING_TOKENS: '16000'
       REVIEW_OUTPUT_FILE: pr_review.md
       REVIEW_COMMENT_FILE: .ccs-ai-review-comment.md
 
@@ -226,7 +226,7 @@ jobs:
           show_full_output: true # Visible logs for debugging slow/failing reviews
           track_progress: false # Disabled - no progress comments, just final review
           prompt: |
-            ultrathink
+            think
 
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.prepare.outputs.pr_number }}
@@ -257,7 +257,9 @@ jobs:
           claude_args: |
             --bare
             --model ${{ env.REVIEW_MODEL }}
-            --allowedTools "Edit,Glob,Grep,LS,Read,Write,Bash(gh pr diff *),Bash(gh pr view *),Bash(gh issue view *),Bash(git diff *),Bash(git log *),Bash(git status *),Bash(cat *),Bash(ls *)"
+            --permission-mode bypassPermissions
+            --max-turns 20
+            --allowedTools "Glob,Grep,Read,Write,Bash(gh pr diff *),Bash(gh pr view *),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(cat *),Bash(ls *),Bash(wc *),Bash(head *),Bash(tail *),Bash(find *)"
 
       # Fallback: if Claude didn't write the review file, extract from execution output
       - name: Extract review from execution output (fallback)


### PR DESCRIPTION
## Summary

- Add `--permission-mode bypassPermissions` — eliminates permission denial loop in CI (16 denials/41 turns observed)
- Add `--max-turns 20` — prevents runaway sessions (previously uncapped, hit 41 turns)
- Replace `ultrathink` with `think` and reduce thinking tokens 32K→16K — sufficient for read-only review
- Expand `--allowedTools` with commonly-tried bash tools (`wc`, `head`, `tail`, `find`, `git show`)
- Remove unused tools (`Edit`, `LS`) — reviews shouldn't edit files
- Reduce timeout 20→15 min for faster failure detection

**Evidence:** Run [#23659037151](https://github.com/kaitranntt/ccs/actions/runs/23659037151) — 11.6 min, 41 turns, 16 permission denials, $1.95, failed to write review.

**`--bare` note:** Kept intentionally. Prevents loading the 16KB dev CLAUDE.md which was misleading Claude into trying quality gates and workflows irrelevant to reviews. All review context comes via prompt + `.github/review-prompt.md`.

Closes #818

## Test plan

- [ ] Merge to main, trigger AI review on an open PR via `/review` comment
- [ ] Verify review completes in <8 min with 0 permission denials
- [ ] Verify review comment is posted successfully
- [ ] Cherry-pick to dev after merge