### PR TITLE
fix(ci): restore PR-Agent reviewer bot identity

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -93,7 +93,6 @@ jobs:
       pull-requests: write
       contents: read
     env:
-      GITHUB_TOKEN: ${{ github.token }}
       OPENAI_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
       "OPENAI.API_BASE": ${{ vars.AI_REVIEW_BASE_URL }}
       "config.model": ${{ vars.AI_REVIEW_MODEL }}
@@ -102,5 +101,14 @@ jobs:
       "github_action_config.auto_improve": "false"
 
     steps:
+      - name: Generate App Token
+        id: pr-agent-app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CCS_REVIEWER_APP_ID }}
+          private-key: ${{ secrets.CCS_REVIEWER_PRIVATE_KEY }}
+
       - name: Run PR-Agent
         uses: qodo-ai/pr-agent@v0.34
+        env:
+          GITHUB_TOKEN: ${{ steps.pr-agent-app-token.outputs.token }}

--- a/tests/unit/scripts/github/ai-review-workflow.test.ts
+++ b/tests/unit/scripts/github/ai-review-workflow.test.ts
@@ -16,11 +16,12 @@ describe('PR-Agent review lane migration', () => {
 
     const workflow = fs.readFileSync(workflowPath, 'utf8');
     const config = fs.readFileSync(prAgentConfigPath, 'utf8');
+    const appTokenUsages = workflow.match(/uses: actions\/create-github-app-token@v1/g) ?? [];
 
     expect(workflow).toContain('name: AI Code Review');
     expect(workflow).toContain('runs-on: [self-hosted, cliproxy]');
     expect(workflow).toContain('uses: qodo-ai/pr-agent');
-    expect(workflow).toContain('uses: actions/create-github-app-token@v1');
+    expect(appTokenUsages).toHaveLength(2);
     expect(workflow).toContain('OPENAI.API_BASE');
     expect(workflow).toContain('OPENAI_KEY');
     expect(workflow).toContain('vars.AI_REVIEW_BASE_URL');
@@ -34,6 +35,9 @@ describe('PR-Agent review lane migration', () => {
     expect(workflow).toContain("format('dispatch-{0}', github.run_id)");
     expect(workflow).toContain('CCS_REVIEWER_APP_ID');
     expect(workflow).toContain('CCS_REVIEWER_PRIVATE_KEY');
+    expect(workflow).toContain('id: pr-agent-app-token');
+    expect(workflow).toContain('GITHUB_TOKEN: ${{ steps.pr-agent-app-token.outputs.token }}');
+    expect(workflow).not.toContain('GITHUB_TOKEN: ${{ github.token }}');
     expect(workflow).not.toContain('uses: anthropics/claude-code-action@v1');
 
     expect(config).toContain('[config]');


### PR DESCRIPTION
## Summary
- mint a `ccs-reviewer` GitHub App token inside the PR-Agent job itself
- pass that app token to the `Run PR-Agent` step instead of `${{ github.token }}`
- lock the workflow contract test to the new auth path

## Why
The PR-Agent review output was being published with the default Actions token, so GitHub attributed the comment to `github-actions[bot]` instead of `ccs-reviewer[bot]`.

## Validation
- `bun test tests/unit/scripts/github/ai-review-workflow.test.ts`
- `bun run build`
- `bun run validate`
- pre-push workflow gate for changed GitHub workflows

## Follow-up
- after merge, rerun `/review` on PR `#1007` to confirm the published PR-Agent comment is authored by `ccs-reviewer[bot]`
