### PR TITLE
hotfix: raise PR-Agent model budget to 128k

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,9 +1,11 @@
 [config]
 git_provider = "github"
+fallback_models = ["gpt-5.4-mini"]
 publish_output = true
 publish_output_progress = false
 response_language = "en-US"
-max_model_tokens = 32000
+max_model_tokens = 131072
+custom_model_max_tokens = 131072
 large_patch_policy = "clip"
 temperature = 0.1
 

--- a/tests/unit/scripts/github/ai-review-workflow.test.ts
+++ b/tests/unit/scripts/github/ai-review-workflow.test.ts
@@ -38,6 +38,8 @@ describe('PR-Agent review lane migration', () => {
 
     expect(config).toContain('[config]');
     expect(config).toContain('git_provider = "github"');
+    expect(config).toContain('fallback_models = ["gpt-5.4-mini"]');
+    expect(config).toContain('custom_model_max_tokens = 131072');
     expect(config).toContain('[pr_reviewer]');
     expect(config).not.toContain('auto_review = true');
     expect(config).not.toContain('claude-code-action');


### PR DESCRIPTION
## Summary
- set PR-Agent custom model token budget to 128k for self-hosted review models
- override the fallback model to `gpt-5.4-mini` instead of the upstream `o4-mini` default
- lock the workflow regression test to the shipped PR-Agent config

## Why
The self-hosted review lane was reaching PR-Agent's default model metadata path for `dashscope/qwen3.6-plus`, which prevented review publication. This hotfix aligns the repository config with the self-hosted model budget and a valid fallback available through Cliproxy.

## Validation
- `bun run validate`
