### PR TITLE
fix(ci): allow PR-Agent dispatch bot reruns

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,7 +21,8 @@ concurrency:
           github.event.comment.body != '/review' ||
           (
             github.event.sender.type == 'Bot' &&
-            github.event.sender.login != 'github-actions[bot]'
+            github.event.sender.login != 'github-actions[bot]' &&
+            github.event.sender.login != 'ccs-reviewer[bot]'
           )
         )
       ) && format('skip-{0}', github.run_id) ||
@@ -80,7 +81,8 @@ jobs:
           github.event.comment.body == '/review' &&
           (
             contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.comment.author_association) ||
-            github.event.sender.login == 'github-actions[bot]'
+            github.event.sender.login == 'github-actions[bot]' ||
+            github.event.sender.login == 'ccs-reviewer[bot]'
           )
         )
       )

--- a/tests/unit/scripts/github/ai-review-workflow.test.ts
+++ b/tests/unit/scripts/github/ai-review-workflow.test.ts
@@ -29,6 +29,7 @@ describe('PR-Agent review lane migration', () => {
     expect(workflow).toContain('github_action_config.auto_review');
     expect(workflow).toContain("github.event.comment.body == '/review'");
     expect(workflow).toContain('github.event.comment.author_association');
+    expect(workflow).toContain('ccs-reviewer[bot]');
     expect(workflow).toContain("format('skip-{0}', github.run_id)");
     expect(workflow).toContain("format('dispatch-{0}', github.run_id)");
     expect(workflow).toContain('CCS_REVIEWER_APP_ID');


### PR DESCRIPTION
## Summary

- allow the `ccs-reviewer[bot]` app identity through the trusted `/review` comment path
- keep the concurrency skip-group logic from suppressing the app-bot rerun flow
- extend the workflow test to cover the dispatch bot identity explicitly

## Why

The merged PR-Agent migration keeps `workflow_dispatch` by posting `/review` with the `ccs-reviewer` GitHub App token. The issue_comment gate only trusted `github-actions[bot]`, so manual dispatch could silently fail.

## Testing

- [x] `bun test tests/unit/scripts/github/ai-review-workflow.test.ts`
- [x] `bun run build`
- [x] `bun run validate`
