### PR TITLE
fix(accounts): refine codex plan badges

### DIFF
--- a/src/cliproxy/accounts/email-account-identity.ts
+++ b/src/cliproxy/accounts/email-account-identity.ts
@@ -1,6 +1,9 @@
 import type { CLIProxyProvider } from '../types';
 
 const DUPLICATE_EMAIL_ACCOUNT_PROVIDERS = new Set<string>(['codex']);
+const FREE_PLAN_PARTS = new Set(['free']);
+const PERSONAL_PLAN_PARTS = new Set(['plus', 'pro']);
+const BUSINESS_PLAN_PARTS = new Set(['team']);
 
 // Keep variant parsing aligned with ui/src/lib/account-identity.ts. The UI copy is
 // separate because the browser bundle cannot import this server module directly.
@@ -47,6 +50,20 @@ function formatVariantPart(value: string): string {
             .map((part) => part[0]?.toUpperCase() + part.slice(1))
             .join(' ');
   }
+}
+
+function formatWorkspaceLabel(parts: string[]): string | null {
+  const workspaceId = parts.find((part) => /^[a-f0-9]{8}$/i.test(part));
+  if (workspaceId) {
+    return `Workspace ${workspaceId.toLowerCase()}`;
+  }
+
+  return parts.map(formatVariantPart).filter(Boolean).join(' · ') || null;
+}
+
+function formatAudienceDetail(parts: string[]): string | null {
+  const label = parts.map(formatVariantPart).filter(Boolean).join(' · ');
+  return label || null;
 }
 
 export function supportsDuplicateEmailAccounts(provider: CLIProxyProvider | string): boolean {
@@ -136,10 +153,16 @@ export function formatAccountVariantLabel(accountId: string, email?: string): st
   }
 
   const suffix = parts[parts.length - 1]?.toLowerCase();
-  if (suffix && ['team', 'free', 'plus', 'pro'].includes(suffix)) {
-    return [formatVariantPart(suffix), ...parts.slice(0, -1).map(formatVariantPart)]
-      .filter(Boolean)
-      .join(' · ');
+  if (suffix && BUSINESS_PLAN_PARTS.has(suffix)) {
+    return ['Business', formatWorkspaceLabel(parts.slice(0, -1))].filter(Boolean).join(' · ');
+  }
+
+  if (suffix && FREE_PLAN_PARTS.has(suffix)) {
+    return ['Free', formatAudienceDetail(parts.slice(0, -1))].filter(Boolean).join(' · ');
+  }
+
+  if (suffix && PERSONAL_PLAN_PARTS.has(suffix)) {
+    return ['Personal', formatAudienceDetail(parts.slice(0, -1))].filter(Boolean).join(' · ');
   }
 
   return parts.map(formatVariantPart).filter(Boolean).join(' · ');

--- a/src/cliproxy/accounts/email-account-identity.ts
+++ b/src/cliproxy/accounts/email-account-identity.ts
@@ -162,7 +162,9 @@ export function formatAccountVariantLabel(accountId: string, email?: string): st
   }
 
   if (suffix && PERSONAL_PLAN_PARTS.has(suffix)) {
-    return ['Personal', formatAudienceDetail(parts.slice(0, -1))].filter(Boolean).join(' · ');
+    return ['Personal', formatVariantPart(suffix), formatAudienceDetail(parts.slice(0, -1))]
+      .filter(Boolean)
+      .join(' · ');
   }
 
   return parts.map(formatVariantPart).filter(Boolean).join(' · ');

