### PR TITLE
fix(shared-manager): exclude .staging dirs from marketplace registry sync

### DIFF
--- a/src/management/shared-manager.ts
+++ b/src/management/shared-manager.ts
@@ -947,23 +947,20 @@ class SharedManager {
 
     const discoveredEntries = this.discoverMarketplaceEntries(targetConfigDir);
 
-    for (const [name, value] of Object.entries(discoveredEntries)) {
-      const existing = merged[name];
-      if (existing && typeof existing === 'object' && !Array.isArray(existing)) {
-        merged[name] = {
-          ...(existing as Record<string, unknown>),
-          installLocation: value.installLocation,
-        };
-        continue;
-      }
-
-      merged[name] = value;
-    }
-
+    // Keep only registry entries that have a physical directory, and update their
+    // installLocation. Entries only on disk (no registry record) are excluded —
+    // they lack required schema fields that Claude Code enforces.
     for (const name of Object.keys(merged)) {
+      const entry = merged[name];
       if (!(name in discoveredEntries)) {
         delete merged[name];
+      } else if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+        merged[name] = {
+          ...(entry as Record<string, unknown>),
+          installLocation: discoveredEntries[name].installLocation,
+        };
       }
+      // else: entry is in discoveredEntries but has a malformed value — preserve as-is
     }
 
     return JSON.stringify(merged, null, 2);
