### PR TITLE
fix: clear stale cliproxy reauth badge after oauth

### DIFF
--- a/src/web-server/routes/cliproxy-auth-routes.ts
+++ b/src/web-server/routes/cliproxy-auth-routes.ts
@@ -33,6 +33,7 @@ import {
 } from '../../cliproxy/proxy-target-resolver';
 import { fetchRemoteAuthStatus } from '../../cliproxy/remote-auth-fetcher';
 import { ensureManagedModelPrefixes } from '../../cliproxy/managed-model-prefixes';
+import { invalidateQuotaCache } from '../../cliproxy/quota-response-cache';
 import { loadOrCreateUnifiedConfig } from '../../config/unified-config-loader';
 import { tryKiroImport } from '../../cliproxy/auth/kiro-import';
 import {
@@ -188,6 +189,13 @@ function shouldKeepWaitingForLocalToken(
   return (
     upstreamCompletedAt !== null && now - upstreamCompletedAt < POLLED_AUTH_LOCAL_TOKEN_GRACE_MS
   );
+}
+
+function invalidateQuotaForRegisteredAccount(account: {
+  provider: CLIProxyProvider;
+  id: string;
+}): void {
+  invalidateQuotaCache(account.provider, account.id);
 }
 
 function parseKiroMethod(raw: unknown): { method: KiroAuthMethod; invalid: boolean } {
@@ -1022,6 +1030,7 @@ router.get('/:provider/status', async (req: Request, res: Response): Promise<voi
       } catch {
         // Keep manual callback success path non-fatal when prefix repair cannot run.
       }
+      invalidateQuotaForRegisteredAccount(account);
       res.json({
         status: 'ok',
         account: {
@@ -1173,6 +1182,7 @@ router.post('/:provider/submit-callback', async (req: Request, res: Response): P
           // Keep manual callback success path non-fatal when prefix repair cannot run.
         }
       }
+      invalidateQuotaForRegisteredAccount(account);
 
       res.json({
         success: true,
@@ -1204,6 +1214,8 @@ router.post('/:provider/submit-callback', async (req: Request, res: Response): P
       });
       return;
     }
+
+    invalidateQuotaForRegisteredAccount(account);
 
     res.json({
       success: true,

--- a/tests/unit/web-server/cliproxy-auth-routes-manual-callback.test.ts
+++ b/tests/unit/web-server/cliproxy-auth-routes-manual-callback.test.ts
@@ -6,6 +6,11 @@ import * as path from 'path';
 import * as http from 'http';
 import type { Server } from 'http';
 import cliproxyAuthRoutes from '../../../src/web-server/routes/cliproxy-auth-routes';
+import {
+  clearQuotaCache,
+  getCachedQuota,
+  setCachedQuota,
+} from '../../../src/cliproxy/quota-response-cache';
 import { restoreFetch, mockFetch } from '../../mocks';
 
 describe('cliproxy-auth-routes manual callback nickname persistence', () => {
@@ -49,6 +54,7 @@ describe('cliproxy-auth-routes manual callback nickname persistence', () => {
 
   afterEach(() => {
     restoreFetch();
+    clearQuotaCache();
 
     if (originalCcsHome === undefined) {
       delete process.env.CCS_HOME;
@@ -563,5 +569,63 @@ describe('cliproxy-auth-routes manual callback nickname persistence', () => {
     };
 
     expect(registry.providers.codex.accounts['new@example.com']?.email).toBe('new@example.com');
+  });
+
+  it('clears stale Claude quota cache after polling auth success', async () => {
+    mockFetch([
+      {
+        url: /\/v0\/management\/anthropic-auth-url\?is_webui=true$/,
+        response: {
+          auth_url: 'https://auth.example.com/authorize?state=state-claude-cache-clear',
+          state: 'state-claude-cache-clear',
+        },
+      },
+      {
+        url: /\/v0\/management\/get-auth-status\?state=state-claude-cache-clear$/,
+        response: { status: 'ok' },
+      },
+    ]);
+
+    const startResponse = await postJson('/api/cliproxy/auth/claude/start-url', {});
+    expect(startResponse.status).toBe(200);
+
+    const accountId = 'claude-team@example.com';
+    setCachedQuota('claude', accountId, {
+      success: false,
+      error: 'Authentication required for policy limits',
+      needsReauth: true,
+    });
+    expect(getCachedQuota('claude', accountId)).not.toBeNull();
+
+    const tokenDir = path.join(tempHome, '.ccs', 'cliproxy', 'auth');
+    fs.mkdirSync(tokenDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tokenDir, 'claude-claude-team@example.com.json'),
+      JSON.stringify({
+        type: 'claude',
+        email: accountId,
+        access_token: 'fresh-token',
+        refresh_token: 'refresh-token',
+        expired: '2099-01-01T00:00:00.000Z',
+      }),
+      'utf8'
+    );
+
+    const statusResponse = await getJson(
+      '/api/cliproxy/auth/claude/status?state=state-claude-cache-clear'
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(statusResponse.body).toEqual({
+      status: 'ok',
+      account: {
+        id: accountId,
+        email: accountId,
+        nickname: 'claude-team',
+        provider: 'claude',
+        isDefault: true,
+      },
+    });
+    expect(getCachedQuota('claude', accountId)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- clear stale per-account quota cache entries after successful CLIProxy OAuth registration
- prevent Claude dashboard accounts from staying stuck on `Reauth` immediately after auth succeeds
- add regression coverage for the Claude auth polling path

## Root Cause
CCS kept serving a cached quota result that still had `needsReauth=true` even after the OAuth flow finished and the account was successfully registered.

## Validation
- [x] `bun test tests/unit/web-server/cliproxy-auth-routes-manual-callback.test.ts`
- [x] `bun run validate`
- [x] `bun run validate:ci-parity`

Closes #972
