### PR TITLE
hotfix: restore prepack packaging contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "ui:build": "cd ui && bun run build",
     "ui:preview": "cd ui && bun run preview",
     "ui:validate": "cd ui && bun run validate",
+    "prepack": "bun run build:all",
     "prepare": "husky",
     "postinstall": "node scripts/postinstall.js"
   },


### PR DESCRIPTION
## Summary
- restore `package.json` `prepack` to `bun run build:all`
- repair the packaging contract expected by npm packaging tests and release automation
- keep the deleted `sync-version.js` flow removed; only restore the rebuild hook

## Root Cause
`prepack` was removed in commit `18729c99` while deleting `sync-version.js`. The `main` release workflow then failed at `Validate (typecheck + lint + format + tests)` because `tests/npm/cross-platform.test.js` asserts that packaged assets are rebuilt before npm pack/publish.

Failing run: https://github.com/kaitranntt/ccs/actions/runs/23863516174/job/69576242995

## Verification
- `bun run build:all && bun run validate`
- `bun run validate:ci-parity`