@@ -981,6 +978,11 @@ class SharedManager {
 
     for (const entry of fs.readdirSync(marketplacesDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) {
+        continue;
+      }
+
+      // Skip hidden dirs and Claude Code's .staging rename-dance work trees.
+      if (entry.name.startsWith('.') || entry.name.endsWith('.staging')) {
         continue;
       }
 

--- a/src/management/shared-manager.ts
+++ b/src/management/shared-manager.ts
@@ -936,6 +936,10 @@ class SharedManager {
         }
 
         for (const [name, value] of Object.entries(parsed as Record<string, unknown>)) {
+          if (!this.isMarketplaceRegistryEntry(value)) {
+            continue;
+          }
+
           merged[name] = normalizePluginMetadataValue(value, targetConfigDir).normalized;
         }
       } catch (err) {
@@ -954,13 +958,14 @@ class SharedManager {
       const entry = merged[name];
       if (!(name in discoveredEntries)) {
         delete merged[name];
-      } else if (entry && typeof entry === 'object' && !Array.isArray(entry)) {
+      } else if (this.isMarketplaceRegistryEntry(entry)) {
         merged[name] = {
-          ...(entry as Record<string, unknown>),
+          ...entry,
           installLocation: discoveredEntries[name].installLocation,
         };
+      } else {
+        delete merged[name];
       }
-      // else: entry is in discoveredEntries but has a malformed value — preserve as-is
     }
 
     return JSON.stringify(merged, null, 2);
@@ -981,8 +986,8 @@ class SharedManager {
         continue;
       }
 
-      // Skip hidden dirs and Claude Code's .staging rename-dance work trees.
-      if (entry.name.startsWith('.') || entry.name.endsWith('.staging')) {
+      // Skip hidden dirs and Claude Code rename-dance leftovers (.staging/.bak).
+      if (this.isTransientMarketplaceDirectory(entry.name)) {
         continue;
       }
 
@@ -992,6 +997,14 @@ class SharedManager {
     }
 
     return discovered;
+  }
+
+  private isTransientMarketplaceDirectory(name: string): boolean {
+    return name.startsWith('.') || name.endsWith('.staging') || name.endsWith('.bak');
+  }
+
+  private isMarketplaceRegistryEntry(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
   }
 
   private writePluginMetadataFile(

--- a/tests/unit/shared-manager.test.ts
+++ b/tests/unit/shared-manager.test.ts
@@ -360,7 +360,7 @@ describe('SharedManager', () => {
       expect(reconciled.stale).toBeUndefined();
     });
 
-    it('does not register .staging directories left behind by interrupted marketplace auto-updates', () => {
+    it('does not register transient marketplace directories left behind by interrupted auto-updates', () => {
       // Regression: CCS used to write bare { installLocation } entries for marketplace
       // directories with no registry record. Claude Code requires source + lastUpdated,
       // so those entries corrupted known_marketplaces.json and broke /plugin.
@@ -369,24 +369,29 @@ describe('SharedManager', () => {
       fs.mkdirSync(instancePath, { recursive: true });
       manager.linkSharedDirectories(instancePath);
 
-      // Simulate Claude Code leaving a .staging dir behind in both the global claude dir
-      // and the instance dir (discoverMarketplaceEntries scans each independently).
-      fs.mkdirSync(marketplacePath(claudeDir(), 'claude-plugins-official.staging'), {
-        recursive: true,
-      });
-      fs.mkdirSync(marketplacePath(instancePath, 'claude-plugins-official.staging'), {
-        recursive: true,
-      });
+      // Simulate Claude Code leaving rename-dance temp dirs behind in both the
+      // global claude dir and the instance dir (discoverMarketplaceEntries scans
+      // each independently).
+      for (const suffix of ['.staging', '.bak']) {
+        fs.mkdirSync(marketplacePath(claudeDir(), `claude-plugins-official${suffix}`), {
+          recursive: true,
+        });
+        fs.mkdirSync(marketplacePath(instancePath, `claude-plugins-official${suffix}`), {
+          recursive: true,
+        });
+      }
 
       manager.normalizeMarketplaceRegistryPaths(instancePath);
 
       const globalRegistryPath = path.join(claudeDir(), 'plugins', 'known_marketplaces.json');
       const global = readJson(globalRegistryPath) as Record<string, unknown>;
       expect(global['claude-plugins-official.staging']).toBeUndefined();
+      expect(global['claude-plugins-official.bak']).toBeUndefined();
 
       const instanceRegistryPath = path.join(instancePath, 'plugins', 'known_marketplaces.json');
       const instance = readJson(instanceRegistryPath) as Record<string, unknown>;
       expect(instance['claude-plugins-official.staging']).toBeUndefined();
+      expect(instance['claude-plugins-official.bak']).toBeUndefined();
     });
 
     it('removes registry entries whose physical marketplace directory no longer exists', () => {
@@ -419,6 +424,29 @@ describe('SharedManager', () => {
       const instanceRegistryPath = path.join(instancePath, 'plugins', 'known_marketplaces.json');
       const instance = readJson(instanceRegistryPath) as Record<string, unknown>;
       expect(instance['vanished-marketplace']).toBeUndefined();
+    });
+
+    it('drops malformed marketplace entries even when the payload directory still exists', () => {
+      const manager = new SharedManager();
+      const instancePath = instanceDir('work');
+      fs.mkdirSync(instancePath, { recursive: true });
+      manager.linkSharedDirectories(instancePath);
+
+      fs.mkdirSync(marketplacePath(claudeDir(), 'claude-code-plugins'), { recursive: true });
+
+      const globalRegistryPath = path.join(claudeDir(), 'plugins', 'known_marketplaces.json');
+      writeJson(globalRegistryPath, {
+        'claude-code-plugins': 'bad-entry',
+      });
+
+      manager.normalizeMarketplaceRegistryPaths(instancePath);
+
+      const global = readJson(globalRegistryPath) as Record<string, unknown>;
+      expect(global['claude-code-plugins']).toBeUndefined();
+
+      const instanceRegistryPath = path.join(instancePath, 'plugins', 'known_marketplaces.json');
+      const instance = readJson(instanceRegistryPath) as Record<string, unknown>;
+      expect(instance['claude-code-plugins']).toBeUndefined();
     });
 
     it('warns and skips malformed marketplace registries while keeping valid sources', () => {

--- a/tests/unit/shared-manager.test.ts
+++ b/tests/unit/shared-manager.test.ts
@@ -360,6 +360,67 @@ describe('SharedManager', () => {
       expect(reconciled.stale).toBeUndefined();
     });
 
+    it('does not register .staging directories left behind by interrupted marketplace auto-updates', () => {
+      // Regression: CCS used to write bare { installLocation } entries for marketplace
+      // directories with no registry record. Claude Code requires source + lastUpdated,
+      // so those entries corrupted known_marketplaces.json and broke /plugin.
+      const manager = new SharedManager();
+      const instancePath = instanceDir('work');
+      fs.mkdirSync(instancePath, { recursive: true });
+      manager.linkSharedDirectories(instancePath);
+
+      // Simulate Claude Code leaving a .staging dir behind in both the global claude dir
+      // and the instance dir (discoverMarketplaceEntries scans each independently).
+      fs.mkdirSync(marketplacePath(claudeDir(), 'claude-plugins-official.staging'), {
+        recursive: true,
+      });
+      fs.mkdirSync(marketplacePath(instancePath, 'claude-plugins-official.staging'), {
+        recursive: true,
+      });
+
+      manager.normalizeMarketplaceRegistryPaths(instancePath);
+
+      const globalRegistryPath = path.join(claudeDir(), 'plugins', 'known_marketplaces.json');
+      const global = readJson(globalRegistryPath) as Record<string, unknown>;
+      expect(global['claude-plugins-official.staging']).toBeUndefined();
+
+      const instanceRegistryPath = path.join(instancePath, 'plugins', 'known_marketplaces.json');
+      const instance = readJson(instanceRegistryPath) as Record<string, unknown>;
+      expect(instance['claude-plugins-official.staging']).toBeUndefined();
+    });
+
+    it('removes registry entries whose physical marketplace directory no longer exists', () => {
+      // Regression guard: buildMarketplaceRegistryContent merges JSON sources then
+      // cross-checks against discoveredEntries. Any name in the merged registry that
+      // has no matching directory on disk must be pruned so stale entries don't
+      // accumulate across marketplace uninstalls or renames.
+      const manager = new SharedManager();
+      const instancePath = instanceDir('work');
+      fs.mkdirSync(instancePath, { recursive: true });
+      manager.linkSharedDirectories(instancePath);
+
+      // Write a registry entry for a marketplace that has no physical directory.
+      const globalRegistryPath = path.join(claudeDir(), 'plugins', 'known_marketplaces.json');
+      writeJson(globalRegistryPath, {
+        'vanished-marketplace': {
+          source: { type: 'github', repo: 'example/vanished' },
+          lastUpdated: '2024-01-01T00:00:00.000Z',
+          installLocation: marketplacePath(claudeDir(), 'vanished-marketplace'),
+        },
+      });
+      // Intentionally do NOT create the physical directory — simulate an uninstalled
+      // marketplace whose registry entry was not cleaned up.
+
+      manager.normalizeMarketplaceRegistryPaths(instancePath);
+
+      const global = readJson(globalRegistryPath) as Record<string, unknown>;
+      expect(global['vanished-marketplace']).toBeUndefined();
+
+      const instanceRegistryPath = path.join(instancePath, 'plugins', 'known_marketplaces.json');
+      const instance = readJson(instanceRegistryPath) as Record<string, unknown>;
+      expect(instance['vanished-marketplace']).toBeUndefined();
+    });
+
     it('warns and skips malformed marketplace registries while keeping valid sources', () => {
       const manager = new SharedManager();
       const instancePath = instanceDir('work');


### PR DESCRIPTION
## Problem

Claude Code's marketplace auto-update uses a three-step atomic rename:

1. Clone marketplace into \`<name>.staging/\`
2. Rename existing \`<name>/\` to \`<name>.bak/\`
3. Rename \`<name>.staging/\` to \`<name>/\`

On Windows, an EPERM error at step 3 can leave \`<name>.staging/\` permanently on disk.

CCS scanned physical directories to build the marketplace registry, so a lingering \`.staging\` directory was registered as a bare \`{ installLocation }\` entry in \`known_marketplaces.json\`. Claude Code's Zod schema requires each entry to also carry \`source\` and \`lastUpdated\`, so the corrupt entry caused the \`/plugin\` command to throw a validation error on every subsequent startup.

Symptom: \`[OK] Synchronized marketplace registry paths\` printed at CCS launch, followed by Claude Code's \`/plugin\` crashing with a schema validation error.

## Fix

Two layers of defence in \`SharedManager\`:

**Layer 1 — \`discoverMarketplaceEntries\`**: skip any directory whose name starts with \`.\` or ends with \`.staging\`. This covers \`.staging\` and \`.bak\` temporary directories left by interrupted rename operations.

**Layer 2 — \`buildMarketplaceRegistryContent\`**: invert the loop direction. Previously the function iterated \`discoveredEntries\` and upserted into the registry, which could introduce bare \`{ installLocation }\` entries for disk-only directories with no prior registry record. Now the function iterates the merged registry and only retains entries that also have a matching physical directory. Disk-only entries lacking the required schema fields are silently ignored.

## Tests

Two new regression tests in \`tests/unit/shared-manager.test.ts\`:

- **.staging pollution**: creates a \`claude-plugins-official.staging/\` directory in both the global Claude dir and the instance dir, asserts neither appears in the written registry.
- **Orphan registry cleanup**: writes a registry entry for a marketplace whose physical directory does not exist, asserts the entry is pruned from the output.

## Checklist

- [x] Regression tests added covering both fix layers
- [x] \`bun run validate\` passes (typecheck + lint + format + maintainability + tests)
- [x] Pre-push gate passes
- [x] No CLI interface or help text changes required