### PR TITLE
hotfix(ci): fix AI review max-turns and Write tool enforcement

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -242,14 +242,16 @@ jobs:
             ${{ steps.review-prompt.outputs.content }}
 
             ## IMPORTANT: Writing the Review
-            After completing your analysis, write the final review markdown to `${{ env.REVIEW_OUTPUT_FILE }}`.
+            After completing your analysis, use the `Write` tool to write the final review markdown to `${{ env.REVIEW_OUTPUT_FILE }}`.
+            Do NOT use `Edit` tool — use `Write` tool directly to create the file in one shot.
             Do NOT post any GitHub comments yourself. The workflow will publish the saved file.
+            Do NOT modify any source code files — this is a READ-ONLY review.
 
             End your review with:
             > 🤖 Reviewed by `${{ env.REVIEW_MODEL }}`
 
             IMPORTANT RULES:
-            - Overwrite `${{ env.REVIEW_OUTPUT_FILE }}`
+            - Use `Write` tool to overwrite `${{ env.REVIEW_OUTPUT_FILE }}` with the complete review
             - Do NOT use shell operators like || or && in bash commands
             - Do NOT use heredoc (<<) syntax in bash commands
             - Use simple, single-purpose bash commands only
@@ -258,7 +260,7 @@ jobs:
             --bare
             --model ${{ env.REVIEW_MODEL }}
             --permission-mode bypassPermissions
-            --max-turns 20
+            --max-turns 30
             --allowedTools "Glob,Grep,Read,Write,Bash(gh pr diff *),Bash(gh pr view *),Bash(git diff *),Bash(git log *),Bash(git show *),Bash(cat *),Bash(ls *),Bash(wc *),Bash(head *),Bash(tail *),Bash(find *)"
 
       # Fallback: if Claude didn't write the review file, extract from execution output


### PR DESCRIPTION
## Summary

Follow-up to #819. Run #23661898954 hit `error_max_turns` at turn 21 despite successfully writing the review. Two fixes:

- **`--max-turns 20` → `30`**: Large PRs (31 files, ~1900 diff lines) need ~25 turns for thorough analysis + writing. The 20-turn cap was too tight.
- **Explicit `Write` tool instruction**: Claude used `Edit` tool (failed on empty file) → `python3 -c` fallback → wasted 3 turns on file writing. Now prompt explicitly says use `Write` tool in one shot.
- **READ-ONLY constraint**: Added "Do NOT modify any source code files" to prevent accidental edits during review.

**Evidence:** [Run #23661898954](https://github.com/kaitranntt/ccs/actions/runs/23661898954) — 8.4 min, 21 turns, 0 permission denials, $1.14, review posted but action reported failure due to max-turns exit.

Part of #818

## Test plan

- [ ] Merge to main, trigger review on a large PR (20+ files)
- [ ] Verify action exits with success (not error_max_turns)
- [ ] Verify review uses `Write` tool (check execution log artifact)
- [ ] Cherry-pick to dev