### PR TITLE
fix(codex): probe Windows cmd wrappers via cmd shell

### DIFF
--- a/src/targets/codex-detector.ts
+++ b/src/targets/codex-detector.ts
@@ -53,12 +53,14 @@ function runCodexProbe(codexPath: string, args: string[]): string | undefined {
 
     if (needsShell) {
       const cmdString = [codexPath, ...args].map(escapeShellArg).join(' ');
-      return childProcess.execFileSync('cmd.exe', ['/d', '/s', '/c', cmdString], {
+      const result = childProcess.spawnSync(cmdString, {
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'ignore'],
         timeout: 5000,
         windowsHide: true,
+        shell: 'cmd.exe',
       });
+      return result.status === 0 ? result.stdout : undefined;
     }
 
     return childProcess.execFileSync(codexPath, args, {

--- a/tests/unit/targets/codex-detector.test.ts
+++ b/tests/unit/targets/codex-detector.test.ts
@@ -58,19 +58,35 @@ describe('codex-detector', () => {
     process.env.CCS_CODEX_PATH = fakeCodex;
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
-    const execFileSyncSpy = spyOn(childProcess, 'execFileSync').mockImplementation((command, args) => {
-      return String(command).includes('cmd.exe') && Array.isArray(args) && args.join(' ').includes('--help')
-        ? 'Codex CLI\n  -c, --config <key=value>\n'
-        : 'codex-cli 0.118.0-alpha.3';
+    const spawnSyncSpy = spyOn(childProcess, 'spawnSync').mockImplementation((command) => {
+      const commandString = String(command);
+      return {
+        pid: 123,
+        output: ['', '', ''],
+        stdout: commandString.includes('--help')
+          ? 'Codex CLI\n  -c, --config <key=value>\n'
+          : 'codex-cli 0.118.0-alpha.3',
+        stderr: '',
+        status: 0,
+        signal: null,
+      } as unknown as ReturnType<typeof childProcess.spawnSync>;
     });
 
     const info = getCodexBinaryInfo();
+    const calls = spawnSyncSpy.mock.calls;
+    const cmdWrapperProbeCall = calls.find(([command]) => {
+      return String(command).includes(fakeCodex);
+    });
 
-    expect(execFileSyncSpy).toHaveBeenCalled();
+    expect(spawnSyncSpy).toHaveBeenCalled();
+    expect(cmdWrapperProbeCall).toBeDefined();
+    expect((cmdWrapperProbeCall?.[1] as Record<string, unknown> | undefined)?.shell).toBe(
+      'cmd.exe'
+    );
     expect(info?.needsShell).toBe(true);
     expect(info?.features).toContain('config-overrides');
 
-    execFileSyncSpy.mockRestore();
+    spawnSyncSpy.mockRestore();
   });
 
   it('keeps the cmd wrapper when Windows PATH exposes codex.cmd and a sibling ps1 also exists', () => {


### PR DESCRIPTION
## Summary
Fix Windows Codex detector probing for `.cmd` wrappers.

## Problem
On Windows, `ccsxp` can fail with:

`Codex CLI does not advertise --config overrides`

even when the installed Codex wrapper does support `--config`.

## Root cause
`v7.72.1` can prefer `codex.cmd` on some Windows PATH layouts, but the detector probes `.cmd/.bat` wrappers through a `cmd.exe /c` path that misquotes the wrapper command on this setup. The failed probe makes CCS think Codex lacks config override support.

## Fix
Use `spawnSync(cmdString, { shell: 'cmd.exe' })` for `.cmd/.bat` probes so the wrapper is executed with the quoting contract expected by `escapeShellArg()`.

## Validation
- Reproduced on Windows local machine
- Verified patched install resolves the `ccsxp` failure
- `node node_modules/typescript/bin/tsc --noEmit` passes
- `bun test tests/unit/targets/codex-detector.test.ts` is still blocked locally by a Bun temp-dir cleanup permission issue on Windows