### PR TITLE
docs: Added OpenCode plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,19 @@ Defaults:
 
 Detailed guide: [`docs/cursor-integration.md`](./docs/cursor-integration.md)
 
+### OpenCode Plugin Setup:
+
+Use the [`opencode-ccs-sync`](https://github.com/JasonLandbridge/opencode-ccs-sync) plugin to keep OpenCode aligned with your live CCS setup automatically. After you add the plugin and restart OpenCode, it performs an initial sync on startup and automatically re-syncs whenever `~/.ccs/config.yaml` or the live `~/.ccs/*.settings.json` provider files change. The plugin reads the active CCS provider settings, exposes only the providers and models actually selected in those settings files, and writes managed `ccs-*` entries into your OpenCode config.
+
+Example OpenCode config:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-ccs-sync"],
+}
+```
+
 ### Claude IDE Extension Setup
 
 CCS now has a native setup flow for the Anthropic Claude extension in VS Code and compatible hosts.


### PR DESCRIPTION
## Summary

Created [opencode-ccs-sync OpenCode plugin](https://github.com/JasonLandbridge/opencode-ccs-sync) for automatic synchronization between Claude Code Switch (CCS) and OpenCode configuration. I added a short setup section to the readme, please change or update location if it fits better somewhere else. 

Thank you for this awesome application!

## Testing

Use what applies. If you skipped something, add a short note instead of forcing it.

- [x] `bun run validate`
- [x] `bun run validate:ci-parity`
- [x] `cd ui && bun run validate` if UI changed
- [ ] Not run

## Checklist

Check what applies. Not every item is relevant for every PR.

- [x] Base branch is `dev` unless this is an approved hotfix
- [ ] Branch name follows `feat/*`, `fix/*`, `docs/*`, or approved hotfix naming
- [ ] Relevant `--help` output updated if CLI behavior changed
- [ ] Tests added or updated if behavior changed
- [x] README or local docs updated if user-facing behavior changed
- [ ] No secrets, tokens, or private config data are included

## Docs Impact

Docs impact: `none | minor | major`

Action: `no update needed` or describe what doc was updated
