### PR TITLE
ci: concurrency group + split build/test with artifact sharing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
 
 # Design notes:
 # - Matrix parallelism cuts wall time from ~3-4min to ~60-90s (cache warm).
-# - Each matrix leg restores the same cache; `Ensure deps` fills gaps on cache miss.
+# - Concurrency group cancels superseded runs on the same ref (saves runner time on rapid pushes).
+# - Build leg produces dist/ artifact; test leg downloads it instead of rebuilding (DRY).
 # - fail-fast: false so every failure is visible in one run (no re-pushing to see the next failure).
-# - Test leg runs build:all inline because it needs dist/ artifacts; still parallel with other legs.
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:
@@ -20,8 +24,6 @@ jobs:
           - { name: typecheck, cmd: 'bun run typecheck' }
           - { name: lint,      cmd: 'bun run lint' }
           - { name: format,    cmd: 'bun run format:check' }
-          - { name: build,     cmd: 'bun run build:all' }
-          - { name: test,      cmd: 'bun run build:all && bun run test:all' }
     name: ${{ matrix.check.name }}
 
     steps:
@@ -56,3 +58,90 @@ jobs:
 
       - name: Run ${{ matrix.check.name }}
         run: ${{ matrix.check.cmd }}
+
+  build:
+    runs-on: [self-hosted, linux, x64]
+    name: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Restore bun + node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            ui/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'ui/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Ensure dependencies
+        run: |
+          [ -d node_modules ] || bun install --frozen-lockfile
+          [ -d ui/node_modules ] || (cd ui && bun install --frozen-lockfile)
+
+      - name: Build
+        run: bun run build:all
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
+
+  test:
+    runs-on: [self-hosted, linux, x64]
+    name: test
+    needs: [build]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.9'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Restore bun + node_modules cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+            ui/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'ui/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Ensure dependencies
+        run: |
+          [ -d node_modules ] || bun install --frozen-lockfile
+          [ -d ui/node_modules ] || (cd ui && bun install --frozen-lockfile)
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Test
+        run: bun run test:all


### PR DESCRIPTION
## Summary

Optimizes CI for faster feedback and lower runner time on rapid pushes.

**Changes:**
- **Concurrency group** — keyed on `github.ref` with `cancel-in-progress: true`. Superseded runs on the same branch are cancelled automatically, so pushing twice in quick succession no longer double-books the self-hosted runner.
- **Split validate/build/test** — previous matrix had `test` doing `build:all && test:all` inline, duplicating the `build` leg's work. Now:
  - `validate` matrix: typecheck, lint, format (parallel, no build needed)
  - `build`: runs `build:all`, uploads `dist/` as artifact
  - `test`: `needs: [build]`, downloads `dist/`, runs `test:all`
- Net: test leg stops rebuilding; build artifact is reused; fewer wall-clock seconds per PR.

## Check name changes

Matrix legs are now: `typecheck`, `lint`, `format`, `build`, `test` (same names as before, just split across jobs — build and test become separate jobs instead of matrix rows).

## Test plan
- [x] Push and verify all 5 checks appear and pass
- [ ] Rapid second push cancels the first run (concurrency)
- [ ] `dist/` artifact uploaded by build, consumed by test (no rebuild in test leg)