### PR TITLE
hotfix: update ai-review workflow model budget

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -118,7 +118,7 @@ jobs:
     name: Claude Code Review
     needs: prepare
     if: needs.prepare.result == 'success'
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ${{ fromJSON(needs.prepare.outputs.runs_on) }}
     permissions:
       contents: read
@@ -127,12 +127,12 @@ jobs:
 
     env:
       ANTHROPIC_BASE_URL: https://api.z.ai/api/anthropic
-      REVIEW_MODEL: glm-5-turbo
+      REVIEW_MODEL: glm-5.1
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.GLM_API_KEY }}
-      ANTHROPIC_MODEL: glm-5-turbo
-      ANTHROPIC_DEFAULT_OPUS_MODEL: glm-5-turbo
-      ANTHROPIC_DEFAULT_SONNET_MODEL: glm-5-turbo
-      ANTHROPIC_DEFAULT_HAIKU_MODEL: glm-5-turbo
+      ANTHROPIC_MODEL: glm-5.1
+      ANTHROPIC_DEFAULT_OPUS_MODEL: glm-5.1
+      ANTHROPIC_DEFAULT_SONNET_MODEL: glm-5.1
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: glm-5.1
       DISABLE_BUG_COMMAND: '1'
       DISABLE_ERROR_REPORTING: '1'
       DISABLE_TELEMETRY: '1'
@@ -277,7 +277,7 @@ jobs:
             --bare
             --model ${{ env.REVIEW_MODEL }}
             --permission-mode bypassPermissions
-            --max-turns 40
+            --max-turns 45
             --allowedTools "Read,Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(cat:*),Bash(ls:*),Bash(wc:*),Bash(head:*),Bash(tail:*),Bash(find:*),Bash(grep:*)"
             --json-schema '${{ env.REVIEW_OUTPUT_SCHEMA }}'
 

--- a/tests/unit/scripts/github/ai-review-workflow.test.ts
+++ b/tests/unit/scripts/github/ai-review-workflow.test.ts
@@ -8,14 +8,18 @@ function loadWorkflow() {
 }
 
 describe('ai-review workflow', () => {
-  test('uses the claude-code-action reviewer path with glm-5-turbo and PR-sha comment markers', () => {
+  test('uses the claude-code-action reviewer path with glm-5.1 and PR-sha comment markers', () => {
     const workflow = loadWorkflow();
 
-    expect(workflow).toContain('REVIEW_MODEL: glm-5-turbo');
-    expect(workflow).toContain('ANTHROPIC_MODEL: glm-5-turbo');
+    expect(workflow).toContain('timeout-minutes: 20');
+    expect(workflow).toContain('REVIEW_MODEL: glm-5.1');
+    expect(workflow).toContain('ANTHROPIC_MODEL: glm-5.1');
+    expect(workflow).toContain('ANTHROPIC_DEFAULT_OPUS_MODEL: glm-5.1');
+    expect(workflow).toContain('ANTHROPIC_DEFAULT_SONNET_MODEL: glm-5.1');
+    expect(workflow).toContain('ANTHROPIC_DEFAULT_HAIKU_MODEL: glm-5.1');
     expect(workflow).toContain('uses: anthropics/claude-code-action@v1');
     expect(workflow).toContain('--model ${{ env.REVIEW_MODEL }}');
-    expect(workflow).toContain('--max-turns 40');
+    expect(workflow).toContain('--max-turns 45');
     expect(workflow).toContain('--json-schema');
     expect(workflow).toContain('normalize-ai-review-output.mjs');
     expect(workflow).not.toContain('build-ai-review-packet.mjs');


### PR DESCRIPTION
## Problem
The AI reviewer workflow was still pinned to `glm-5-turbo`.

## What changed
- switched the workflow reviewer model envs to `glm-5.1`
- increased the workflow timeout from `15` to `20` minutes
- increased the reviewer turn budget from `40` to `45`
- expanded the workflow regression test to assert the full reviewer model config

## Validation
- `bun test tests/unit/scripts/github`
- `bun run validate`
- `CCS_PR_BASE=main bun run validate:ci-parity`

Closes #922
