### PR TITLE
test(ci): isolate CCS-managed env vars from host session

### DIFF
--- a/tests/unit/commands/persist-command-handler.test.ts
+++ b/tests/unit/commands/persist-command-handler.test.ts
@@ -73,6 +73,7 @@ function stubProcessExit(): void {
 beforeEach(async () => {
   tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ccs-persist-handler-test-'));
   originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
   originalProcessExit = process.exit;
   originalFsOpen = fs.promises.open;
   originalFsRename = fs.promises.rename;

--- a/tests/unit/commands/persist-command-handler.test.ts
+++ b/tests/unit/commands/persist-command-handler.test.ts
@@ -73,6 +73,7 @@ function stubProcessExit(): void {
 beforeEach(async () => {
   tempRoot = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'ccs-persist-handler-test-'));
   originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  // Clear CLAUDE_CONFIG_DIR so scoped CCS_HOME takes effect (leaks from host CCS session)
   delete process.env.CLAUDE_CONFIG_DIR;
   originalProcessExit = process.exit;
   originalFsOpen = fs.promises.open;

--- a/tests/unit/hooks/websearch-transformer.test.ts
+++ b/tests/unit/hooks/websearch-transformer.test.ts
@@ -101,6 +101,7 @@ function runHookWithMockedFetch(mode: 'success' | 'empty' | 'non-result' | 'fail
       }),
       env: {
         ...process.env,
+        CCS_PROFILE_TYPE: '',
         CCS_WEBSEARCH_ENABLED: '1',
         CCS_WEBSEARCH_SKIP: '0',
         CCS_WEBSEARCH_BRAVE: '0',
@@ -352,6 +353,7 @@ describe('websearch-transformer hook helpers', () => {
         }),
         env: {
           ...process.env,
+          CCS_PROFILE_TYPE: '',
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'hook-trace-test',
@@ -428,6 +430,7 @@ describe('websearch-transformer hook helpers', () => {
         }),
         env: {
           ...process.env,
+          CCS_PROFILE_TYPE: '',
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_FILE: disallowedTracePath,
@@ -509,6 +512,7 @@ global.fetch = async (url) => {
         }),
         env: {
           ...process.env,
+          CCS_PROFILE_TYPE: '',
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'quota-fallback-test',
@@ -623,6 +627,7 @@ global.fetch = async (url) => {
         }),
         env: {
           ...process.env,
+          CCS_PROFILE_TYPE: '',
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'cooldown-skip-test',
@@ -723,6 +728,7 @@ global.fetch = async (url) => {
         }),
         env: {
           ...process.env,
+          CCS_PROFILE_TYPE: '',
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'transient-retry-test',

--- a/tests/unit/hooks/websearch-transformer.test.ts
+++ b/tests/unit/hooks/websearch-transformer.test.ts
@@ -12,6 +12,12 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 
 const hookPath = join(process.cwd(), 'lib', 'hooks', 'websearch-transformer.cjs');
+
+/**
+ * Neutralise CCS_PROFILE_TYPE so shouldSkipHook() does not short-circuit
+ * when tests run inside a CCS-managed Claude session (where it is 'account').
+ */
+const NEUTRAL_PROFILE_TYPE = '';
 type HookOutput = {
   hookSpecificOutput: {
     additionalContext: string;
@@ -101,7 +107,7 @@ function runHookWithMockedFetch(mode: 'success' | 'empty' | 'non-result' | 'fail
       }),
       env: {
         ...process.env,
-        CCS_PROFILE_TYPE: '',
+        CCS_PROFILE_TYPE: NEUTRAL_PROFILE_TYPE,
         CCS_WEBSEARCH_ENABLED: '1',
         CCS_WEBSEARCH_SKIP: '0',
         CCS_WEBSEARCH_BRAVE: '0',
@@ -353,7 +359,7 @@ describe('websearch-transformer hook helpers', () => {
         }),
         env: {
           ...process.env,
-          CCS_PROFILE_TYPE: '',
+          CCS_PROFILE_TYPE: NEUTRAL_PROFILE_TYPE,
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'hook-trace-test',
@@ -430,7 +436,7 @@ describe('websearch-transformer hook helpers', () => {
         }),
         env: {
           ...process.env,
-          CCS_PROFILE_TYPE: '',
+          CCS_PROFILE_TYPE: NEUTRAL_PROFILE_TYPE,
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_FILE: disallowedTracePath,
@@ -512,7 +518,7 @@ global.fetch = async (url) => {
         }),
         env: {
           ...process.env,
-          CCS_PROFILE_TYPE: '',
+          CCS_PROFILE_TYPE: NEUTRAL_PROFILE_TYPE,
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'quota-fallback-test',
@@ -627,7 +633,7 @@ global.fetch = async (url) => {
         }),
         env: {
           ...process.env,
-          CCS_PROFILE_TYPE: '',
+          CCS_PROFILE_TYPE: NEUTRAL_PROFILE_TYPE,
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'cooldown-skip-test',
@@ -728,7 +734,7 @@ global.fetch = async (url) => {
         }),
         env: {
           ...process.env,
-          CCS_PROFILE_TYPE: '',
+          CCS_PROFILE_TYPE: NEUTRAL_PROFILE_TYPE,
           CCS_HOME: ccsHome,
           CCS_WEBSEARCH_TRACE: '1',
           CCS_WEBSEARCH_TRACE_LAUNCH_ID: 'transient-retry-test',

--- a/tests/unit/utils/claudecode-env-stripping.test.ts
+++ b/tests/unit/utils/claudecode-env-stripping.test.ts
@@ -30,6 +30,7 @@ let baselineSighupListeners: Array<(...args: unknown[]) => void> = [];
 let originalCcsHome: string | undefined;
 let originalCcsClaudePath: string | undefined;
 let originalDisableAutoUpdater: string | undefined;
+let originalClaudeConfigDir: string | undefined;
 const realSpawn = childProcess.spawn.bind(childProcess);
 const realSpawnSync = childProcess.spawnSync.bind(childProcess);
 const realExecSync = childProcess.execSync.bind(childProcess);
@@ -154,7 +155,9 @@ describe('CLAUDECODE environment stripping', () => {
     originalCcsHome = process.env.CCS_HOME;
     originalCcsClaudePath = process.env.CCS_CLAUDE_PATH;
     originalDisableAutoUpdater = process.env.DISABLE_AUTOUPDATER;
+    originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
     delete process.env.DISABLE_AUTOUPDATER;
+    delete process.env.CLAUDE_CONFIG_DIR;
     baselineSigintListeners = process.listeners('SIGINT');
     baselineSigtermListeners = process.listeners('SIGTERM');
     baselineSighupListeners = process.listeners('SIGHUP');
@@ -175,6 +178,8 @@ describe('CLAUDECODE environment stripping', () => {
     } else {
       delete process.env.DISABLE_AUTOUPDATER;
     }
+    if (originalClaudeConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    else delete process.env.CLAUDE_CONFIG_DIR;
 
     for (const listener of process.listeners('SIGINT')) {
       if (!baselineSigintListeners.includes(listener)) {

--- a/tests/unit/utils/claudecode-env-stripping.test.ts
+++ b/tests/unit/utils/claudecode-env-stripping.test.ts
@@ -152,12 +152,17 @@ describe('CLAUDECODE environment stripping', () => {
   beforeEach(() => {
     spawnCalls.length = 0;
     process.env.CCS_QUIET = '1';
+
+    // Save original env values for restoration in afterEach
     originalCcsHome = process.env.CCS_HOME;
     originalCcsClaudePath = process.env.CCS_CLAUDE_PATH;
     originalDisableAutoUpdater = process.env.DISABLE_AUTOUPDATER;
     originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    // Clear CCS-managed env vars that leak from host sessions
     delete process.env.DISABLE_AUTOUPDATER;
     delete process.env.CLAUDE_CONFIG_DIR;
+
     baselineSigintListeners = process.listeners('SIGINT');
     baselineSigtermListeners = process.listeners('SIGTERM');
     baselineSighupListeners = process.listeners('SIGHUP');


### PR DESCRIPTION
## Summary

- Fix 9 test failures when running `bun run test:all` inside a CCS-managed Claude session
- Tests leak host env vars (`CLAUDE_CONFIG_DIR`, `CCS_PROFILE_TYPE`) into subprocess spawns and fixture setup
- `persist-command-handler`: clear `CLAUDE_CONFIG_DIR` in `beforeEach` so scoped `CCS_HOME` takes effect
- `claudecode-env-stripping`: save/restore `CLAUDE_CONFIG_DIR` across test lifecycle
- `websearch-transformer`: neutralize `CCS_PROFILE_TYPE` in all subprocess env blocks to prevent `shouldSkipHook()` from silently exiting

## Test plan

- [x] `bun run test:all` passes with `CLAUDE_CONFIG_DIR` and `CCS_PROFILE_TYPE=account` set in host env (was 9 failures, now 0)
- [x] `bun run test:all` passes with clean env (no regressions)
- [x] `bun run validate` passes
- [x] `bun run validate:ci-parity` passes

Built [OnSteroids](https://onsteroids.ai)