### PR TITLE
hotfix: add hotfix commit type to semantic-release config

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -20,6 +20,7 @@ const commitAnalyzer = [
   {
     preset: 'conventionalcommits',
     releaseRules: [
+      { type: 'hotfix', release: 'patch' },
       { type: 'docs', scope: 'README', release: 'patch' },
       { type: 'refactor', release: 'patch' },
       { type: 'style', release: 'patch' },
@@ -35,6 +36,7 @@ const releaseNotesGenerator = [
       types: [
         { type: 'feat', section: 'Features' },
         { type: 'fix', section: 'Bug Fixes' },
+        { type: 'hotfix', section: 'Hotfixes' },
         { type: 'docs', section: 'Documentation' },
         { type: 'style', section: 'Styles' },
         { type: 'refactor', section: 'Code Refactoring' },


### PR DESCRIPTION
## Summary

- Add `hotfix` type to `releaseRules` → triggers `patch` release
- Add `Hotfixes` section to release notes generator → shows as distinct section in CHANGELOG and GitHub releases

Without this, `hotfix:` commits are silently ignored by `@semantic-release/commit-analyzer` — no version bump, no npm publish, no GitHub release.

## Test plan

- [ ] Merge this PR (uses `hotfix:` commit type itself — self-testing)
- [ ] Verify semantic-release creates a patch release (e.g., 7.60.1)
- [ ] Verify CHANGELOG shows "Hotfixes" section
- [ ] Cherry-pick to dev