### PR TITLE
feat(cliproxy): add --json flag to catalog command

### DIFF
--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -5,6 +5,7 @@ import {
   SYNCABLE_PROVIDERS,
   getResolvedCatalog,
   refreshCatalogFromProxy,
+  getAllResolvedCatalogs,
 } from '../../cliproxy/catalog-cache';
 import { getCatalogRoutingSnapshot } from '../../cliproxy/catalog-routing';
 import { ensureManagedModelPrefixes } from '../../cliproxy/managed-model-prefixes';
@@ -171,6 +172,20 @@ export async function handleCatalogRefresh(verbose: boolean): Promise<void> {
   console.log('');
   console.log(`  ${color('[OK]', 'success')} Catalog synced (${totalModels} total models)`);
   console.log('');
+}
+
+/**
+ * Output catalog as JSON for programmatic consumption.
+ * Used by OnSteroids and other tools to get available models per provider.
+ * Format: { provider: [{ id, name }], ... }
+ */
+export function handleCatalogJson(): void {
+  const catalogs = getAllResolvedCatalogs();
+  const result: Record<string, Array<{ id: string; name: string }>> = {};
+  for (const [provider, catalog] of Object.entries(catalogs)) {
+    result[provider] = catalog.models.map((m) => ({ id: m.id, name: m.name }));
+  }
+  console.log(JSON.stringify(result));
 }
 
 /** Reset catalog cache */

--- a/src/commands/cliproxy/index.ts
+++ b/src/commands/cliproxy/index.ts
@@ -40,6 +40,7 @@ import {
   handleCatalogStatus,
   handleCatalogRefresh,
   handleCatalogReset,
+  handleCatalogJson,
 } from './catalog-subcommand';
 
 /**
@@ -146,6 +147,10 @@ export async function handleCliproxyCommand(args: string[]): Promise<void> {
 
   // Catalog commands
   if (command === 'catalog') {
+    if (hasAnyFlag(remainingArgs, ['--json'])) {
+      handleCatalogJson();
+      return;
+    }
     const subcommand = remainingArgs[1];
     if (subcommand === 'refresh') {
       await handleCatalogRefresh(verbose);


### PR DESCRIPTION
## Summary

- Add `--json` flag to `ccs cliproxy catalog` for machine-readable model catalog output
- Outputs `{ "provider": [{ "id": "...", "name": "..." }, ...] }` format
- Enables programmatic integration with external tools (e.g., OnSteroids unified model selector)

## Changes

- `src/commands/cliproxy/catalog-subcommand.ts` — new `handleCatalogJson()` using existing `getAllResolvedCatalogs()`
- `src/commands/cliproxy/index.ts` — route `--json` flag before subcommand dispatch

## Test plan

- [x] `ccs cliproxy catalog --json` outputs valid JSON with provider→models mapping
- [x] `ccs cliproxy catalog` (without flag) behaves unchanged
- [x] `bun run format && bun run lint:fix` pass
- [x] Typecheck passes

Closes CCS-1

Built [OnSteroids](https://onsteroids.ai)