### PR TITLE
fix(image-analysis): wrap defaultDeps in arrow functions to fix circular dep capture

### DIFF
--- a/src/utils/hooks/image-analysis-runtime-status.ts
+++ b/src/utils/hooks/image-analysis-runtime-status.ts
@@ -29,11 +29,11 @@ interface ImageAnalysisRuntimeStatusDeps {
 }
 
 const defaultDeps: ImageAnalysisRuntimeStatusDeps = {
-  checkRemoteProxy,
-  fetchRemoteAuthStatus,
-  getAuthStatus,
-  getProxyTarget,
-  initializeAccounts,
+  checkRemoteProxy: (...args) => checkRemoteProxy(...args),
+  fetchRemoteAuthStatus: (...args) => fetchRemoteAuthStatus(...args),
+  getAuthStatus: (...args) => getAuthStatus(...args),
+  getProxyTarget: () => getProxyTarget(),
+  initializeAccounts: () => initializeAccounts(),
   isCliproxyRunning: () => isCliproxyRunning(),
 };
 

--- a/tests/unit/utils/hooks/image-analysis-runtime-status-circular-dependency.test.ts
+++ b/tests/unit/utils/hooks/image-analysis-runtime-status-circular-dependency.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { dirname } from 'path';
+import type { ImageAnalysisStatus } from '../../../../src/utils/hooks/image-analysis-backend-resolver';
+import type { AuthStatus } from '../../../../src/cliproxy/auth-handler';
+import {
+  ModuleKind,
+  ScriptTarget,
+  transpileModule,
+  type CompilerOptions,
+} from 'typescript';
+
+function createStatus(overrides: Partial<ImageAnalysisStatus> = {}): ImageAnalysisStatus {
+  return {
+    enabled: true,
+    supported: true,
+    status: 'active',
+    backendId: 'ghcp',
+    backendDisplayName: 'GitHub Copilot (OAuth)',
+    model: 'claude-haiku-4.5',
+    resolutionSource: 'profile-backend',
+    reason: null,
+    shouldPersistHook: true,
+    persistencePath: '/tmp/orq.settings.json',
+    runtimePath: '/api/provider/ghcp',
+    usesCurrentTarget: true,
+    usesCurrentAuthToken: true,
+    hookInstalled: true,
+    sharedHookInstalled: true,
+    authReadiness: 'unknown',
+    authProvider: 'ghcp',
+    authDisplayName: 'GitHub Copilot (OAuth)',
+    authReason: 'Auth readiness has not been verified yet.',
+    proxyReadiness: 'unknown',
+    proxyReason: 'CLIProxy runtime readiness has not been verified yet.',
+    effectiveRuntimeMode: 'native-read',
+    effectiveRuntimeReason: null,
+    profileModel: 'claude-haiku-4.5',
+    nativeReadPreference: false,
+    nativeImageCapable: true,
+    nativeImageReason: 'claude-haiku-4.5 can read images natively.',
+    ...overrides,
+  };
+}
+
+describe('image-analysis-runtime-status circular dependency regression', () => {
+  it('reads auth deps from the CommonJS module object at call time', async () => {
+    const authHandlerModule: {
+      initializeAccounts: undefined | (() => void);
+      getAuthStatus: undefined | ((provider: 'ghcp') => AuthStatus);
+    } = {
+      initializeAccounts: undefined,
+      getAuthStatus: undefined,
+    };
+
+    const sourcePath = new URL(
+      '../../../../src/utils/hooks/image-analysis-runtime-status.ts',
+      import.meta.url
+    );
+    const source = readFileSync(sourcePath, 'utf8');
+    const compilerOptions: CompilerOptions = {
+      module: ModuleKind.CommonJS,
+      target: ScriptTarget.ES2020,
+      esModuleInterop: true,
+    };
+    const transpiled = transpileModule(source, { compilerOptions }).outputText;
+
+    const module = { exports: {} as Record<string, unknown> };
+    const requireMap: Record<string, unknown> = {
+      '../../cliproxy/auth-handler': authHandlerModule,
+      '../../cliproxy/remote-proxy-client': {
+        checkRemoteProxy: async () => ({ reachable: false, error: 'not-used' }),
+      },
+      '../../cliproxy/remote-auth-fetcher': {
+        fetchRemoteAuthStatus: async () => [],
+      },
+      '../../cliproxy/proxy-target-resolver': {
+        getProxyTarget: () => ({
+          host: '127.0.0.1',
+          port: 8317,
+          protocol: 'http',
+          isRemote: false,
+        }),
+      },
+      '../../cliproxy/provider-capabilities': {
+        getProviderDisplayName: () => 'GitHub Copilot (OAuth)',
+        isCLIProxyProvider: () => true,
+      },
+      '../../cliproxy/stats-fetcher': {
+        isCliproxyRunning: async () => true,
+      },
+      '../../config/unified-config-types': {
+        DEFAULT_IMAGE_ANALYSIS_CONFIG: {},
+      },
+      './image-analysis-backend-resolver': {
+        resolveImageAnalysisStatus: () => createStatus(),
+      },
+    };
+
+    const compiledModule = new Function(
+      'exports',
+      'require',
+      'module',
+      '__filename',
+      '__dirname',
+      transpiled
+    );
+    compiledModule(
+      module.exports,
+      (specifier: string) => {
+        const dependency = requireMap[specifier];
+        if (!dependency) {
+          throw new Error(`Unexpected dependency: ${specifier}`);
+        }
+        return dependency;
+      },
+      module,
+      sourcePath.pathname,
+      dirname(sourcePath.pathname)
+    );
+
+    authHandlerModule.initializeAccounts = () => {};
+    authHandlerModule.getAuthStatus = () => ({
+      provider: 'ghcp',
+      authenticated: true,
+      tokenDir: '/tmp/auth',
+      tokenFiles: ['github-copilot-test.json'],
+      accounts: [],
+      defaultAccount: undefined,
+    });
+
+    const { hydrateImageAnalysisRuntimeStatus } = module.exports as {
+      hydrateImageAnalysisRuntimeStatus: (
+        baseStatus: ImageAnalysisStatus,
+        deps?: Record<string, unknown>
+      ) => Promise<ImageAnalysisStatus>;
+    };
+    const status = await hydrateImageAnalysisRuntimeStatus(createStatus(), {});
+
+    expect(status.authReadiness).toBe('ready');
+    expect(status.proxyReadiness).toBe('ready');
+    expect(status.effectiveRuntimeMode).toBe('cliproxy-image-analysis');
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #973

`deps.initializeAccounts is not a function` (and `deps.getAuthStatus is not a function`) errors occur even on v7.68.1. The issue persists after reinstalling because the root cause is a **circular dependency in the module graph**, not a stale installation.

## Root Cause

In `defaultDeps`, most function references are captured directly at module evaluation time:

```ts
const defaultDeps: ImageAnalysisRuntimeStatusDeps = {
  checkRemoteProxy,       // captured at module load time
  fetchRemoteAuthStatus,  // captured at module load time
  getAuthStatus,          // captured at module load time
  getProxyTarget,         // captured at module load time
  initializeAccounts,     // captured at module load time
  isCliproxyRunning: () => isCliproxyRunning(),  // ✅ already wrapped
};
```

When `cliproxy/executor/index.js` (or similar entry points) loads this module, `auth-handler.js` is mid-initialization due to circular dependencies. At that moment, `initializeAccounts`, `getAuthStatus`, etc. are still `undefined`, and those `undefined` values get locked into `defaultDeps`.

`isCliproxyRunning` was already correctly wrapped in an arrow function — deferring evaluation to call time, by which point all modules are fully initialized.

## Fix

Apply the same arrow function wrapping consistently to all deps:

```ts
const defaultDeps: ImageAnalysisRuntimeStatusDeps = {
  checkRemoteProxy: (...args) => checkRemoteProxy(...args),
  fetchRemoteAuthStatus: (...args) => fetchRemoteAuthStatus(...args),
  getAuthStatus: (...args) => getAuthStatus(...args),
  getProxyTarget: () => getProxyTarget(),
  initializeAccounts: () => initializeAccounts(),
  isCliproxyRunning: () => isCliproxyRunning(),
};
```

## Verification

- Reproduced the error on v7.68.1 by tracing the module load order with Node.js instrumentation
- Confirmed `auth_handler_1.initializeAccounts` is `undefined` when first captured, but becomes a function after full initialization
- Applied the patch locally — error no longer occurs
- All 6 existing unit tests pass