### PR TITLE
feat(cliproxy): add --json flag to catalog command

### DIFF
--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -177,7 +177,7 @@ export async function handleCatalogRefresh(verbose: boolean): Promise<void> {
 /**
  * Output catalog as JSON for programmatic consumption.
  * Used by OnSteroids and other tools to get available models per provider.
- * Format: { provider: [{ id, name }], ... }
+ * Format: { [providerName: string]: Array<{ id: string, name: string }> }
  */
 export function handleCatalogJson(): void {
   const catalogs = getAllResolvedCatalogs();

--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -184,6 +184,7 @@ interface CatalogJsonModel {
   deprecated?: boolean;
   deprecationReason?: string;
   broken?: boolean;
+  issueUrl?: string;
   thinking?: ThinkingSupport;
   extendedContext?: boolean;
   nativeImageInput?: boolean;
@@ -198,6 +199,9 @@ export function handleCatalogJson(): void {
   const catalogs = getAllResolvedCatalogs();
   const result: Record<string, CatalogJsonModel[]> = {};
   for (const [provider, catalog] of Object.entries(catalogs)) {
+    if (!catalog) {
+      continue;
+    }
     result[provider] = catalog.models.map((m) => {
       const entry: CatalogJsonModel = { id: m.id, name: m.name };
       if (m.tier !== undefined) entry.tier = m.tier;
@@ -205,6 +209,7 @@ export function handleCatalogJson(): void {
       if (m.deprecated !== undefined) entry.deprecated = m.deprecated;
       if (m.deprecationReason !== undefined) entry.deprecationReason = m.deprecationReason;
       if (m.broken !== undefined) entry.broken = m.broken;
+      if (m.issueUrl !== undefined) entry.issueUrl = m.issueUrl;
       if (m.thinking !== undefined) entry.thinking = m.thinking;
       if (m.extendedContext !== undefined) entry.extendedContext = m.extendedContext;
       if (m.nativeImageInput !== undefined) entry.nativeImageInput = m.nativeImageInput;

--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -174,16 +174,39 @@ export async function handleCatalogRefresh(verbose: boolean): Promise<void> {
   console.log('');
 }
 
+/** JSON-serialisable model entry emitted by `catalog --json`. */
+interface CatalogJsonModel {
+  id: string;
+  name: string;
+  tier?: 'free' | 'pro' | 'ultra';
+  description?: string;
+  deprecated?: boolean;
+  deprecationReason?: string;
+  broken?: boolean;
+  extendedContext?: boolean;
+  nativeImageInput?: boolean;
+}
+
 /**
  * Output catalog as JSON for programmatic consumption.
  * Used by OnSteroids and other tools to get available models per provider.
- * Format: { [providerName: string]: Array<{ id: string, name: string }> }
+ * Format: { [providerName: string]: CatalogJsonModel[] }
  */
 export function handleCatalogJson(): void {
   const catalogs = getAllResolvedCatalogs();
-  const result: Record<string, Array<{ id: string; name: string }>> = {};
+  const result: Record<string, CatalogJsonModel[]> = {};
   for (const [provider, catalog] of Object.entries(catalogs)) {
-    result[provider] = catalog.models.map((m) => ({ id: m.id, name: m.name }));
+    result[provider] = catalog.models.map((m) => {
+      const entry: CatalogJsonModel = { id: m.id, name: m.name };
+      if (m.tier) entry.tier = m.tier;
+      if (m.description) entry.description = m.description;
+      if (m.deprecated) entry.deprecated = m.deprecated;
+      if (m.deprecationReason) entry.deprecationReason = m.deprecationReason;
+      if (m.broken) entry.broken = m.broken;
+      if (m.extendedContext) entry.extendedContext = m.extendedContext;
+      if (m.nativeImageInput) entry.nativeImageInput = m.nativeImageInput;
+      return entry;
+    });
   }
   console.log(JSON.stringify(result));
 }

--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -10,6 +10,7 @@ import {
 import { getCatalogRoutingSnapshot } from '../../cliproxy/catalog-routing';
 import { ensureManagedModelPrefixes } from '../../cliproxy/managed-model-prefixes';
 import { getProxyTarget } from '../../cliproxy/proxy-target-resolver';
+import type { ThinkingSupport } from '../../cliproxy/model-catalog';
 import type { CLIProxyProvider } from '../../cliproxy/types';
 import type { RemoteModelInfo } from '../../cliproxy/management-api-types';
 import type { CliproxyProviderRoutingHints } from '../../shared/cliproxy-model-routing';
@@ -183,6 +184,7 @@ interface CatalogJsonModel {
   deprecated?: boolean;
   deprecationReason?: string;
   broken?: boolean;
+  thinking?: ThinkingSupport;
   extendedContext?: boolean;
   nativeImageInput?: boolean;
 }
@@ -203,6 +205,7 @@ export function handleCatalogJson(): void {
       if (m.deprecated !== undefined) entry.deprecated = m.deprecated;
       if (m.deprecationReason !== undefined) entry.deprecationReason = m.deprecationReason;
       if (m.broken !== undefined) entry.broken = m.broken;
+      if (m.thinking !== undefined) entry.thinking = m.thinking;
       if (m.extendedContext !== undefined) entry.extendedContext = m.extendedContext;
       if (m.nativeImageInput !== undefined) entry.nativeImageInput = m.nativeImageInput;
       return entry;

--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -5,6 +5,7 @@ import {
   SYNCABLE_PROVIDERS,
   getResolvedCatalog,
   refreshCatalogFromProxy,
+  getAllResolvedCatalogs,
 } from '../../cliproxy/catalog-cache';
 import { getCatalogRoutingSnapshot } from '../../cliproxy/catalog-routing';
 import { ensureManagedModelPrefixes } from '../../cliproxy/managed-model-prefixes';
@@ -171,6 +172,20 @@ export async function handleCatalogRefresh(verbose: boolean): Promise<void> {
   console.log('');
   console.log(`  ${color('[OK]', 'success')} Catalog synced (${totalModels} total models)`);
   console.log('');
+}
+
+/**
+ * Output catalog as JSON for programmatic consumption.
+ * Used by OnSteroids and other tools to get available models per provider.
+ * Format: { provider: [{ id, name }], ... }
+ */
+export function handleCatalogJson(): void {
+  const catalogs = getAllResolvedCatalogs();
+  const result: Record<string, Array<{ id: string; name: string }>> = {};
+  for (const [provider, catalog] of Object.entries(catalogs)) {
+    result[provider] = catalog.models.map((m) => ({ id: m.id, name: m.name }));
+  }
+  console.log(JSON.stringify(result));
 }
 
 /** Reset catalog cache */

--- a/src/commands/cliproxy/catalog-subcommand.ts
+++ b/src/commands/cliproxy/catalog-subcommand.ts
@@ -198,13 +198,13 @@ export function handleCatalogJson(): void {
   for (const [provider, catalog] of Object.entries(catalogs)) {
     result[provider] = catalog.models.map((m) => {
       const entry: CatalogJsonModel = { id: m.id, name: m.name };
-      if (m.tier) entry.tier = m.tier;
-      if (m.description) entry.description = m.description;
-      if (m.deprecated) entry.deprecated = m.deprecated;
-      if (m.deprecationReason) entry.deprecationReason = m.deprecationReason;
-      if (m.broken) entry.broken = m.broken;
-      if (m.extendedContext) entry.extendedContext = m.extendedContext;
-      if (m.nativeImageInput) entry.nativeImageInput = m.nativeImageInput;
+      if (m.tier !== undefined) entry.tier = m.tier;
+      if (m.description !== undefined) entry.description = m.description;
+      if (m.deprecated !== undefined) entry.deprecated = m.deprecated;
+      if (m.deprecationReason !== undefined) entry.deprecationReason = m.deprecationReason;
+      if (m.broken !== undefined) entry.broken = m.broken;
+      if (m.extendedContext !== undefined) entry.extendedContext = m.extendedContext;
+      if (m.nativeImageInput !== undefined) entry.nativeImageInput = m.nativeImageInput;
       return entry;
     });
   }

--- a/src/commands/cliproxy/help-subcommand.ts
+++ b/src/commands/cliproxy/help-subcommand.ts
@@ -39,6 +39,7 @@ export async function showHelp(): Promise<void> {
         ['catalog', 'Show catalog status, routing hints, and pinned short prefixes'],
         ['catalog refresh', 'Sync models from remote CLIProxy'],
         ['catalog reset', 'Clear cache, revert to static catalog'],
+        ['catalog --json', 'Output full model catalog as minified JSON'],
       ],
     ],
     [

--- a/src/commands/cliproxy/index.ts
+++ b/src/commands/cliproxy/index.ts
@@ -40,6 +40,7 @@ import {
   handleCatalogStatus,
   handleCatalogRefresh,
   handleCatalogReset,
+  handleCatalogJson,
 } from './catalog-subcommand';
 
 /**
@@ -146,6 +147,10 @@ export async function handleCliproxyCommand(args: string[]): Promise<void> {
 
   // Catalog commands
   if (command === 'catalog') {
+    if (hasAnyFlag(remainingArgs, ['--json'])) {
+      handleCatalogJson();
+      return;
+    }
     const subcommand = remainingArgs[1];
     if (subcommand === 'refresh') {
       await handleCatalogRefresh(verbose);

--- a/src/commands/cliproxy/index.ts
+++ b/src/commands/cliproxy/index.ts
@@ -147,6 +147,8 @@ export async function handleCliproxyCommand(args: string[]): Promise<void> {
 
   // Catalog commands
   if (command === 'catalog') {
+    // --json takes priority over subcommands (refresh/reset) — it always
+    // outputs the current resolved catalog regardless of other arguments.
     if (hasAnyFlag(remainingArgs, ['--json'])) {
       handleCatalogJson();
       return;

--- a/tests/unit/commands/cliproxy-catalog-json.test.ts
+++ b/tests/unit/commands/cliproxy-catalog-json.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { handleCatalogJson } from '../../../src/commands/cliproxy/catalog-subcommand';
+import { handleCliproxyCommand } from '../../../src/commands/cliproxy/index';
 
 let originalConsoleLog: typeof console.log;
 let capturedOutput: string[];
@@ -16,49 +18,96 @@ afterEach(() => {
 });
 
 describe('cliproxy catalog --json output', () => {
-  it('outputs valid JSON mapping provider names to model arrays', async () => {
-    const { handleCatalogJson } = await import(
-      `../../../src/commands/cliproxy/catalog-subcommand?catalog-json-format=${Date.now()}`
-    );
-
+  it('outputs valid JSON mapping provider names to model arrays', () => {
     handleCatalogJson();
 
     expect(capturedOutput).toHaveLength(1);
-    const parsed = JSON.parse(capturedOutput[0]) as Record<
-      string,
-      Array<{ id: string; name: string }>
-    >;
+    const parsed = JSON.parse(capturedOutput[0]) as Record<string, unknown[]>;
 
     // Must be a non-empty object (static catalog always has providers)
     expect(typeof parsed).toBe('object');
     expect(Object.keys(parsed).length).toBeGreaterThan(0);
 
-    // Every provider entry must be an array of { id, name } objects
-    for (const [provider, models] of Object.entries(parsed)) {
+    // Every provider entry must be an array of objects with at least id and name
+    for (const models of Object.values(parsed)) {
       expect(Array.isArray(models)).toBe(true);
       expect(models.length).toBeGreaterThan(0);
-      for (const model of models) {
+      for (const model of models as Array<Record<string, unknown>>) {
         expect(typeof model.id).toBe('string');
         expect(typeof model.name).toBe('string');
-        // Only id and name — no extra metadata leaks
-        expect(Object.keys(model).sort()).toEqual(['id', 'name']);
       }
-      // Provider key should be a non-empty string
-      expect(provider.length).toBeGreaterThan(0);
     }
   });
 
-  it('outputs minified JSON (single line, no whitespace formatting)', async () => {
-    const { handleCatalogJson } = await import(
-      `../../../src/commands/cliproxy/catalog-subcommand?catalog-json-minified=${Date.now()}`
-    );
+  it('includes metadata fields when present on model entries', () => {
+    handleCatalogJson();
 
+    const parsed = JSON.parse(capturedOutput[0]) as Record<
+      string,
+      Array<Record<string, unknown>>
+    >;
+    const allModels = Object.values(parsed).flat();
+
+    // At least some models in the static catalog have tier set
+    const withTier = allModels.filter((m) => m.tier !== undefined);
+    expect(withTier.length).toBeGreaterThan(0);
+
+    // Tier values must be one of the allowed strings
+    for (const model of withTier) {
+      expect(['free', 'pro', 'ultra']).toContain(model.tier);
+    }
+  });
+
+  it('omits undefined optional fields instead of including nulls', () => {
+    handleCatalogJson();
+
+    const parsed = JSON.parse(capturedOutput[0]) as Record<
+      string,
+      Array<Record<string, unknown>>
+    >;
+    const allModels = Object.values(parsed).flat();
+
+    for (const model of allModels) {
+      for (const value of Object.values(model)) {
+        expect(value).not.toBeNull();
+        expect(value).not.toBeUndefined();
+      }
+    }
+  });
+
+  it('outputs minified JSON (single line, no whitespace formatting)', () => {
     handleCatalogJson();
 
     const output = capturedOutput[0];
-    // Minified JSON has no newlines
     expect(output.includes('\n')).toBe(false);
-    // Valid JSON roundtrip
     expect(JSON.stringify(JSON.parse(output))).toBe(output);
+  });
+});
+
+describe('cliproxy catalog --json routing', () => {
+  it('routes catalog --json through handleCliproxyCommand', async () => {
+    await handleCliproxyCommand(['catalog', '--json']);
+
+    expect(capturedOutput).toHaveLength(1);
+    const parsed = JSON.parse(capturedOutput[0]);
+    expect(typeof parsed).toBe('object');
+    expect(Object.keys(parsed).length).toBeGreaterThan(0);
+  });
+
+  it('--json takes priority over refresh subcommand', async () => {
+    await handleCliproxyCommand(['catalog', 'refresh', '--json']);
+
+    expect(capturedOutput).toHaveLength(1);
+    // Should output JSON, not refresh output
+    const parsed = JSON.parse(capturedOutput[0]);
+    expect(typeof parsed).toBe('object');
+  });
+
+  it('--json takes priority when placed before subcommand', async () => {
+    await handleCliproxyCommand(['catalog', '--json', 'reset']);
+
+    expect(capturedOutput).toHaveLength(1);
+    const parsed = JSON.parse(capturedOutput[0]);
+    expect(typeof parsed).toBe('object');
   });
 });

--- a/tests/unit/commands/cliproxy-catalog-json.test.ts
+++ b/tests/unit/commands/cliproxy-catalog-json.test.ts
@@ -75,6 +75,39 @@ describe('cliproxy catalog --json output', () => {
     }
   });
 
+  it('includes explicit false boolean values in output', () => {
+    handleCatalogJson();
+
+    const parsed = JSON.parse(capturedOutput[0]) as Record<
+      string,
+      Array<Record<string, unknown>>
+    >;
+    const allModels = Object.values(parsed).flat();
+
+    // Static catalog has models with extendedContext: false
+    const withExplicitFalse = allModels.filter((m) => m.extendedContext === false);
+    expect(withExplicitFalse.length).toBeGreaterThan(0);
+  });
+
+  it('includes thinking configuration when present on models', () => {
+    handleCatalogJson();
+
+    const parsed = JSON.parse(capturedOutput[0]) as Record<
+      string,
+      Array<Record<string, unknown>>
+    >;
+    const allModels = Object.values(parsed).flat();
+
+    // Static catalog has thinking models (e.g. Claude Opus 4.6 Thinking)
+    const withThinking = allModels.filter((m) => m.thinking !== undefined);
+    expect(withThinking.length).toBeGreaterThan(0);
+
+    for (const model of withThinking) {
+      const thinking = model.thinking as Record<string, unknown>;
+      expect(['budget', 'levels', 'none']).toContain(thinking.type);
+    }
+  });
+
   it('outputs minified JSON (single line, no whitespace formatting)', () => {
     handleCatalogJson();
 

--- a/tests/unit/commands/cliproxy-catalog-json.test.ts
+++ b/tests/unit/commands/cliproxy-catalog-json.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+let originalConsoleLog: typeof console.log;
+let capturedOutput: string[];
+
+beforeEach(() => {
+  originalConsoleLog = console.log;
+  capturedOutput = [];
+  console.log = (...args: unknown[]) => {
+    capturedOutput.push(args.map(String).join(' '));
+  };
+});
+
+afterEach(() => {
+  console.log = originalConsoleLog;
+});
+
+describe('cliproxy catalog --json output', () => {
+  it('outputs valid JSON mapping provider names to model arrays', async () => {
+    const { handleCatalogJson } = await import(
+      `../../../src/commands/cliproxy/catalog-subcommand?catalog-json-format=${Date.now()}`
+    );
+
+    handleCatalogJson();
+
+    expect(capturedOutput).toHaveLength(1);
+    const parsed = JSON.parse(capturedOutput[0]) as Record<
+      string,
+      Array<{ id: string; name: string }>
+    >;
+
+    // Must be a non-empty object (static catalog always has providers)
+    expect(typeof parsed).toBe('object');
+    expect(Object.keys(parsed).length).toBeGreaterThan(0);
+
+    // Every provider entry must be an array of { id, name } objects
+    for (const [provider, models] of Object.entries(parsed)) {
+      expect(Array.isArray(models)).toBe(true);
+      expect(models.length).toBeGreaterThan(0);
+      for (const model of models) {
+        expect(typeof model.id).toBe('string');
+        expect(typeof model.name).toBe('string');
+        // Only id and name — no extra metadata leaks
+        expect(Object.keys(model).sort()).toEqual(['id', 'name']);
+      }
+      // Provider key should be a non-empty string
+      expect(provider.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('outputs minified JSON (single line, no whitespace formatting)', async () => {
+    const { handleCatalogJson } = await import(
+      `../../../src/commands/cliproxy/catalog-subcommand?catalog-json-minified=${Date.now()}`
+    );
+
+    handleCatalogJson();
+
+    const output = capturedOutput[0];
+    // Minified JSON has no newlines
+    expect(output.includes('\n')).toBe(false);
+    // Valid JSON roundtrip
+    expect(JSON.stringify(JSON.parse(output))).toBe(output);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `ccs cliproxy catalog --json` for machine-readable model catalog output
- Format: `{ [providerName]: ModelEntry[] }` — minified JSON to stdout
- Each model entry includes full metadata: `id`, `name`, `tier`, `description`, `deprecated`, `deprecationReason`, `broken`, `issueUrl`, `thinking`, `extendedContext`, `nativeImageInput`
- Undefined optional fields are omitted (no nulls); explicit `false` values are preserved
- `--help` updated with new flag entry

## Changes

- `src/commands/cliproxy/catalog-subcommand.ts` — new `handleCatalogJson()` with `!== undefined` guards for all optional fields
- `src/commands/cliproxy/index.ts` — route `--json` flag before subcommand dispatch (`--json` takes priority over `refresh`/`reset`)
- `src/commands/cliproxy/help-subcommand.ts` — add `catalog --json` to help output
- `tests/unit/commands/cliproxy-catalog-json.test.ts` — 9 unit tests covering JSON structure, metadata, routing integration

## Test plan

- [x] `bun run validate` passes
- [x] `bun run validate:ci-parity` passes
- [x] Unit tests verify: valid JSON structure per provider, metadata presence (tier, thinking), no null/undefined values in output, explicit `false` booleans preserved, minified single-line format
- [x] Routing tests verify: `catalog --json` dispatched via `handleCliproxyCommand`, `--json` takes priority over `refresh` and `reset` subcommands
- [x] Manual: `ccs cliproxy catalog --json | jq .` outputs expected provider/model structure with full metadata