### PR TITLE
hotfix: restore bun types for stable release CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@semantic-release/release-notes-generator": "^14.1.0",
     "@tailwindcss/vite": "^4.1.17",
     "@types/bcrypt": "^6.0.0",
+    "@types/bun": "^1.3.12",
     "@types/chokidar": "^2.1.7",
     "@types/express": "^4.17.21",
     "@types/express-rate-limit": "6.0.0",


### PR DESCRIPTION
## Summary
- restore the missing `@types/bun` dev dependency in `package.json`
- realign the manifest with the existing Bun type requirement in `tsconfig.json`
- unblock the stable `Release` workflow on `main`

## Root Cause
The merged `main` release commit kept `"types": ["node", "bun"]` in `tsconfig.json`, but `package.json` no longer listed `@types/bun`.

That created two CI problems on the stable release path:
- `bun install --frozen-lockfile` failed because the manifest and lock state drifted
- after local normalization, `tsc --noEmit` failed with `TS2688: Cannot find type definition file for 'bun'`

## Verification
- reproduced the failing GitHub Actions run `24349386534` locally from `origin/main`
- `bun install --frozen-lockfile`
- `cd ui && bun install --frozen-lockfile`
- `CCS_HOME=/tmp/ccs-hotfix-release-lockfile bun run build:all`
- `CCS_HOME=/tmp/ccs-hotfix-release-lockfile bun run validate`
- `CCS_HOME=/tmp/ccs-hotfix-release-lockfile bun run validate:ci-parity`

## Follow-up
After this merges to `main`, cherry-pick `6cfb1715` back to `dev` to keep the branches aligned.
