### PR TITLE
fix(docker): delegate restart/install to supervisorctl in Docker deployments

### DIFF
--- a/src/docker/supervisord-lifecycle.ts
+++ b/src/docker/supervisord-lifecycle.ts
@@ -1,0 +1,36 @@
+/**
+ * Supervisord lifecycle helpers for Docker deployments (`ccs docker up`).
+ *
+ * In Docker, supervisord owns the CLIProxy process lifecycle. Direct
+ * stop+start via session-tracker / service-manager creates orphaned
+ * processes and causes supervisord to enter FATAL state (EADDRINUSE).
+ * All restart operations must delegate to `supervisorctl` instead.
+ */
+
+import * as fs from 'fs';
+import { execSync } from 'child_process';
+import { CLIPROXY_DEFAULT_PORT } from '../cliproxy/config/port-manager';
+
+const SUPERVISOR_SOCK = '/var/run/supervisor.sock';
+const SUPERVISOR_CONF = '/etc/supervisord.conf';
+
+/** True when running inside a supervisord-managed container. */
+export function isRunningUnderSupervisord(): boolean {
+  return fs.existsSync(SUPERVISOR_SOCK);
+}
+
+/** Restart the cliproxy program via supervisorctl. Returns port on success. */
+export function restartCliproxyViaSupervisord(): {
+  success: boolean;
+  port?: number;
+  error?: string;
+} {
+  try {
+    execSync(`supervisorctl -c ${SUPERVISOR_CONF} restart cliproxy`, { timeout: 15_000 });
+    return { success: true, port: CLIPROXY_DEFAULT_PORT };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(`[cliproxy] supervisorctl restart failed: ${detail}`);
+    return { success: false, error: 'supervisorctl restart failed' };
+  }
+}

--- a/src/web-server/routes/cliproxy-stats-routes.ts
+++ b/src/web-server/routes/cliproxy-stats-routes.ts
@@ -6,6 +6,10 @@ import { Router, Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
 import {
+  isRunningUnderSupervisord,
+  restartCliproxyViaSupervisord,
+} from '../../docker/supervisord-lifecycle';
+import {
   fetchCliproxyStats,
   fetchCliproxyModels,
   isCliproxyRunning,
@@ -1014,7 +1018,14 @@ router.post('/install', async (req: Request, res: Response): Promise<void> => {
  */
 router.post('/restart', async (_req: Request, res: Response): Promise<void> => {
   try {
-    // Stop proxy first
+    if (isRunningUnderSupervisord()) {
+      // Docker mode: delegate to supervisord which owns the process lifecycle
+      const result = restartCliproxyViaSupervisord();
+      res.json(result);
+      return;
+    }
+
+    // Local mode: direct process management
     await stopProxy();
 
     // Small delay to ensure port is released

--- a/src/web-server/services/cliproxy-dashboard-install-service.ts
+++ b/src/web-server/services/cliproxy-dashboard-install-service.ts
@@ -3,6 +3,10 @@ import { ensureCliproxyService, type ServiceStartResult } from '../../cliproxy/s
 import { getProxyStatus as getProxyProcessStatus } from '../../cliproxy/session-tracker';
 import { isCliproxyRunning } from '../../cliproxy/stats-fetcher';
 import type { CLIProxyBackend } from '../../cliproxy/types';
+import {
+  isRunningUnderSupervisord,
+  restartCliproxyViaSupervisord,
+} from '../../docker/supervisord-lifecycle';
 
 interface ProxyStatusLike {
   running: boolean;
@@ -60,6 +64,20 @@ export async function installDashboardCliproxyVersion(
       success: true,
       restarted: false,
       message: `Successfully installed ${backendLabel} v${version}`,
+    };
+  }
+
+  // In Docker, supervisord owns process lifecycle — delegate restart to it
+  if (isRunningUnderSupervisord()) {
+    const result = restartCliproxyViaSupervisord();
+    return {
+      success: result.success,
+      restarted: result.success,
+      port: result.port,
+      error: result.error,
+      message: result.success
+        ? `Successfully installed ${backendLabel} v${version} and restarted it on port ${result.port}`
+        : `Installed ${backendLabel} v${version}, but restart failed`,
     };
   }
 


### PR DESCRIPTION
## Summary

- Dashboard restart button and install service used local-mode process management (`stopProxy` + `ensureCliproxyService`) that conflicts with supervisord in Docker deployments
- Kills CLIProxy binary → bootstrap wrapper exits → supervisord tries restart → `ensureCliproxyService` spawns orphaned process on `:8317` → `EADDRINUSE` → supervisord FATAL state
- Affects **all** `ccs docker up` deployments universally

## Fix

- New shared utility `src/docker/supervisord-lifecycle.ts` detects supervisord via `/var/run/supervisor.sock` and delegates to `supervisorctl -c /etc/supervisord.conf restart cliproxy`
- Applied to both `POST /api/cliproxy/restart` (restart button) and install service (install + restart flow)
- Local-mode behavior unchanged — only activates when supervisor socket exists
- Matches existing pattern in `docker-executor.ts:232` (`ccs docker update` already uses `supervisorctl restart`)

## Changed Files

| File | Change |
|------|--------|
| `src/docker/supervisord-lifecycle.ts` | New: shared supervisord detection + restart utility |
| `src/web-server/routes/cliproxy-stats-routes.ts` | Restart endpoint branches on supervisord |
| `src/web-server/services/cliproxy-dashboard-install-service.ts` | Install service branches on supervisord |

## Test Plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] Lint passes (`eslint src/ --fix`)
- [x] Format passes (`prettier --check src/`)
- [x] No new test failures (8 pre-existing on dev, 0 introduced)
- [ ] Deploy to Docker host and verify restart button works
- [ ] Verify install + restart flow works in Docker

Closes #964