### PR TITLE
feat(ci): make PR-Agent reviews more verbose

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -10,23 +10,27 @@ large_patch_policy = "clip"
 temperature = 0.1
 
 [pr_reviewer]
+require_score_review = true
 require_tests_review = true
-require_estimate_effort_to_review = false
+require_estimate_effort_to_review = true
+require_can_be_split_review = true
 require_security_review = true
-require_ticket_analysis_review = false
+require_todo_scan = true
+require_ticket_analysis_review = true
 publish_output_no_suggestions = true
 persistent_comment = true
-num_max_findings = 6
-final_update_message = false
+num_max_findings = 10
+final_update_message = true
 enable_review_labels_security = false
 enable_review_labels_effort = false
-enable_intro_text = false
-enable_help_text = false
+enable_intro_text = true
+enable_help_text = true
 extra_instructions = """\
 Focus on correctness, security, regressions, and missing verification.
 Read the full diff before reporting findings, and inspect surrounding code before claiming a bug.
-Prefer a short list of confirmed issues over speculative commentary.
-Do not pad the review with praise, scorecards, effort estimates, or generic best-practice advice.
+Be thorough across the enabled review sections, even when no major defects are found.
+When a change looks safe, explain why it appears safe and call out any residual assumptions or manual verification gaps.
+Prefer substantive analysis over generic praise or filler, and keep every claim evidence-based.
 
 CCS-specific checks:
 - CLI output in src/ must stay ASCII-only: [OK], [!], [X], [i]

--- a/tests/unit/scripts/github/ai-review-workflow.test.ts
+++ b/tests/unit/scripts/github/ai-review-workflow.test.ts
@@ -44,6 +44,15 @@ describe('PR-Agent review lane migration', () => {
     expect(config).toContain('git_provider = "github"');
     expect(config).toContain('fallback_models = ["gpt-5.4-mini"]');
     expect(config).toContain('custom_model_max_tokens = 131072');
+    expect(config).toContain('require_score_review = true');
+    expect(config).toContain('require_estimate_effort_to_review = true');
+    expect(config).toContain('require_can_be_split_review = true');
+    expect(config).toContain('require_todo_scan = true');
+    expect(config).toContain('require_ticket_analysis_review = true');
+    expect(config).toContain('num_max_findings = 10');
+    expect(config).toContain('final_update_message = true');
+    expect(config).toContain('enable_intro_text = true');
+    expect(config).toContain('enable_help_text = true');
     expect(config).toContain('[pr_reviewer]');
     expect(config).not.toContain('auto_review = true');
     expect(config).not.toContain('claude-code-action');


### PR DESCRIPTION
## Summary
- enable more PR-Agent review sections so review comments contain a fuller evaluation
- increase `num_max_findings` and turn on intro/help/update text to avoid ultra-minimal review output
- lock the richer review profile in the existing workflow/config regression test

## What Changed
- enable `require_score_review`
- enable `require_estimate_effort_to_review`
- enable `require_can_be_split_review`
- enable `require_todo_scan`
- re-enable `require_ticket_analysis_review`
- raise `num_max_findings` from `6` to `10`
- enable `final_update_message`, `enable_intro_text`, and `enable_help_text`
- update `extra_instructions` to ask for a fuller, evidence-based evaluation even when no major defects are found

## Validation
- `bun test tests/unit/scripts/github/ai-review-workflow.test.ts`
- `bun run build`
- `bun run validate`
- feature-branch pre-push workflow gate