--- a/src/cliproxy/quota-fetcher-codex.ts
+++ b/src/cliproxy/quota-fetcher-codex.ts
@@ -624,11 +624,12 @@ export async function fetchCodexQuota(
 
       // Extract plan type
       const planTypeRaw = data.plan_type || data.planType;
-      let planType: 'free' | 'plus' | 'team' | null = null;
+      let planType: 'free' | 'plus' | 'pro' | 'team' | null = null;
       if (planTypeRaw) {
         const normalized = planTypeRaw.toLowerCase();
         if (normalized === 'free') planType = 'free';
         else if (normalized === 'plus') planType = 'plus';
+        else if (normalized === 'pro') planType = 'pro';
         else if (normalized === 'team') planType = 'team';
       }
 

--- a/src/cliproxy/quota-types.ts
+++ b/src/cliproxy/quota-types.ts
@@ -74,8 +74,8 @@ export interface CodexQuotaResult extends QuotaErrorMetadata {
   windows: CodexQuotaWindow[];
   /** Explicit core usage windows (5h + weekly) for easier reset display */
   coreUsage?: CodexCoreUsageSummary;
-  /** Plan type: free, plus, team, or null if unknown */
-  planType: 'free' | 'plus' | 'team' | null;
+  /** Plan type: free, plus, pro, team, or null if unknown */
+  planType: 'free' | 'plus' | 'pro' | 'team' | null;
   /** Timestamp of fetch */
   lastUpdated: number;
   /** Error message if fetch failed */

--- a/ui/src/components/account/flow-viz/account-card.tsx
+++ b/ui/src/components/account/flow-viz/account-card.tsx
@@ -104,6 +104,35 @@ function getCodexPlanAudience(quota: unknown): AccountAudience {
   return 'unknown';
 }
 
+function resolveCodexAudience(
+  identityAudience: AccountAudience,
+  planAudience: AccountAudience
+): AccountAudience {
+  if (planAudience === 'unknown') {
+    return identityAudience;
+  }
+
+  if (planAudience === 'business') {
+    return 'business';
+  }
+
+  if (identityAudience === 'business') {
+    return 'business';
+  }
+
+  if (planAudience === 'personal') {
+    return 'personal';
+  }
+
+  if (planAudience === 'free') {
+    return identityAudience === 'unknown' || identityAudience === 'free'
+      ? 'free'
+      : identityAudience;
+  }
+
+  return identityAudience;
+}
+
 function getCodexPlanDetailLabel(quota: unknown): string | null {
   if (!quota || typeof quota !== 'object' || !('planType' in quota)) {
     return null;
@@ -162,7 +191,7 @@ function getVariantAudience(
   },
   quota?: unknown
 ) {
-  return variant.audience !== 'unknown' ? variant.audience : getCodexPlanAudience(quota);
+  return resolveCodexAudience(variant.audience, getCodexPlanAudience(quota));
 }
 
 function getVariantInlineLabel(
@@ -176,8 +205,11 @@ function getVariantInlineLabel(
   quota?: unknown
 ) {
   const detailLabel = getVariantDetailLabel(variant, quota);
+  const audience = getVariantAudience(variant, quota);
   const audienceLabel =
-    variant.audienceLabel ?? getDetailedAudienceLabel(getVariantAudience(variant, quota));
+    variant.audience === audience
+      ? (variant.audienceLabel ?? getDetailedAudienceLabel(audience))
+      : getDetailedAudienceLabel(audience);
   const composedLabel = [audienceLabel, detailLabel].filter(Boolean).join(' · ');
   return composedLabel || variant.inlineLabel || null;
 }
@@ -207,8 +239,8 @@ function getVariantMarkerLabel(
 
   const normalizedFallback =
     compactDetailLabel?.trim() ||
-    variant.audienceLabel?.trim() ||
     getDetailedAudienceLabel(audience) ||
+    variant.audienceLabel?.trim() ||
     variant.detailLabel?.trim();
   return normalizedFallback?.[0]?.toUpperCase() ?? '?';
 }

--- a/ui/src/components/account/flow-viz/account-card.tsx
+++ b/ui/src/components/account/flow-viz/account-card.tsx
@@ -6,6 +6,7 @@ import { AccountSurfaceCard } from '@/components/account/shared/account-surface-
 import { QuotaTooltipContent } from '@/components/shared/quota-tooltip-content';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { getCodexIdentityBadge, type CodexIdentityBadge } from '@/lib/account-identity';
 import {
   cn,
   formatQuotaPercent,
@@ -88,68 +89,56 @@ function getCompactQuotaColor(percentage: number) {
   return 'bg-red-500';
 }
 
-function getCodexPlanAudience(quota: unknown): AccountAudience {
+function getCodexQuotaBadge(quota: unknown): CodexIdentityBadge {
   if (!quota || typeof quota !== 'object' || !('planType' in quota)) {
-    return 'unknown';
+    return { audience: 'unknown', label: null };
   }
 
   const planType = (quota as { planType?: unknown }).planType;
   if (typeof planType !== 'string' || planType.trim().length === 0) {
-    return 'unknown';
+    return { audience: 'unknown', label: null };
   }
 
-  if (planType === 'team') return 'business';
-  if (planType === 'free') return 'free';
-  if (planType === 'plus' || planType === 'pro') return 'personal';
-  return 'unknown';
+  if (planType === 'team') {
+    return { audience: 'business', label: 'Business' };
+  }
+
+  if (planType === 'free') {
+    return { audience: 'free', label: 'Free' };
+  }
+
+  if (planType === 'plus') {
+    return { audience: 'personal', label: 'Plus' };
+  }
+
+  if (planType === 'pro') {
+    return { audience: 'personal', label: 'Pro' };
+  }
+
+  return { audience: 'unknown', label: null };
 }
 
-function resolveCodexAudience(
-  identityAudience: AccountAudience,
-  planAudience: AccountAudience
-): AccountAudience {
-  if (planAudience === 'unknown') {
-    return identityAudience;
+function resolveCodexBadge(
+  identityBadge: CodexIdentityBadge,
+  quotaBadge: CodexIdentityBadge
+): CodexIdentityBadge {
+  if (!quotaBadge.label) {
+    return identityBadge;
   }
 
-  if (planAudience === 'business') {
-    return 'business';
+  if (
+    quotaBadge.label === 'Business' ||
+    quotaBadge.label === 'Plus' ||
+    quotaBadge.label === 'Pro'
+  ) {
+    return quotaBadge;
   }
 
-  if (identityAudience === 'business') {
-    return 'business';
+  if (quotaBadge.label === 'Free' && identityBadge.label && identityBadge.label !== 'Free') {
+    return identityBadge;
   }
 
-  if (planAudience === 'personal') {
-    return 'personal';
-  }
-
-  if (planAudience === 'free') {
-    return identityAudience === 'unknown' || identityAudience === 'free'
-      ? 'free'
-      : identityAudience;
-  }
-
-  return identityAudience;
-}
-
-function getCodexPlanDetailLabel(quota: unknown): string | null {
-  if (!quota || typeof quota !== 'object' || !('planType' in quota)) {
-    return null;
-  }
-
-  const planType = (quota as { planType?: unknown }).planType;
-  if (typeof planType !== 'string' || planType.trim().length === 0) {
-    return null;
-  }
-
-  if (planType === 'free' || planType === 'team') {
-    return null;
-  }
-
-  return planType === 'plus' || planType === 'pro'
-    ? planType[0].toUpperCase() + planType.slice(1)
-    : null;
+  return quotaBadge;
 }
 
 function getVariantDetailLabel(
@@ -160,9 +149,32 @@ function getVariantDetailLabel(
   },
   quota?: unknown
 ) {
-  return (
-    variant.detailLabel ?? variant.compactDetailLabel ?? getCodexPlanDetailLabel(quota) ?? null
-  );
+  return resolveCodexBadge(
+    getCodexIdentityBadge({
+      audience: variant.audience,
+      detailLabel: variant.detailLabel,
+      compactDetailLabel: variant.compactDetailLabel,
+    }),
+    getCodexQuotaBadge(quota)
+  ).label;
+}
+
+function getVariantBadgeAudience(
+  variant: {
+    audience: AccountAudience;
+    detailLabel?: string | null;
+    compactDetailLabel?: string | null;
+  },
+  quota?: unknown
+) {
+  return resolveCodexBadge(
+    getCodexIdentityBadge({
+      audience: variant.audience,
+      detailLabel: variant.detailLabel,
+      compactDetailLabel: variant.compactDetailLabel,
+    }),
+    getCodexQuotaBadge(quota)
+  ).audience;
 }
 
 function getVariantCompactDetailLabel(
@@ -173,9 +185,7 @@ function getVariantCompactDetailLabel(
   },
   quota?: unknown
 ) {
-  return (
-    variant.compactDetailLabel ?? variant.detailLabel ?? getCodexPlanDetailLabel(quota) ?? null
-  );
+  return getVariantDetailLabel(variant, quota);
 }
 
 function getDetailedAudienceLabel(audience: AccountAudience): string | null {
@@ -191,7 +201,7 @@ function getVariantAudience(
   },
   quota?: unknown
 ) {
-  return resolveCodexAudience(variant.audience, getCodexPlanAudience(quota));
+  return getVariantBadgeAudience(variant, quota);
 }
 
 function getVariantInlineLabel(
@@ -204,14 +214,7 @@ function getVariantInlineLabel(
   },
   quota?: unknown
 ) {
-  const detailLabel = getVariantDetailLabel(variant, quota);
-  const audience = getVariantAudience(variant, quota);
-  const audienceLabel =
-    variant.audience === audience
-      ? (variant.audienceLabel ?? getDetailedAudienceLabel(audience))
-      : getDetailedAudienceLabel(audience);
-  const composedLabel = [audienceLabel, detailLabel].filter(Boolean).join(' · ');
-  return composedLabel || variant.inlineLabel || null;
+  return getVariantDetailLabel(variant, quota) || variant.inlineLabel || null;
 }
 
 function getVariantMarkerLabel(
@@ -227,8 +230,7 @@ function getVariantMarkerLabel(
   const audience = getVariantAudience(variant, quota);
   const compactDetailLabel = getVariantCompactDetailLabel(variant, quota);
   if (audience === 'business') {
-    const businessVariantCount = audienceCounts.get('business') ?? 0;
-    return businessVariantCount > 1 && compactDetailLabel ? compactDetailLabel : 'Biz';
+    return 'Biz';
   }
   if (audience === 'free') {
     return compactDetailLabel ?? 'Free';
@@ -237,11 +239,7 @@ function getVariantMarkerLabel(
     return compactDetailLabel ?? 'Pers';
   }
 
-  const normalizedFallback =
-    compactDetailLabel?.trim() ||
-    getDetailedAudienceLabel(audience) ||
-    variant.audienceLabel?.trim() ||
-    variant.detailLabel?.trim();
+  const normalizedFallback = compactDetailLabel?.trim() || getDetailedAudienceLabel(audience);
   return normalizedFallback?.[0]?.toUpperCase() ?? '?';
 }
 

--- a/ui/src/components/account/flow-viz/account-card.tsx
+++ b/ui/src/components/account/flow-viz/account-card.tsx
@@ -100,24 +100,53 @@ function getCodexPlanAudience(quota: unknown): AccountAudience {
 
   if (planType === 'team') return 'business';
   if (planType === 'free') return 'free';
-  if (planType === 'plus') return 'personal';
+  if (planType === 'plus' || planType === 'pro') return 'personal';
   return 'unknown';
 }
 
-function getVariantDetailLabel(variant: {
-  audience: AccountAudience;
-  detailLabel?: string | null;
-  compactDetailLabel?: string | null;
-}) {
-  return variant.detailLabel ?? variant.compactDetailLabel ?? null;
+function getCodexPlanDetailLabel(quota: unknown): string | null {
+  if (!quota || typeof quota !== 'object' || !('planType' in quota)) {
+    return null;
+  }
+
+  const planType = (quota as { planType?: unknown }).planType;
+  if (typeof planType !== 'string' || planType.trim().length === 0) {
+    return null;
+  }
+
+  if (planType === 'free' || planType === 'team') {
+    return null;
+  }
+
+  return planType === 'plus' || planType === 'pro'
+    ? planType[0].toUpperCase() + planType.slice(1)
+    : null;
 }
 
-function getVariantCompactDetailLabel(variant: {
-  audience: AccountAudience;
-  compactDetailLabel?: string | null;
-  detailLabel?: string | null;
-}) {
-  return variant.compactDetailLabel ?? variant.detailLabel ?? null;
+function getVariantDetailLabel(
+  variant: {
+    audience: AccountAudience;
+    detailLabel?: string | null;
+    compactDetailLabel?: string | null;
+  },
+  quota?: unknown
+) {
+  return (
+    variant.detailLabel ?? variant.compactDetailLabel ?? getCodexPlanDetailLabel(quota) ?? null
+  );
+}
+
+function getVariantCompactDetailLabel(
+  variant: {
+    audience: AccountAudience;
+    compactDetailLabel?: string | null;
+    detailLabel?: string | null;
+  },
+  quota?: unknown
+) {
+  return (
+    variant.compactDetailLabel ?? variant.detailLabel ?? getCodexPlanDetailLabel(quota) ?? null
+  );
 }
 
 function getDetailedAudienceLabel(audience: AccountAudience): string | null {
@@ -146,7 +175,7 @@ function getVariantInlineLabel(
   },
   quota?: unknown
 ) {
-  const detailLabel = getVariantDetailLabel(variant);
+  const detailLabel = getVariantDetailLabel(variant, quota);
   const audienceLabel =
     variant.audienceLabel ?? getDetailedAudienceLabel(getVariantAudience(variant, quota));
   const composedLabel = [audienceLabel, detailLabel].filter(Boolean).join(' · ');
@@ -164,7 +193,7 @@ function getVariantMarkerLabel(
   quota?: unknown
 ) {
   const audience = getVariantAudience(variant, quota);
-  const compactDetailLabel = getVariantCompactDetailLabel(variant);
+  const compactDetailLabel = getVariantCompactDetailLabel(variant, quota);
   if (audience === 'business') {
     const businessVariantCount = audienceCounts.get('business') ?? 0;
     return businessVariantCount > 1 && compactDetailLabel ? compactDetailLabel : 'Biz';
@@ -197,7 +226,7 @@ function getGroupedVariantSummaryLabel(
   const audiences = new Set(variants.map((variant) => variant.audience));
   const hasDistinctDetails = variants.some((variant, index) =>
     Boolean(
-      getVariantCompactDetailLabel(variant) ||
+      getVariantCompactDetailLabel(variant, quotas[index]) ||
       getDetailedAudienceLabel(getVariantAudience(variant, quotas[index]))
     )
   );

--- a/ui/src/components/account/flow-viz/account-card.tsx
+++ b/ui/src/components/account/flow-viz/account-card.tsx
@@ -13,7 +13,6 @@ import {
   getProviderResetTime,
   getQuotaFailureInfo,
 } from '@/lib/utils';
-import { formatAccountVariantPart } from '@/lib/account-identity';
 import { GripVertical, Loader2, Pause, Play } from 'lucide-react';
 import {
   useAccountQuota,
@@ -28,6 +27,7 @@ import { AccountCardStats } from './account-card-stats';
 import { cleanEmail } from './utils';
 
 type Zone = 'left' | 'right' | 'top' | 'bottom';
+type AccountAudience = 'business' | 'free' | 'personal' | 'unknown';
 
 const QUOTA_PROVIDER_ALIASES = [
   'antigravity',
@@ -88,46 +88,57 @@ function getCompactQuotaColor(percentage: number) {
   return 'bg-red-500';
 }
 
-function getCodexPlanDetailLabel(quota: unknown): string | null {
+function getCodexPlanAudience(quota: unknown): AccountAudience {
   if (!quota || typeof quota !== 'object' || !('planType' in quota)) {
-    return null;
+    return 'unknown';
   }
 
   const planType = (quota as { planType?: unknown }).planType;
   if (typeof planType !== 'string' || planType.trim().length === 0) {
-    return null;
+    return 'unknown';
   }
 
-  return formatAccountVariantPart(planType);
+  if (planType === 'team') return 'business';
+  if (planType === 'free') return 'free';
+  if (planType === 'plus') return 'personal';
+  return 'unknown';
 }
 
-function getVariantDetailLabel(
+function getVariantDetailLabel(variant: {
+  audience: AccountAudience;
+  detailLabel?: string | null;
+  compactDetailLabel?: string | null;
+}) {
+  return variant.detailLabel ?? variant.compactDetailLabel ?? null;
+}
+
+function getVariantCompactDetailLabel(variant: {
+  audience: AccountAudience;
+  compactDetailLabel?: string | null;
+  detailLabel?: string | null;
+}) {
+  return variant.compactDetailLabel ?? variant.detailLabel ?? null;
+}
+
+function getDetailedAudienceLabel(audience: AccountAudience): string | null {
+  if (audience === 'business') return 'Business';
+  if (audience === 'free') return 'Free';
+  if (audience === 'personal') return 'Personal';
+  return null;
+}
+
+function getVariantAudience(
   variant: {
-    audience: string;
-    detailLabel?: string | null;
-    compactDetailLabel?: string | null;
+    audience: AccountAudience;
   },
   quota?: unknown
 ) {
-  const codexPlanDetail = getCodexPlanDetailLabel(quota);
-  return variant.detailLabel ?? variant.compactDetailLabel ?? codexPlanDetail;
-}
-
-function getVariantCompactDetailLabel(
-  variant: {
-    audience: string;
-    compactDetailLabel?: string | null;
-    detailLabel?: string | null;
-  },
-  quota?: unknown
-) {
-  const codexPlanDetail = getCodexPlanDetailLabel(quota);
-  return variant.compactDetailLabel ?? variant.detailLabel ?? codexPlanDetail;
+  return variant.audience !== 'unknown' ? variant.audience : getCodexPlanAudience(quota);
 }
 
 function getVariantInlineLabel(
   variant: {
-    audience: string;
+    audience: AccountAudience;
     audienceLabel?: string | null;
     detailLabel?: string | null;
     compactDetailLabel?: string | null;
@@ -135,14 +146,16 @@ function getVariantInlineLabel(
   },
   quota?: unknown
 ) {
-  const detailLabel = getVariantDetailLabel(variant, quota);
-  const composedLabel = [variant.audienceLabel, detailLabel].filter(Boolean).join(' · ');
+  const detailLabel = getVariantDetailLabel(variant);
+  const audienceLabel =
+    variant.audienceLabel ?? getDetailedAudienceLabel(getVariantAudience(variant, quota));
+  const composedLabel = [audienceLabel, detailLabel].filter(Boolean).join(' · ');
   return composedLabel || variant.inlineLabel || null;
 }
 
 function getVariantMarkerLabel(
   variant: {
-    audience: string;
+    audience: AccountAudience;
     audienceLabel?: string | null;
     detailLabel?: string | null;
     compactDetailLabel?: string | null;
@@ -150,23 +163,30 @@ function getVariantMarkerLabel(
   audienceCounts: Map<string, number>,
   quota?: unknown
 ) {
-  const compactDetailLabel = getVariantCompactDetailLabel(variant, quota);
-  if (variant.audience === 'business') {
+  const audience = getVariantAudience(variant, quota);
+  const compactDetailLabel = getVariantCompactDetailLabel(variant);
+  if (audience === 'business') {
     const businessVariantCount = audienceCounts.get('business') ?? 0;
     return businessVariantCount > 1 && compactDetailLabel ? compactDetailLabel : 'Biz';
   }
-  if (variant.audience === 'personal') {
+  if (audience === 'free') {
+    return compactDetailLabel ?? 'Free';
+  }
+  if (audience === 'personal') {
     return compactDetailLabel ?? 'Pers';
   }
 
   const normalizedFallback =
-    compactDetailLabel?.trim() || variant.audienceLabel?.trim() || variant.detailLabel?.trim();
+    compactDetailLabel?.trim() ||
+    variant.audienceLabel?.trim() ||
+    getDetailedAudienceLabel(audience) ||
+    variant.detailLabel?.trim();
   return normalizedFallback?.[0]?.toUpperCase() ?? '?';
 }
 
 function getGroupedVariantSummaryLabel(
   variants: Array<{
-    audience: string;
+    audience: AccountAudience;
     audienceLabel?: string | null;
     detailLabel?: string | null;
     compactDetailLabel?: string | null;
@@ -176,7 +196,10 @@ function getGroupedVariantSummaryLabel(
 ) {
   const audiences = new Set(variants.map((variant) => variant.audience));
   const hasDistinctDetails = variants.some((variant, index) =>
-    Boolean(getVariantCompactDetailLabel(variant, quotas[index]))
+    Boolean(
+      getVariantCompactDetailLabel(variant) ||
+      getDetailedAudienceLabel(getVariantAudience(variant, quotas[index]))
+    )
   );
 
   if (
@@ -274,9 +297,11 @@ export function AccountCard({
                 index > 0 && 'border-l border-border/50',
                 variant.audience === 'business'
                   ? 'bg-sky-500/12 text-sky-700 dark:bg-sky-500/20 dark:text-sky-300'
-                  : variant.audience === 'personal'
-                    ? 'bg-emerald-500/12 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
-                    : 'bg-muted text-muted-foreground'
+                  : variant.audience === 'free'
+                    ? 'bg-slate-200/70 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200'
+                    : variant.audience === 'personal'
+                      ? 'bg-emerald-500/12 text-emerald-700 dark:bg-emerald-500/20 dark:text-emerald-300'
+                      : 'bg-muted text-muted-foreground'
               )}
             >
               {getVariantMarkerLabel(

--- a/ui/src/components/account/flow-viz/account-card.tsx
+++ b/ui/src/components/account/flow-viz/account-card.tsx
@@ -152,8 +152,8 @@ function getVariantDetailLabel(
   return resolveCodexBadge(
     getCodexIdentityBadge({
       audience: variant.audience,
-      detailLabel: variant.detailLabel,
-      compactDetailLabel: variant.compactDetailLabel,
+      detailLabel: variant.detailLabel ?? null,
+      compactDetailLabel: variant.compactDetailLabel ?? null,
     }),
     getCodexQuotaBadge(quota)
   ).label;
@@ -170,8 +170,8 @@ function getVariantBadgeAudience(
   return resolveCodexBadge(
     getCodexIdentityBadge({
       audience: variant.audience,
-      detailLabel: variant.detailLabel,
-      compactDetailLabel: variant.compactDetailLabel,
+      detailLabel: variant.detailLabel ?? null,
+      compactDetailLabel: variant.compactDetailLabel ?? null,
     }),
     getCodexQuotaBadge(quota)
   ).audience;
@@ -224,7 +224,6 @@ function getVariantMarkerLabel(
     detailLabel?: string | null;
     compactDetailLabel?: string | null;
   },
-  audienceCounts: Map<string, number>,
   quota?: unknown
 ) {
   const audience = getVariantAudience(variant, quota);
@@ -250,8 +249,7 @@ function getGroupedVariantSummaryLabel(
     detailLabel?: string | null;
     compactDetailLabel?: string | null;
   }>,
-  quotas: Array<unknown>,
-  audienceCounts: Map<string, number>
+  quotas: Array<unknown>
 ) {
   const audiences = new Set(variants.map((variant) => variant.audience));
   const hasDistinctDetails = variants.some((variant, index) =>
@@ -273,7 +271,7 @@ function getGroupedVariantSummaryLabel(
 
   if (variants.length === 1) {
     const [variant] = variants;
-    return getVariantMarkerLabel(variant, audienceCounts, quotas[0]);
+    return getVariantMarkerLabel(variant, quotas[0]);
   }
 
   return null;
@@ -321,14 +319,9 @@ export function AccountCard({
   const groupedVariantQuotas = groupedHeaderVariants.map(
     (_, index) => variantQuotaQueries[index]?.data
   );
-  const groupedVariantAudienceCounts = groupedHeaderVariants.reduce((counts, variant) => {
-    counts.set(variant.audience, (counts.get(variant.audience) ?? 0) + 1);
-    return counts;
-  }, new Map<string, number>());
   const groupedVariantSummaryLabel = getGroupedVariantSummaryLabel(
     groupedHeaderVariants,
-    groupedVariantQuotas,
-    groupedVariantAudienceCounts
+    groupedVariantQuotas
   );
 
   const compactMetaBadges = hasGroupedVariants ? (
@@ -363,11 +356,7 @@ export function AccountCard({
                       : 'bg-muted text-muted-foreground'
               )}
             >
-              {getVariantMarkerLabel(
-                variant,
-                groupedVariantAudienceCounts,
-                groupedVariantQuotas[index]
-              )}
+              {getVariantMarkerLabel(variant, groupedVariantQuotas[index])}
             </span>
           ))
         )}

--- a/ui/src/components/account/shared/account-surface-card.tsx
+++ b/ui/src/components/account/shared/account-surface-card.tsx
@@ -113,6 +113,35 @@ function getCodexPlanAudience(quota: UnifiedQuotaResult | undefined): AccountAud
   return 'unknown';
 }
 
+function resolveCodexAudience(
+  identityAudience: AccountAudience,
+  planAudience: AccountAudience
+): AccountAudience {
+  if (planAudience === 'unknown') {
+    return identityAudience;
+  }
+
+  if (planAudience === 'business') {
+    return 'business';
+  }
+
+  if (identityAudience === 'business') {
+    return 'business';
+  }
+
+  if (planAudience === 'personal') {
+    return 'personal';
+  }
+
+  if (planAudience === 'free') {
+    return identityAudience === 'unknown' || identityAudience === 'free'
+      ? 'free'
+      : identityAudience;
+  }
+
+  return identityAudience;
+}
+
 function getCodexPlanDetailLabel(quota: UnifiedQuotaResult | undefined): string | null {
   if (!quota || !('planType' in quota) || !quota.planType) {
     return null;
@@ -157,9 +186,16 @@ export function AccountSurfaceCard({
     normalizedProvider === 'codex' ? getCodexPlanAudience(quota) : 'unknown';
   const codexPlanDetailLabel =
     normalizedProvider === 'codex' ? getCodexPlanDetailLabel(quota) : null;
-  const effectiveAudience = identity.audience !== 'unknown' ? identity.audience : codexPlanAudience;
+  const effectiveAudience =
+    normalizedProvider === 'codex'
+      ? resolveCodexAudience(identity.audience, codexPlanAudience)
+      : identity.audience !== 'unknown'
+        ? identity.audience
+        : codexPlanAudience;
   const effectiveAudienceLabel =
-    identity.audienceLabel ?? getDetailedAudienceLabel(effectiveAudience);
+    identity.audience === effectiveAudience
+      ? (identity.audienceLabel ?? getDetailedAudienceLabel(effectiveAudience))
+      : getDetailedAudienceLabel(effectiveAudience);
   const resolvedDetailLabel = identity.detailLabel ?? codexPlanDetailLabel;
   const resolvedCompactDetailLabel = identity.compactDetailLabel ?? codexPlanDetailLabel;
   const showTierBadge =

--- a/ui/src/components/account/shared/account-surface-card.tsx
+++ b/ui/src/components/account/shared/account-surface-card.tsx
@@ -2,7 +2,11 @@ import type { ReactNode } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { PRIVACY_BLUR_CLASS } from '@/contexts/privacy-context';
 import type { UnifiedQuotaResult } from '@/hooks/use-cliproxy-stats';
-import { formatAccountVariantPart, getAccountIdentityPresentation } from '@/lib/account-identity';
+import {
+  getAccountIdentityPresentation,
+  getCodexIdentityBadge,
+  type CodexIdentityBadge,
+} from '@/lib/account-identity';
 import { cn } from '@/lib/utils';
 import { Pause, Star, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -66,13 +70,6 @@ function getCompactAudienceBadgeLabel(audience: AccountAudience, t: (key: string
   return '?';
 }
 
-function getDetailedAudienceLabel(audience: AccountAudience): string | null {
-  if (audience === 'business') return 'Business';
-  if (audience === 'free') return 'Free';
-  if (audience === 'personal') return 'Personal';
-  return null;
-}
-
 function getCompactDetailBadgeClass(audience: AccountAudience) {
   if (audience === 'business') {
     return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:border-sky-400/30 dark:bg-sky-500/15 dark:text-sky-200';
@@ -102,56 +99,51 @@ function resolveEffectiveTier(
   return tier;
 }
 
-function getCodexPlanAudience(quota: UnifiedQuotaResult | undefined): AccountAudience {
+function getCodexQuotaBadge(quota: UnifiedQuotaResult | undefined): CodexIdentityBadge {
   if (!quota || !('planType' in quota) || !quota.planType) {
-    return 'unknown';
+    return { audience: 'unknown', label: null };
   }
 
-  if (quota.planType === 'team') return 'business';
-  if (quota.planType === 'free') return 'free';
-  if (quota.planType === 'plus' || quota.planType === 'pro') return 'personal';
-  return 'unknown';
+  if (quota.planType === 'team') {
+    return { audience: 'business', label: 'Business' };
+  }
+
+  if (quota.planType === 'free') {
+    return { audience: 'free', label: 'Free' };
+  }
+
+  if (quota.planType === 'plus') {
+    return { audience: 'personal', label: 'Plus' };
+  }
+
+  if (quota.planType === 'pro') {
+    return { audience: 'personal', label: 'Pro' };
+  }
+
+  return { audience: 'unknown', label: null };
 }
 
-function resolveCodexAudience(
-  identityAudience: AccountAudience,
-  planAudience: AccountAudience
-): AccountAudience {
-  if (planAudience === 'unknown') {
-    return identityAudience;
+function resolveCodexBadge(
+  identityBadge: CodexIdentityBadge,
+  quotaBadge: CodexIdentityBadge
+): CodexIdentityBadge {
+  if (!quotaBadge.label) {
+    return identityBadge;
   }
 
-  if (planAudience === 'business') {
-    return 'business';
+  if (
+    quotaBadge.label === 'Business' ||
+    quotaBadge.label === 'Plus' ||
+    quotaBadge.label === 'Pro'
+  ) {
+    return quotaBadge;
   }
 
-  if (identityAudience === 'business') {
-    return 'business';
+  if (quotaBadge.label === 'Free' && identityBadge.label && identityBadge.label !== 'Free') {
+    return identityBadge;
   }
 
-  if (planAudience === 'personal') {
-    return 'personal';
-  }
-
-  if (planAudience === 'free') {
-    return identityAudience === 'unknown' || identityAudience === 'free'
-      ? 'free'
-      : identityAudience;
-  }
-
-  return identityAudience;
-}
-
-function getCodexPlanDetailLabel(quota: UnifiedQuotaResult | undefined): string | null {
-  if (!quota || !('planType' in quota) || !quota.planType) {
-    return null;
-  }
-
-  if (quota.planType === 'free' || quota.planType === 'team') {
-    return null;
-  }
-
-  return formatAccountVariantPart(quota.planType);
+  return quotaBadge;
 }
 
 export function AccountSurfaceCard({
@@ -182,22 +174,10 @@ export function AccountSurfaceCard({
   const title = displayEmail || identity.email || accountId;
   const normalizedProvider = provider.toLowerCase();
   const effectiveTier = resolveEffectiveTier(tier, quota);
-  const codexPlanAudience =
-    normalizedProvider === 'codex' ? getCodexPlanAudience(quota) : 'unknown';
-  const codexPlanDetailLabel =
-    normalizedProvider === 'codex' ? getCodexPlanDetailLabel(quota) : null;
-  const effectiveAudience =
+  const effectiveCodexBadge =
     normalizedProvider === 'codex'
-      ? resolveCodexAudience(identity.audience, codexPlanAudience)
-      : identity.audience !== 'unknown'
-        ? identity.audience
-        : codexPlanAudience;
-  const effectiveAudienceLabel =
-    identity.audience === effectiveAudience
-      ? (identity.audienceLabel ?? getDetailedAudienceLabel(effectiveAudience))
-      : getDetailedAudienceLabel(effectiveAudience);
-  const resolvedDetailLabel = identity.detailLabel ?? codexPlanDetailLabel;
-  const resolvedCompactDetailLabel = identity.compactDetailLabel ?? codexPlanDetailLabel;
+      ? resolveCodexBadge(getCodexIdentityBadge(identity), getCodexQuotaBadge(quota))
+      : null;
   const showTierBadge =
     (normalizedProvider === 'agy' ||
       normalizedProvider === 'antigravity' ||
@@ -218,26 +198,38 @@ export function AccountSurfaceCard({
           {effectiveTier}
         </span>
       )}
-      {effectiveAudienceLabel && (
-        <span
-          title={effectiveAudienceLabel}
-          className={cn(
-            'text-[8px] font-semibold px-1.5 py-0.5 rounded-md shrink-0',
-            getAudienceBadgeClass(effectiveAudience)
+      {normalizedProvider === 'codex'
+        ? effectiveCodexBadge?.label && (
+            <span
+              title={effectiveCodexBadge.label}
+              className={cn(
+                'text-[8px] font-semibold px-1.5 py-0.5 rounded-md border shrink-0',
+                getCompactDetailBadgeClass(effectiveCodexBadge.audience)
+              )}
+            >
+              {effectiveCodexBadge.label}
+            </span>
+          )
+        : identity.audienceLabel && (
+            <span
+              title={identity.audienceLabel}
+              className={cn(
+                'text-[8px] font-semibold px-1.5 py-0.5 rounded-md shrink-0',
+                getAudienceBadgeClass(identity.audience)
+              )}
+            >
+              {getCompactAudienceBadgeLabel(identity.audience, t)}
+            </span>
           )}
-        >
-          {getCompactAudienceBadgeLabel(effectiveAudience, t)}
-        </span>
-      )}
-      {resolvedCompactDetailLabel && (
+      {normalizedProvider !== 'codex' && identity.compactDetailLabel && (
         <span
-          title={resolvedDetailLabel ?? resolvedCompactDetailLabel}
+          title={identity.detailLabel ?? identity.compactDetailLabel}
           className={cn(
             'text-[8px] font-semibold px-1.5 py-0.5 rounded-md border shrink-0',
-            getCompactDetailBadgeClass(effectiveAudience)
+            getCompactDetailBadgeClass(identity.audience)
           )}
         >
-          {resolvedCompactDetailLabel}
+          {identity.compactDetailLabel}
         </span>
       )}
       {paused && (
@@ -295,20 +287,31 @@ export function AccountSurfaceCard({
                 {title}
               </span>
               {isCompact && (compactMetaBadges ?? defaultCompactMetaBadges)}
-              {!isCompact && effectiveAudienceLabel && (
+              {!isCompact && normalizedProvider === 'codex' && effectiveCodexBadge?.label && (
                 <Badge
                   variant="outline"
                   className={cn(
                     'text-[10px] h-4 px-1.5 border-transparent',
-                    getAudienceBadgeClass(effectiveAudience)
+                    getAudienceBadgeClass(effectiveCodexBadge.audience)
                   )}
                 >
-                  {effectiveAudienceLabel}
+                  {effectiveCodexBadge.label}
                 </Badge>
               )}
-              {!isCompact && resolvedDetailLabel && (
+              {!isCompact && normalizedProvider !== 'codex' && identity.audienceLabel && (
+                <Badge
+                  variant="outline"
+                  className={cn(
+                    'text-[10px] h-4 px-1.5 border-transparent',
+                    getAudienceBadgeClass(identity.audience)
+                  )}
+                >
+                  {identity.audienceLabel}
+                </Badge>
+              )}
+              {!isCompact && normalizedProvider !== 'codex' && identity.detailLabel && (
                 <Badge variant="outline" className="text-[10px] h-4 px-1.5">
-                  {resolvedDetailLabel}
+                  {identity.detailLabel}
                 </Badge>
               )}
               {!isCompact && isDefault && (

--- a/ui/src/components/account/shared/account-surface-card.tsx
+++ b/ui/src/components/account/shared/account-surface-card.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { PRIVACY_BLUR_CLASS } from '@/contexts/privacy-context';
 import type { UnifiedQuotaResult } from '@/hooks/use-cliproxy-stats';
-import { formatAccountVariantPart, getAccountIdentityPresentation } from '@/lib/account-identity';
+import { getAccountIdentityPresentation } from '@/lib/account-identity';
 import { cn } from '@/lib/utils';
 import { Pause, Star, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { AccountQuotaPanel } from './account-quota-panel';
 
 type AccountSurfaceMode = 'compact' | 'detailed';
+type AccountAudience = 'business' | 'free' | 'personal' | 'unknown';
 type AccountTier = 'free' | 'pro' | 'ultra' | 'unknown';
 
 interface AccountSurfaceCardProps {
@@ -36,9 +37,13 @@ interface AccountSurfaceCardProps {
   className?: string;
 }
 
-function getAudienceBadgeClass(audience: 'business' | 'personal' | 'unknown') {
+function getAudienceBadgeClass(audience: AccountAudience) {
   if (audience === 'business') {
     return 'bg-sky-500/12 text-sky-700 dark:text-sky-300';
+  }
+
+  if (audience === 'free') {
+    return 'bg-slate-200/70 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200';
   }
 
   if (audience === 'personal') {
@@ -54,18 +59,27 @@ function getTierBadgeClass(tier: AccountTier | undefined) {
     : 'bg-yellow-500/15 text-yellow-700 dark:bg-yellow-500/20 dark:text-yellow-400';
 }
 
-function getCompactAudienceBadgeLabel(
-  audience: 'business' | 'personal' | 'unknown',
-  t: (key: string) => string
-) {
+function getCompactAudienceBadgeLabel(audience: AccountAudience, t: (key: string) => string) {
   if (audience === 'business') return t('accountSurfaceCard.business');
+  if (audience === 'free') return t('accountSurfaceCard.free');
   if (audience === 'personal') return t('accountSurfaceCard.personal');
   return '?';
 }
 
-function getCompactDetailBadgeClass(audience: 'business' | 'personal' | 'unknown') {
+function getDetailedAudienceLabel(audience: AccountAudience): string | null {
+  if (audience === 'business') return 'Business';
+  if (audience === 'free') return 'Free';
+  if (audience === 'personal') return 'Personal';
+  return null;
+}
+
+function getCompactDetailBadgeClass(audience: AccountAudience) {
   if (audience === 'business') {
     return 'border-sky-500/30 bg-sky-500/10 text-sky-700 dark:border-sky-400/30 dark:bg-sky-500/15 dark:text-sky-200';
+  }
+
+  if (audience === 'free') {
+    return 'border-slate-300/70 bg-slate-100/80 text-slate-700 dark:border-slate-500/40 dark:bg-slate-700/30 dark:text-slate-200';
   }
 
   if (audience === 'personal') {
@@ -88,12 +102,15 @@ function resolveEffectiveTier(
   return tier;
 }
 
-function getCodexPlanDetailLabel(quota: UnifiedQuotaResult | undefined): string | null {
+function getCodexPlanAudience(quota: UnifiedQuotaResult | undefined): AccountAudience {
   if (!quota || !('planType' in quota) || !quota.planType) {
-    return null;
+    return 'unknown';
   }
 
-  return formatAccountVariantPart(quota.planType);
+  if (quota.planType === 'team') return 'business';
+  if (quota.planType === 'free') return 'free';
+  if (quota.planType === 'plus') return 'personal';
+  return 'unknown';
 }
 
 export function AccountSurfaceCard({
@@ -124,10 +141,13 @@ export function AccountSurfaceCard({
   const title = displayEmail || identity.email || accountId;
   const normalizedProvider = provider.toLowerCase();
   const effectiveTier = resolveEffectiveTier(tier, quota);
-  const codexPlanDetailLabel =
-    normalizedProvider === 'codex' ? getCodexPlanDetailLabel(quota) : null;
-  const resolvedDetailLabel = identity.detailLabel ?? codexPlanDetailLabel;
-  const resolvedCompactDetailLabel = identity.compactDetailLabel ?? codexPlanDetailLabel;
+  const codexPlanAudience =
+    normalizedProvider === 'codex' ? getCodexPlanAudience(quota) : 'unknown';
+  const effectiveAudience = identity.audience !== 'unknown' ? identity.audience : codexPlanAudience;
+  const effectiveAudienceLabel =
+    identity.audienceLabel ?? getDetailedAudienceLabel(effectiveAudience);
+  const resolvedDetailLabel = identity.detailLabel;
+  const resolvedCompactDetailLabel = identity.compactDetailLabel;
   const showTierBadge =
     (normalizedProvider === 'agy' ||
       normalizedProvider === 'antigravity' ||
@@ -148,17 +168,15 @@ export function AccountSurfaceCard({
           {effectiveTier}
         </span>
       )}
-      {identity.audienceLabel && (
+      {effectiveAudienceLabel && (
         <span
-          title={identity.audienceLabel}
+          title={effectiveAudienceLabel}
           className={cn(
             'text-[8px] font-semibold px-1.5 py-0.5 rounded-md shrink-0',
-            identity.audience === 'business'
-              ? 'bg-sky-500/15 text-sky-700 dark:bg-sky-500/25 dark:text-sky-300'
-              : 'bg-emerald-500/15 text-emerald-700 dark:bg-emerald-500/25 dark:text-emerald-300'
+            getAudienceBadgeClass(effectiveAudience)
           )}
         >
-          {getCompactAudienceBadgeLabel(identity.audience, t)}
+          {getCompactAudienceBadgeLabel(effectiveAudience, t)}
         </span>
       )}
       {resolvedCompactDetailLabel && (
@@ -166,7 +184,7 @@ export function AccountSurfaceCard({
           title={resolvedDetailLabel ?? resolvedCompactDetailLabel}
           className={cn(
             'text-[8px] font-semibold px-1.5 py-0.5 rounded-md border shrink-0',
-            getCompactDetailBadgeClass(identity.audience)
+            getCompactDetailBadgeClass(effectiveAudience)
           )}
         >
           {resolvedCompactDetailLabel}
@@ -227,15 +245,15 @@ export function AccountSurfaceCard({
                 {title}
               </span>
               {isCompact && (compactMetaBadges ?? defaultCompactMetaBadges)}
-              {!isCompact && identity.audienceLabel && (
+              {!isCompact && effectiveAudienceLabel && (
                 <Badge
                   variant="outline"
                   className={cn(
                     'text-[10px] h-4 px-1.5 border-transparent',
-                    getAudienceBadgeClass(identity.audience)
+                    getAudienceBadgeClass(effectiveAudience)
                   )}
                 >
-                  {identity.audienceLabel}
+                  {effectiveAudienceLabel}
                 </Badge>
               )}
               {!isCompact && resolvedDetailLabel && (

--- a/ui/src/components/account/shared/account-surface-card.tsx
+++ b/ui/src/components/account/shared/account-surface-card.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { PRIVACY_BLUR_CLASS } from '@/contexts/privacy-context';
 import type { UnifiedQuotaResult } from '@/hooks/use-cliproxy-stats';
-import { getAccountIdentityPresentation } from '@/lib/account-identity';
+import { formatAccountVariantPart, getAccountIdentityPresentation } from '@/lib/account-identity';
 import { cn } from '@/lib/utils';
 import { Pause, Star, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -109,8 +109,20 @@ function getCodexPlanAudience(quota: UnifiedQuotaResult | undefined): AccountAud
 
   if (quota.planType === 'team') return 'business';
   if (quota.planType === 'free') return 'free';
-  if (quota.planType === 'plus') return 'personal';
+  if (quota.planType === 'plus' || quota.planType === 'pro') return 'personal';
   return 'unknown';
+}
+
+function getCodexPlanDetailLabel(quota: UnifiedQuotaResult | undefined): string | null {
+  if (!quota || !('planType' in quota) || !quota.planType) {
+    return null;
+  }
+
+  if (quota.planType === 'free' || quota.planType === 'team') {
+    return null;
+  }
+
+  return formatAccountVariantPart(quota.planType);
 }
 
 export function AccountSurfaceCard({
@@ -143,11 +155,13 @@ export function AccountSurfaceCard({
   const effectiveTier = resolveEffectiveTier(tier, quota);
   const codexPlanAudience =
     normalizedProvider === 'codex' ? getCodexPlanAudience(quota) : 'unknown';
+  const codexPlanDetailLabel =
+    normalizedProvider === 'codex' ? getCodexPlanDetailLabel(quota) : null;
   const effectiveAudience = identity.audience !== 'unknown' ? identity.audience : codexPlanAudience;
   const effectiveAudienceLabel =
     identity.audienceLabel ?? getDetailedAudienceLabel(effectiveAudience);
-  const resolvedDetailLabel = identity.detailLabel;
-  const resolvedCompactDetailLabel = identity.compactDetailLabel;
+  const resolvedDetailLabel = identity.detailLabel ?? codexPlanDetailLabel;
+  const resolvedCompactDetailLabel = identity.compactDetailLabel ?? codexPlanDetailLabel;
   const showTierBadge =
     (normalizedProvider === 'agy' ||
       normalizedProvider === 'antigravity' ||

--- a/ui/src/components/setup/wizard/steps/account-step.tsx
+++ b/ui/src/components/setup/wizard/steps/account-step.tsx
@@ -5,7 +5,7 @@
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ChevronRight, ArrowLeft, User, ExternalLink } from 'lucide-react';
-import { getAccountIdentityPresentation } from '@/lib/account-identity';
+import { getAccountIdentityPresentation, getCodexIdentityBadge } from '@/lib/account-identity';
 import { cn } from '@/lib/utils';
 import { PRIVACY_BLUR_CLASS } from '@/contexts/privacy-context';
 import type { AccountStepProps } from '../types';
@@ -30,6 +30,8 @@ export function AccountStep({
       <div className="grid gap-2 max-h-[320px] overflow-y-auto pr-1">
         {accounts.map((acc) => {
           const identity = getAccountIdentityPresentation(acc.id, acc.email, acc.tokenFile);
+          const codexBadge =
+            acc.provider?.toLowerCase() === 'codex' ? getCodexIdentityBadge(identity) : null;
           return (
             <button
               key={acc.id}
@@ -46,7 +48,21 @@ export function AccountStep({
                     {identity.email}
                   </div>
                   <div className="flex items-center gap-1.5 flex-wrap">
-                    {identity.audienceLabel && (
+                    {codexBadge?.label ? (
+                      <Badge
+                        variant="outline"
+                        className={cn(
+                          'text-[10px] h-4 px-1.5 border-transparent',
+                          codexBadge.audience === 'business'
+                            ? 'bg-sky-500/12 text-sky-700 dark:text-sky-300'
+                            : codexBadge.audience === 'free'
+                              ? 'bg-slate-200/70 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200'
+                              : 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
+                        )}
+                      >
+                        {codexBadge.label}
+                      </Badge>
+                    ) : identity.audienceLabel ? (
                       <Badge
                         variant="outline"
                         className={cn(
@@ -60,8 +76,8 @@ export function AccountStep({
                       >
                         {identity.audienceLabel}
                       </Badge>
-                    )}
-                    {identity.detailLabel && (
+                    ) : null}
+                    {!codexBadge?.label && identity.detailLabel && (
                       <Badge variant="outline" className="text-[10px] h-4 px-1.5">
                         {identity.detailLabel}
                       </Badge>

--- a/ui/src/components/setup/wizard/steps/account-step.tsx
+++ b/ui/src/components/setup/wizard/steps/account-step.tsx
@@ -53,7 +53,9 @@ export function AccountStep({
                           'text-[10px] h-4 px-1.5 border-transparent',
                           identity.audience === 'business'
                             ? 'bg-sky-500/12 text-sky-700 dark:text-sky-300'
-                            : 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
+                            : identity.audience === 'free'
+                              ? 'bg-slate-200/70 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200'
+                              : 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
                         )}
                       >
                         {identity.audienceLabel}

--- a/ui/src/components/setup/wizard/steps/variant-step.tsx
+++ b/ui/src/components/setup/wizard/steps/variant-step.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { getAccountIdentityPresentation } from '@/lib/account-identity';
+import { getAccountIdentityPresentation, getCodexIdentityBadge } from '@/lib/account-identity';
 import {
   Select,
   SelectContent,
@@ -55,6 +55,10 @@ export function VariantStep({
         selectedAccount.tokenFile
       )
     : null;
+  const selectedCodexBadge =
+    selectedProvider === 'codex' && selectedAccountIdentity
+      ? getCodexIdentityBadge(selectedAccountIdentity)
+      : null;
 
   const handleModelSelect = (value: string) => {
     if (value === CUSTOM_MODEL_VALUE) {
@@ -80,7 +84,21 @@ export function VariantStep({
             </span>
             {(selectedAccountIdentity?.audienceLabel || selectedAccountIdentity?.detailLabel) && (
               <div className="flex items-center gap-1.5 flex-wrap">
-                {selectedAccountIdentity?.audienceLabel && (
+                {selectedCodexBadge?.label ? (
+                  <Badge
+                    variant="outline"
+                    className={cn(
+                      'text-[10px] h-4 px-1.5 border-transparent',
+                      selectedCodexBadge.audience === 'business'
+                        ? 'bg-sky-500/12 text-sky-700 dark:text-sky-300'
+                        : selectedCodexBadge.audience === 'free'
+                          ? 'bg-slate-200/70 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200'
+                          : 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
+                    )}
+                  >
+                    {selectedCodexBadge.label}
+                  </Badge>
+                ) : selectedAccountIdentity?.audienceLabel ? (
                   <Badge
                     variant="outline"
                     className={cn(
@@ -94,8 +112,8 @@ export function VariantStep({
                   >
                     {selectedAccountIdentity.audienceLabel}
                   </Badge>
-                )}
-                {selectedAccountIdentity?.detailLabel && (
+                ) : null}
+                {!selectedCodexBadge?.label && selectedAccountIdentity?.detailLabel && (
                   <Badge variant="outline" className="text-[10px] h-4 px-1.5">
                     {selectedAccountIdentity.detailLabel}
                   </Badge>

--- a/ui/src/components/setup/wizard/steps/variant-step.tsx
+++ b/ui/src/components/setup/wizard/steps/variant-step.tsx
@@ -87,7 +87,9 @@ export function VariantStep({
                       'text-[10px] h-4 px-1.5 border-transparent',
                       selectedAccountIdentity.audience === 'business'
                         ? 'bg-sky-500/12 text-sky-700 dark:text-sky-300'
-                        : 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
+                        : selectedAccountIdentity.audience === 'free'
+                          ? 'bg-slate-200/70 text-slate-700 dark:bg-slate-700/40 dark:text-slate-200'
+                          : 'bg-emerald-500/12 text-emerald-700 dark:text-emerald-300'
                     )}
                   >
                     {selectedAccountIdentity.audienceLabel}

--- a/ui/src/lib/account-identity.ts
+++ b/ui/src/lib/account-identity.ts
@@ -16,6 +16,11 @@ export interface AccountIdentityPresentation {
   inlineLabel: string | null;
 }
 
+export interface CodexIdentityBadge {
+  audience: AccountAudience;
+  label: string | null;
+}
+
 function normalizeVariantTokenPart(value: string): string {
   return value
     .trim()
@@ -217,6 +222,27 @@ export function formatAccountVariantLabel(
   tokenFile?: string
 ): string | null {
   return getAccountIdentityPresentation(accountId, email, tokenFile).inlineLabel;
+}
+
+export function getCodexIdentityBadge(
+  presentation: Pick<AccountIdentityPresentation, 'audience' | 'detailLabel' | 'compactDetailLabel'>
+): CodexIdentityBadge {
+  if (presentation.audience === 'business') {
+    return { audience: 'business', label: 'Business' };
+  }
+
+  if (presentation.audience === 'free') {
+    return { audience: 'free', label: 'Free' };
+  }
+
+  if (presentation.audience === 'personal') {
+    return {
+      audience: 'personal',
+      label: presentation.compactDetailLabel ?? presentation.detailLabel ?? 'Personal',
+    };
+  }
+
+  return { audience: 'unknown', label: null };
 }
 
 export function formatAccountDisplayName(

--- a/ui/src/lib/account-identity.ts
+++ b/ui/src/lib/account-identity.ts
@@ -186,14 +186,16 @@ export function getAccountIdentityPresentation(
   }
 
   if (suffix && PERSONAL_PLAN_PARTS.has(suffix)) {
-    const detailLabel = formatAudienceDetail(parts.slice(0, -1));
+    const detailLabel = [formatAccountVariantPart(suffix), formatAudienceDetail(parts.slice(0, -1))]
+      .filter(Boolean)
+      .join(' · ');
     const inlineLabel = ['Personal', detailLabel].filter(Boolean).join(' · '); // TODO i18n: missing key for Personal
     return {
       email: resolvedEmail,
       audience: 'personal',
       audienceLabel: 'Personal',
-      detailLabel,
-      compactDetailLabel: detailLabel,
+      detailLabel: detailLabel || formatAccountVariantPart(suffix),
+      compactDetailLabel: detailLabel || formatAccountVariantPart(suffix),
       inlineLabel,
     };
   }

--- a/ui/src/lib/account-identity.ts
+++ b/ui/src/lib/account-identity.ts
@@ -1,3 +1,5 @@
+import i18n from './i18n';
+
 const FREE_PLAN_PARTS = new Set(['free']);
 const PERSONAL_PLAN_PARTS = new Set(['plus', 'pro']);
 const BUSINESS_PLAN_PARTS = new Set(['team']);
@@ -38,13 +40,13 @@ export function formatAccountVariantPart(part: string): string {
 
   switch (normalized) {
     case 'team':
-      return 'Team'; // TODO i18n: missing key for account variant team
+      return i18n.t('accountIdentity.team');
     case 'free':
-      return 'Free'; // TODO i18n: missing key for account variant free
+      return i18n.t('accountIdentity.free');
     case 'plus':
-      return 'Plus'; // TODO i18n: missing key for account variant plus
+      return i18n.t('accountIdentity.plus');
     case 'pro':
-      return 'Pro'; // TODO i18n: missing key for account variant pro
+      return i18n.t('accountIdentity.pro');
     default:
       return /^[a-f0-9]{8}$/i.test(normalized)
         ? normalized
@@ -104,7 +106,7 @@ function formatWorkspaceLabel(parts: string[]): {
   const workspaceId = parts.find((part) => /^[a-f0-9]{8}$/i.test(part));
   if (workspaceId) {
     return {
-      detailLabel: `Workspace ${workspaceId.toLowerCase()}`, // TODO i18n: missing key for workspace label
+      detailLabel: i18n.t('accountIdentity.workspace', { id: workspaceId.toLowerCase() }),
       compactDetailLabel: workspaceId.toLowerCase(),
     };
   }
@@ -166,11 +168,13 @@ export function getAccountIdentityPresentation(
   const suffix = parts[parts.length - 1]?.toLowerCase();
   if (suffix && BUSINESS_PLAN_PARTS.has(suffix)) {
     const workspace = formatWorkspaceLabel(parts.slice(0, -1));
-    const inlineLabel = ['Business', workspace.detailLabel].filter(Boolean).join(' · '); // TODO i18n: missing keys for Business/Personal audience labels
+    const inlineLabel = [i18n.t('accountIdentity.business'), workspace.detailLabel]
+      .filter(Boolean)
+      .join(' · ');
     return {
       email: resolvedEmail,
       audience: 'business',
-      audienceLabel: 'Business',
+      audienceLabel: i18n.t('accountIdentity.business'),
       detailLabel: workspace.detailLabel,
       compactDetailLabel: workspace.compactDetailLabel,
       inlineLabel,
@@ -179,11 +183,11 @@ export function getAccountIdentityPresentation(
 
   if (suffix && FREE_PLAN_PARTS.has(suffix)) {
     const detailLabel = formatAudienceDetail(parts.slice(0, -1));
-    const inlineLabel = ['Free', detailLabel].filter(Boolean).join(' · '); // TODO i18n: missing key for Free
+    const inlineLabel = [i18n.t('accountIdentity.free'), detailLabel].filter(Boolean).join(' · ');
     return {
       email: resolvedEmail,
       audience: 'free',
-      audienceLabel: 'Free',
+      audienceLabel: i18n.t('accountIdentity.free'),
       detailLabel,
       compactDetailLabel: detailLabel,
       inlineLabel,
@@ -194,11 +198,13 @@ export function getAccountIdentityPresentation(
     const detailLabel = [formatAccountVariantPart(suffix), formatAudienceDetail(parts.slice(0, -1))]
       .filter(Boolean)
       .join(' · ');
-    const inlineLabel = ['Personal', detailLabel].filter(Boolean).join(' · '); // TODO i18n: missing key for Personal
+    const inlineLabel = [i18n.t('accountIdentity.personal'), detailLabel]
+      .filter(Boolean)
+      .join(' · ');
     return {
       email: resolvedEmail,
       audience: 'personal',
-      audienceLabel: 'Personal',
+      audienceLabel: i18n.t('accountIdentity.personal'),
       detailLabel: detailLabel || formatAccountVariantPart(suffix),
       compactDetailLabel: detailLabel || formatAccountVariantPart(suffix),
       inlineLabel,
@@ -228,17 +234,20 @@ export function getCodexIdentityBadge(
   presentation: Pick<AccountIdentityPresentation, 'audience' | 'detailLabel' | 'compactDetailLabel'>
 ): CodexIdentityBadge {
   if (presentation.audience === 'business') {
-    return { audience: 'business', label: 'Business' };
+    return { audience: 'business', label: i18n.t('accountIdentity.business') };
   }
 
   if (presentation.audience === 'free') {
-    return { audience: 'free', label: 'Free' };
+    return { audience: 'free', label: i18n.t('accountIdentity.free') };
   }
 
   if (presentation.audience === 'personal') {
     return {
       audience: 'personal',
-      label: presentation.compactDetailLabel ?? presentation.detailLabel ?? 'Personal',
+      label:
+        presentation.compactDetailLabel ??
+        presentation.detailLabel ??
+        i18n.t('accountIdentity.personal'),
     };
   }
 

--- a/ui/src/lib/account-identity.ts
+++ b/ui/src/lib/account-identity.ts
@@ -1,10 +1,11 @@
-const PERSONAL_PLAN_PARTS = new Set(['free', 'plus', 'pro']);
+const FREE_PLAN_PARTS = new Set(['free']);
+const PERSONAL_PLAN_PARTS = new Set(['plus', 'pro']);
 const BUSINESS_PLAN_PARTS = new Set(['team']);
 
 // Keep variant parsing aligned with src/cliproxy/accounts/email-account-identity.ts.
 // This browser copy stays local because the server module is not bundle-safe for the UI.
 
-export type AccountAudience = 'business' | 'personal' | 'unknown';
+export type AccountAudience = 'business' | 'free' | 'personal' | 'unknown';
 
 export interface AccountIdentityPresentation {
   email: string;
@@ -105,9 +106,14 @@ function formatWorkspaceLabel(parts: string[]): {
 
   const extraLabel = parts.map(formatAccountVariantPart).filter(Boolean).join(' · ');
   return {
-    detailLabel: extraLabel || 'Team', // TODO i18n: missing key for team fallback
-    compactDetailLabel: extraLabel || 'Team',
+    detailLabel: extraLabel || null,
+    compactDetailLabel: extraLabel || null,
   };
+}
+
+function formatAudienceDetail(parts: string[]): string | null {
+  const label = parts.map(formatAccountVariantPart).filter(Boolean).join(' · ');
+  return label || null;
 }
 
 export function extractAccountVariantKey(
@@ -166,14 +172,21 @@ export function getAccountIdentityPresentation(
     };
   }
 
+  if (suffix && FREE_PLAN_PARTS.has(suffix)) {
+    const detailLabel = formatAudienceDetail(parts.slice(0, -1));
+    const inlineLabel = ['Free', detailLabel].filter(Boolean).join(' · '); // TODO i18n: missing key for Free
+    return {
+      email: resolvedEmail,
+      audience: 'free',
+      audienceLabel: 'Free',
+      detailLabel,
+      compactDetailLabel: detailLabel,
+      inlineLabel,
+    };
+  }
+
   if (suffix && PERSONAL_PLAN_PARTS.has(suffix)) {
-    const detailParts = [
-      formatAccountVariantPart(suffix),
-      ...parts.slice(0, -1).map(formatAccountVariantPart),
-    ]
-      .filter(Boolean)
-      .join(' · ');
-    const detailLabel = detailParts || formatAccountVariantPart(suffix);
+    const detailLabel = formatAudienceDetail(parts.slice(0, -1));
     const inlineLabel = ['Personal', detailLabel].filter(Boolean).join(' · '); // TODO i18n: missing key for Personal
     return {
       email: resolvedEmail,

--- a/ui/src/lib/account-visual-groups.ts
+++ b/ui/src/lib/account-visual-groups.ts
@@ -39,7 +39,8 @@ export interface AccountVisualGroup {
 const AUDIENCE_ORDER: Record<AccountAudience, number> = {
   business: 0,
   personal: 1,
-  unknown: 2,
+  free: 2,
+  unknown: 3,
 };
 
 function getLatestTimestamp(current?: string, candidate?: string): string | undefined {

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -610,8 +610,8 @@ export interface CodexQuotaResult {
   windows: CodexQuotaWindow[];
   /** Explicit core usage windows (5h + weekly) for easier reset display */
   coreUsage?: CodexCoreUsageSummary;
-  /** Plan type: free, plus, team, or null if unknown */
-  planType: 'free' | 'plus' | 'team' | null;
+  /** Plan type: free, plus, pro, team, or null if unknown */
+  planType: 'free' | 'plus' | 'pro' | 'team' | null;
   /** Timestamp of fetch */
   lastUpdated: number;
   /** Upstream HTTP status when available */

--- a/ui/src/lib/i18n.ts
+++ b/ui/src/lib/i18n.ts
@@ -1705,6 +1705,15 @@ const resources = {
         personal: 'Pers',
         variant: 'Variant',
       },
+      accountIdentity: {
+        business: 'Business',
+        personal: 'Personal',
+        free: 'Free',
+        team: 'Team',
+        plus: 'Plus',
+        pro: 'Pro',
+        workspace: 'Workspace {{id}}',
+      },
       accountCardStats: {
         notUsedYet: 'Not used yet',
       },
@@ -4053,6 +4062,15 @@ const resources = {
         free: '免费',
         personal: '个人',
         variant: '变体',
+      },
+      accountIdentity: {
+        business: '企业',
+        personal: '个人',
+        free: '免费',
+        team: '团队',
+        plus: 'Plus',
+        pro: 'Pro',
+        workspace: '工作区 {{id}}',
       },
       accountCardStats: {
         notUsedYet: '尚未使用',
@@ -6475,6 +6493,15 @@ const resources = {
         personal: 'Cá nhân',
         variant: 'Biến thể',
       },
+      accountIdentity: {
+        business: 'Doanh nghiệp',
+        personal: 'Cá nhân',
+        free: 'Miễn phí',
+        team: 'Nhóm',
+        plus: 'Plus',
+        pro: 'Pro',
+        workspace: 'Không gian {{id}}',
+      },
       accountCardStats: {
         notUsedYet: 'Chưa sử dụng',
       },
@@ -8677,6 +8704,15 @@ const resources = {
         free: '無料',
         personal: '個人',
         variant: 'バリアント',
+      },
+      accountIdentity: {
+        business: 'ビジネス',
+        personal: '個人',
+        free: '無料',
+        team: 'チーム',
+        plus: 'Plus',
+        pro: 'Pro',
+        workspace: 'ワークスペース {{id}}',
       },
       aiProvidersEntryCard: {
         apiKeys: 'API Keys',

--- a/ui/src/lib/i18n.ts
+++ b/ui/src/lib/i18n.ts
@@ -1701,6 +1701,7 @@ const resources = {
       },
       accountSurfaceCard: {
         business: 'Biz',
+        free: 'Free',
         personal: 'Pers',
         variant: 'Variant',
       },
@@ -4049,6 +4050,7 @@ const resources = {
       },
       accountSurfaceCard: {
         business: '企业',
+        free: '免费',
         personal: '个人',
         variant: '变体',
       },
@@ -6469,6 +6471,7 @@ const resources = {
       },
       accountSurfaceCard: {
         business: 'Biz',
+        free: 'Miễn phí',
         personal: 'Cá nhân',
         variant: 'Biến thể',
       },
@@ -8671,6 +8674,7 @@ const resources = {
       },
       accountSurfaceCard: {
         business: 'ビジネス',
+        free: '無料',
         personal: '個人',
         variant: 'バリアント',
       },

--- a/ui/tests/unit/components/account/flow-viz/account-card.test.tsx
+++ b/ui/tests/unit/components/account/flow-viz/account-card.test.tsx
@@ -154,10 +154,10 @@ describe('AccountCard grouped quota tooltip', () => {
       />
     );
 
-    expect(screen.getByTitle('Business · Workspace 04a0f049 • Free')).toBeInTheDocument();
+    expect(screen.getByTitle('Business • Free')).toBeInTheDocument();
     expect(screen.getByText('Biz')).toBeInTheDocument();
 
-    await userEvent.hover(screen.getByText('Business · Workspace 04a0f049'));
+    await userEvent.hover(screen.getByText('Business'));
     const businessPlan = (await screen.findAllByText('Plan: team')).find((node) =>
       node.closest('[data-slot="tooltip-content"]')
     );
@@ -202,9 +202,8 @@ describe('AccountCard grouped quota tooltip', () => {
       />
     );
 
-    expect(screen.getByTitle('Business · Workspace 04a0f049 • Personal · Pro')).toBeInTheDocument();
-    expect(screen.getByText('Personal · Pro')).toBeInTheDocument();
+    expect(screen.getByTitle('Business • Pro')).toBeInTheDocument();
+    expect(screen.getAllByText('Pro').length).toBeGreaterThan(0);
     expect(screen.queryByText('Free')).not.toBeInTheDocument();
-    expect(screen.getByText('Pro')).toBeInTheDocument();
   });
 });

--- a/ui/tests/unit/components/account/flow-viz/account-card.test.tsx
+++ b/ui/tests/unit/components/account/flow-viz/account-card.test.tsx
@@ -20,7 +20,11 @@ vi.mock('@/hooks/use-cliproxy-stats', async () => {
 const mockedUseAccountQuota = vi.mocked(useAccountQuota);
 const mockedUseAccountQuotas = vi.mocked(useAccountQuotas);
 
-function makeCodexQuota(planType: 'free' | 'plus' | 'team', fiveHour: number, weekly: number) {
+function makeCodexQuota(
+  planType: 'free' | 'plus' | 'pro' | 'team',
+  fiveHour: number,
+  weekly: number
+) {
   return {
     success: true,
     planType,
@@ -201,5 +205,6 @@ describe('AccountCard grouped quota tooltip', () => {
     expect(screen.getByTitle('Business · Workspace 04a0f049 • Personal · Pro')).toBeInTheDocument();
     expect(screen.getByText('Personal · Pro')).toBeInTheDocument();
     expect(screen.queryByText('Free')).not.toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
   });
 });

--- a/ui/tests/unit/components/account/flow-viz/account-card.test.tsx
+++ b/ui/tests/unit/components/account/flow-viz/account-card.test.tsx
@@ -87,11 +87,11 @@ const groupedAccount: AccountData = {
       isDefault: true,
       successCount: 4,
       failureCount: 1,
-      audience: 'personal',
-      audienceLabel: 'Personal',
-      detailLabel: 'Free',
-      compactDetailLabel: 'Free',
-      inlineLabel: 'Personal · Free',
+      audience: 'free',
+      audienceLabel: 'Free',
+      detailLabel: null,
+      compactDetailLabel: null,
+      inlineLabel: 'Free',
     },
   ],
 };
@@ -99,9 +99,11 @@ const groupedAccount: AccountData = {
 const groupedAccountWithProPersonal: AccountData = {
   ...groupedAccount,
   variants: groupedAccount.variants?.map((variant) =>
-    variant.audience === 'personal'
+    variant.audience === 'free'
       ? {
           ...variant,
+          audience: 'personal',
+          audienceLabel: 'Personal',
           detailLabel: 'Pro',
           compactDetailLabel: 'Pro',
           inlineLabel: 'Personal · Pro',
@@ -148,9 +150,7 @@ describe('AccountCard grouped quota tooltip', () => {
       />
     );
 
-    expect(
-      screen.getByTitle('Business · Workspace 04a0f049 • Personal · Free')
-    ).toBeInTheDocument();
+    expect(screen.getByTitle('Business · Workspace 04a0f049 • Free')).toBeInTheDocument();
     expect(screen.getByText('Biz')).toBeInTheDocument();
 
     await userEvent.hover(screen.getByText('Business · Workspace 04a0f049'));
@@ -164,7 +164,14 @@ describe('AccountCard grouped quota tooltip', () => {
     expect(tooltipContent?.className).toContain('text-popover-foreground');
     expect(tooltipContent?.className).toContain('max-w-[calc(100vw-2rem)]');
 
-    await userEvent.hover(screen.getByText('Personal · Free'));
+    const freeLabels = screen.getAllByText('Free');
+    const quotaLabel = freeLabels[freeLabels.length - 1];
+    expect(quotaLabel).toBeDefined();
+    if (!quotaLabel) {
+      throw new Error('Expected a Free quota label');
+    }
+
+    await userEvent.hover(quotaLabel);
     const personalPlan = (await screen.findAllByText('Plan: free')).find((node) =>
       node.closest('[data-slot="tooltip-content"]')
     );
@@ -193,6 +200,6 @@ describe('AccountCard grouped quota tooltip', () => {
 
     expect(screen.getByTitle('Business · Workspace 04a0f049 • Personal · Pro')).toBeInTheDocument();
     expect(screen.getByText('Personal · Pro')).toBeInTheDocument();
-    expect(screen.queryByText('Personal · Free')).not.toBeInTheDocument();
+    expect(screen.queryByText('Free')).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
+++ b/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
@@ -127,4 +127,23 @@ describe('AccountSurfaceCard', () => {
     expect(screen.getByText('Pers')).toBeInTheDocument();
     expect(screen.getByText('Pro')).toBeInTheDocument();
   });
+
+  it('lets live paid Codex plans override stale free identity badges', () => {
+    render(
+      <AccountSurfaceCard
+        mode="compact"
+        provider="codex"
+        accountId="user@example.com#free"
+        email="user@example.com"
+        displayEmail="user@example.com"
+        tokenFile="codex-user@example.com-free.json"
+        quota={createCodexQuotaResult({ planType: 'plus' })}
+        showQuota={false}
+      />
+    );
+
+    expect(screen.getByText('Pers')).toBeInTheDocument();
+    expect(screen.getByText('Plus')).toBeInTheDocument();
+    expect(screen.queryByTitle('Free')).not.toBeInTheDocument();
+  });
 });

--- a/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
+++ b/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
@@ -89,9 +89,9 @@ describe('AccountSurfaceCard', () => {
       />
     );
 
-    expect(screen.getByText('Pers')).toBeInTheDocument();
     expect(screen.getByText('Pro')).toBeInTheDocument();
     expect(screen.queryByText('Free')).not.toBeInTheDocument();
+    expect(screen.queryByText('Pers')).not.toBeInTheDocument();
   });
 
   it('falls back to a single free badge when Codex quota detects a free plan', () => {
@@ -124,8 +124,8 @@ describe('AccountSurfaceCard', () => {
       />
     );
 
-    expect(screen.getByText('Pers')).toBeInTheDocument();
     expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(screen.queryByText('Pers')).not.toBeInTheDocument();
   });
 
   it('lets live paid Codex plans override stale free identity badges', () => {
@@ -142,8 +142,8 @@ describe('AccountSurfaceCard', () => {
       />
     );
 
-    expect(screen.getByText('Pers')).toBeInTheDocument();
     expect(screen.getByText('Plus')).toBeInTheDocument();
+    expect(screen.queryByText('Pers')).not.toBeInTheDocument();
     expect(screen.queryByTitle('Free')).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
+++ b/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
@@ -57,7 +57,7 @@ describe('AccountSurfaceCard', () => {
     expect(screen.getByText('pro')).toBeInTheDocument();
   });
 
-  it('shows both personal identity and free-tier detail for compact Codex cards', () => {
+  it('shows free Codex accounts as a single standalone audience badge', () => {
     render(
       <AccountSurfaceCard
         mode="compact"
@@ -70,12 +70,12 @@ describe('AccountSurfaceCard', () => {
       />
     );
 
-    expect(screen.getByText('Pers')).toBeInTheDocument();
-    expect(screen.getByTitle('Personal')).toBeInTheDocument();
     expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.getByTitle('Free')).toBeInTheDocument();
+    expect(screen.queryByText('Pers')).not.toBeInTheDocument();
   });
 
-  it('keeps richer token-derived Codex personal detail when live quota planType is coarser', () => {
+  it('keeps the simplified personal audience when live quota planType is coarser', () => {
     render(
       <AccountSurfaceCard
         mode="compact"
@@ -89,7 +89,24 @@ describe('AccountSurfaceCard', () => {
       />
     );
 
-    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(screen.getByText('Pers')).toBeInTheDocument();
     expect(screen.queryByText('Free')).not.toBeInTheDocument();
+  });
+
+  it('falls back to a single free badge when Codex quota detects a free plan', () => {
+    render(
+      <AccountSurfaceCard
+        mode="compact"
+        provider="codex"
+        accountId="user@example.com"
+        email="user@example.com"
+        displayEmail="user@example.com"
+        quota={createCodexQuotaResult({ planType: 'free' })}
+        showQuota={false}
+      />
+    );
+
+    expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(screen.queryByText('Pers')).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
+++ b/ui/tests/unit/ui/components/account/shared/account-surface-card.test.tsx
@@ -75,7 +75,7 @@ describe('AccountSurfaceCard', () => {
     expect(screen.queryByText('Pers')).not.toBeInTheDocument();
   });
 
-  it('keeps the simplified personal audience when live quota planType is coarser', () => {
+  it('keeps token-derived personal detail when live quota planType is coarser', () => {
     render(
       <AccountSurfaceCard
         mode="compact"
@@ -90,6 +90,7 @@ describe('AccountSurfaceCard', () => {
     );
 
     expect(screen.getByText('Pers')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
     expect(screen.queryByText('Free')).not.toBeInTheDocument();
   });
 
@@ -108,5 +109,22 @@ describe('AccountSurfaceCard', () => {
 
     expect(screen.getByText('Free')).toBeInTheDocument();
     expect(screen.queryByText('Pers')).not.toBeInTheDocument();
+  });
+
+  it('falls back to plus or pro detail when Codex quota exposes a paid plan', () => {
+    render(
+      <AccountSurfaceCard
+        mode="compact"
+        provider="codex"
+        accountId="user@example.com"
+        email="user@example.com"
+        displayEmail="user@example.com"
+        quota={createCodexQuotaResult({ planType: 'pro' })}
+        showQuota={false}
+      />
+    );
+
+    expect(screen.getByText('Pers')).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
   });
 });

--- a/ui/tests/unit/ui/lib/account-identity.test.ts
+++ b/ui/tests/unit/ui/lib/account-identity.test.ts
@@ -39,14 +39,33 @@ describe('account identity presentation', () => {
     ).toBe('Business · Workspace 04a0f049');
   });
 
-  it('formats personal codex plans deliberately instead of leaking raw free suffixes', () => {
+  it('classifies free codex accounts as a standalone audience', () => {
+    const presentation = getAccountIdentityPresentation(
+      'kaidu.kd@gmail.com',
+      'kaidu.kd@gmail.com',
+      'codex-kaidu.kd@gmail.com-free.json'
+    );
+
+    expect(presentation.audience).toBe('free');
+    expect(presentation.audienceLabel).toBe('Free');
+    expect(presentation.detailLabel).toBeNull();
     expect(
       formatAccountDisplayName(
         'kaidu.kd@gmail.com',
         'kaidu.kd@gmail.com',
         'codex-kaidu.kd@gmail.com-free.json'
       )
-    ).toBe('kaidu.kd@gmail.com (Personal · Free)');
+    ).toBe('kaidu.kd@gmail.com (Free)');
+  });
+
+  it('collapses paid codex personal plans into a single personal audience label', () => {
+    expect(
+      formatAccountDisplayName(
+        'kaidu.kd@gmail.com',
+        'kaidu.kd@gmail.com',
+        'codex-kaidu.kd@gmail.com-plus.json'
+      )
+    ).toBe('kaidu.kd@gmail.com (Personal)');
   });
 
   it('leaves plain accounts without inferred state untouched', () => {

--- a/ui/tests/unit/ui/lib/account-identity.test.ts
+++ b/ui/tests/unit/ui/lib/account-identity.test.ts
@@ -58,14 +58,21 @@ describe('account identity presentation', () => {
     ).toBe('kaidu.kd@gmail.com (Free)');
   });
 
-  it('collapses paid codex personal plans into a single personal audience label', () => {
+  it('keeps plus and pro codex personal plans distinct', () => {
     expect(
       formatAccountDisplayName(
         'kaidu.kd@gmail.com',
         'kaidu.kd@gmail.com',
         'codex-kaidu.kd@gmail.com-plus.json'
       )
-    ).toBe('kaidu.kd@gmail.com (Personal)');
+    ).toBe('kaidu.kd@gmail.com (Personal · Plus)');
+    expect(
+      formatAccountDisplayName(
+        'kaidu.kd@gmail.com',
+        'kaidu.kd@gmail.com',
+        'codex-kaidu.kd@gmail.com-pro.json'
+      )
+    ).toBe('kaidu.kd@gmail.com (Personal · Pro)');
   });
 
   it('leaves plain accounts without inferred state untouched', () => {


### PR DESCRIPTION
## Summary
- keep free Codex accounts as a standalone badge instead of rendering `Personal + Free`
- preserve paid Codex plan detail so `Plus` and `Pro` remain visible when available
- teach the Codex quota parser and shared UI types to recognize `pro` plan responses

## Validation
- [x] `cd /Users/kaitran/CloudPersonal/worktrees/ccs-cli/codex-free-account-badge/ui && bun run test:run tests/unit/ui/lib/account-identity.test.ts tests/unit/ui/components/account/shared/account-surface-card.test.tsx tests/unit/components/account/flow-viz/account-card.test.tsx`
- [x] `cd /Users/kaitran/CloudPersonal/worktrees/ccs-cli/codex-free-account-badge/ui && bun run validate`
- [x] `cd /Users/kaitran/CloudPersonal/worktrees/ccs-cli/codex-free-account-badge && bun run validate`
- [x] `cd /Users/kaitran/CloudPersonal/worktrees/ccs-cli/codex-free-account-badge && bun run validate:ci-parity`
