### PR TITLE
fix(ci): restore cursor image analyzer hook import

### DIFF
--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -41,6 +41,7 @@ import { ensureProfileHooks as ensureImageAnalyzerHooks } from './utils/hooks/im
 import {
   applyImageAnalysisRuntimeOverrides,
   getImageAnalysisHookEnv,
+  installImageAnalyzerHook,
   prepareImageAnalysisFallbackHook,
   resolveImageAnalysisRuntimeConnection,
   resolveImageAnalysisRuntimeStatus,


### PR DESCRIPTION
## Summary
- fix the `Dev Release` build failure introduced after merging #891 into `dev`
- restore the missing `installImageAnalyzerHook` import in `src/ccs.ts` so the new Cursor runtime path compiles on `dev`

## Root cause
The merged `dev` commit `6e2dba8bfcc2f74b2dfbf9d726d689e179d0e174` calls `installImageAnalyzerHook()` in the new Cursor runtime branch, but `src/ccs.ts` did not import that symbol from `./utils/hooks`.

This caused the release workflow to fail during the build step with:
- `src/ccs.ts(914,7): error TS2304: Cannot find name 'installImageAnalyzerHook'.`

Failed run:
- https://github.com/kaitranntt/ccs/actions/runs/23933232190/job/69804343013

## Testing
- `bun run build:all`
- `bun run validate:ci-parity`
