### PR TITLE
fix(proxy): allow openai-compatible profiles to run on separate local ports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,3 +139,8 @@ jobs:
 
       - name: Test
         run: bun run test:all
+
+      - name: Test CLI e2e
+        env:
+          CCS_E2E_SKIP_BUILD: '1'
+        run: bun run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Ensure dependencies
-        run: |
-          [ -d node_modules ] || bun install --frozen-lockfile
-          [ -d ui/node_modules ] || (cd ui && bun install --frozen-lockfile)
+        run: bash scripts/ensure-deps.sh
 
       - name: Run ${{ matrix.check.name }}
         run: ${{ matrix.check.cmd }}
@@ -88,9 +86,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Ensure dependencies
-        run: |
-          [ -d node_modules ] || bun install --frozen-lockfile
-          [ -d ui/node_modules ] || (cd ui && bun install --frozen-lockfile)
+        run: bash scripts/ensure-deps.sh
 
       - name: Build
         run: bun run build:all
@@ -133,9 +129,7 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Ensure dependencies
-        run: |
-          [ -d node_modules ] || bun install --frozen-lockfile
-          [ -d ui/node_modules ] || (cd ui && bun install --frozen-lockfile)
+        run: bash scripts/ensure-deps.sh
 
       - name: Download dist artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -49,6 +49,11 @@ jobs:
       - name: Validate (typecheck + lint + format + tests)
         run: bun run validate
 
+      - name: Test CLI e2e
+        env:
+          CCS_E2E_SKIP_BUILD: '1'
+        run: bun run test:e2e
+
       - name: Release
         id: release
         env:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -41,9 +41,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: |
-          bun install --frozen-lockfile
-          cd ui && bun install --frozen-lockfile
+        run: bash scripts/ensure-deps.sh
 
       - name: Build
         run: bun run build:all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
       - name: Validate (typecheck + lint + format + tests)
         run: bun run validate
 
+      - name: Test CLI e2e
+        env:
+          CCS_E2E_SKIP_BUILD: '1'
+        run: bun run test:e2e
+
       - name: Release
         id: release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,7 @@ jobs:
           bun-version: '1.3.9'
 
       - name: Install dependencies
-        run: |
-          bun install --frozen-lockfile
-          cd ui && bun install --frozen-lockfile
+        run: bash scripts/ensure-deps.sh
 
       - name: Build package
         run: bun run build:all

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ package-lock.json
 .claude/active-plan
 .claude/agent-memory/
 .claude/plans-registry.json*
+CLAUDE.local.md
+AGENTS.override.md
 
 # Logs directory
 logs/

--- a/docs/openai-compatible-providers.md
+++ b/docs/openai-compatible-providers.md
@@ -72,7 +72,10 @@ Useful variants:
 
 ```bash
 ccs proxy start hf --host 127.0.0.1
+ccs proxy activate hf
 ccs proxy activate --fish
+ccs proxy status hf
+ccs proxy stop hf
 ```
 
 `ccs proxy activate` now prints the full local runtime contract:
@@ -85,16 +88,26 @@ ccs proxy activate --fish
 - `API_TIMEOUT_MS`
 - `NO_PROXY`
 
-## One Active Proxy Profile
+## Multiple Active Proxy Profiles
 
-The current runtime is a single local proxy daemon.
+CCS now stores OpenAI-compatible proxy state per profile instead of treating the
+runtime as a singleton.
 
-- Reusing the same OpenAI-compatible profile is supported
-- Starting a different OpenAI-compatible profile while one proxy is already
-  running is rejected instead of silently replacing the active upstream
+- Different compatible profiles can run at the same time on separate local ports
+- `ccs proxy activate` without a profile stays convenient when only one proxy is
+  running
+- When multiple proxies are running, pass the profile explicitly to
+  `activate`, `status`, or `stop`
 
-This is intentional to avoid breaking an in-flight Claude session by swapping
-its upstream provider out from under it.
+If you want deterministic ports, configure them in `~/.ccs/config.yaml`:
+
+```yaml
+proxy:
+  port: 3456
+  profile_ports:
+    hf: 3456
+    openai: 3461
+```
 
 ## Request-Time Routing
 

--- a/scripts/ensure-deps.sh
+++ b/scripts/ensure-deps.sh
@@ -3,22 +3,14 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 UI_DIR="$ROOT_DIR/ui"
-UI_SENTINEL="$UI_DIR/node_modules/@date-fns/tz/date/mini.js"
 
 ensure_root_deps() {
-  if [[ ! -d "$ROOT_DIR/node_modules" ]]; then
-    echo "[deps] Installing root dependencies"
-    (cd "$ROOT_DIR" && bun install --frozen-lockfile)
-  fi
+  echo "[deps] Syncing root dependencies"
+  (cd "$ROOT_DIR" && bun install --frozen-lockfile)
 }
 
 ensure_ui_deps() {
-  if [[ -d "$UI_DIR/node_modules" && -f "$UI_SENTINEL" ]]; then
-    return
-  fi
-
-  echo "[deps] Reinstalling UI dependencies"
-  rm -rf "$UI_DIR/node_modules"
+  echo "[deps] Syncing UI dependencies"
   (cd "$UI_DIR" && bun install --frozen-lockfile)
 }
 

--- a/scripts/ensure-deps.sh
+++ b/scripts/ensure-deps.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UI_DIR="$ROOT_DIR/ui"
+UI_SENTINEL="$UI_DIR/node_modules/@date-fns/tz/date/mini.js"
+
+ensure_root_deps() {
+  if [[ ! -d "$ROOT_DIR/node_modules" ]]; then
+    echo "[deps] Installing root dependencies"
+    (cd "$ROOT_DIR" && bun install --frozen-lockfile)
+  fi
+}
+
+ensure_ui_deps() {
+  if [[ -d "$UI_DIR/node_modules" && -f "$UI_SENTINEL" ]]; then
+    return
+  fi
+
+  echo "[deps] Reinstalling UI dependencies"
+  rm -rf "$UI_DIR/node_modules"
+  (cd "$UI_DIR" && bun install --frozen-lockfile)
+}
+
+ensure_root_deps
+ensure_ui_deps

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -136,7 +136,7 @@ async function handleStatus(args: string[] = []): Promise<number> {
   const printStatus = (status: Awaited<ReturnType<typeof getOpenAICompatProxyStatus>>) => {
     console.log(
       status.running
-        ? ok(`Proxy running on port ${status.port}`)
+        ? ok(`Proxy running on port ${status.port ?? 'unknown'}`)
         : info(`Proxy is not running${status.port ? ` (last known port ${status.port})` : ''}`)
     );
     if (status.host && status.port) {

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -28,7 +28,8 @@ function hasHelpFlag(args: string[]): boolean {
 
 export function findPositionalArg(
   args: string[],
-  optionsWithValues: string[] = []
+  optionsWithValues: string[] = [],
+  flagOptions: string[] = []
 ): string | undefined {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -36,6 +37,9 @@ export function findPositionalArg(
       return i + 1 < args.length ? args[i + 1] : undefined;
     }
     if (arg.startsWith('-')) {
+      if (flagOptions.includes(arg)) {
+        continue;
+      }
       if (optionsWithValues.includes(arg)) {
         i += 1;
       }
@@ -90,7 +94,7 @@ async function handleStart(args: string[]): Promise<number> {
   if (hasHelpFlag(args)) {
     return showHelp();
   }
-  const profileName = findPositionalArg(args, ['--port', '--host']);
+  const profileName = findPositionalArg(args, ['--port', '--host'], ['--insecure']);
   if (!profileName) {
     console.error(
       fail('Usage: ccs proxy start <profile> [--port <n>] [--host <addr>] [--insecure]')

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -5,6 +5,7 @@ import { fail, info, ok } from '../utils/ui';
 import {
   buildOpenAICompatProxyEnv,
   getOpenAICompatProxyStatus,
+  listOpenAICompatProxyStatuses,
   resolveOpenAICompatProfileConfig,
   startOpenAICompatProxy,
   stopOpenAICompatProxy,
@@ -30,9 +31,9 @@ function showHelp(): number {
   console.log(
     '  start <profile>   Start the local proxy for an OpenAI-compatible settings profile'
   );
-  console.log('  stop              Stop the running proxy');
-  console.log('  status            Show daemon status and active profile');
-  console.log('  activate          Print shell exports for the running proxy');
+  console.log('  stop [profile]    Stop the running proxy (or all proxies when omitted)');
+  console.log('  status [profile]  Show daemon status');
+  console.log('  activate [profile] Print shell exports for the running proxy');
   console.log('');
   console.log('Options:');
   console.log('  --port <n>        Override the local proxy port (default: 3456)');
@@ -100,34 +101,49 @@ async function handleStart(args: string[]): Promise<number> {
   return 0;
 }
 
-async function handleStatus(): Promise<number> {
-  const status = await getOpenAICompatProxyStatus();
-  if (!status.running) {
+async function handleStatus(args: string[] = []): Promise<number> {
+  const profileName = args.find((arg) => !arg.startsWith('-'));
+  const running = profileName
+    ? [await getOpenAICompatProxyStatus(profileName)].filter((status) => status.running)
+    : (await listOpenAICompatProxyStatuses()).filter((status) => status.running);
+  if (running.length === 0) {
     console.log(info('Proxy is not running'));
     return 0;
   }
 
-  console.log(ok(`Proxy running on port ${status.port}`));
-  if (status.host) {
-    console.log(`  Host: ${status.host}`);
-    console.log(`  Local URL: http://${status.host}:${status.port}`);
-  }
-  console.log(`  Profile: ${status.profileName}`);
-  console.log(`  Base URL: ${status.baseUrl}`);
-  if (status.model) {
-    console.log(`  Model: ${status.model}`);
-  }
-  if (status.pid) {
-    console.log(`  PID: ${status.pid}`);
+  for (const status of running) {
+    console.log(ok(`Proxy running on port ${status.port}`));
+    if (status.host) {
+      console.log(`  Host: ${status.host}`);
+      console.log(`  Local URL: http://${status.host}:${status.port}`);
+    }
+    console.log(`  Profile: ${status.profileName}`);
+    console.log(`  Base URL: ${status.baseUrl}`);
+    if (status.model) {
+      console.log(`  Model: ${status.model}`);
+    }
+    if (status.pid) {
+      console.log(`  PID: ${status.pid}`);
+    }
   }
   return 0;
 }
 
 async function handleActivate(args: string[]): Promise<number> {
-  const status = await getOpenAICompatProxyStatus();
+  const profileName = args.find((arg) => !arg.startsWith('-'));
+  const status = await getOpenAICompatProxyStatus(profileName);
   if (!status.running || !status.profileName || !status.port || !status.authToken) {
     console.error(fail('Proxy is not running. Start it with: ccs proxy start <profile>'));
     return 1;
+  }
+  if (!profileName) {
+    const running = (await listOpenAICompatProxyStatuses()).filter((entry) => entry.running);
+    if (running.length > 1) {
+      console.error(
+        fail('Multiple proxies are running. Specify a profile: ccs proxy activate <profile>')
+      );
+      return 1;
+    }
   }
 
   const shell = detectShell(args.includes('--fish') ? 'fish' : parseOptionValue(args, '--shell'));
@@ -163,16 +179,17 @@ export async function handleProxyCommand(args: string[]): Promise<number> {
     case 'start':
       return handleStart(args.slice(1));
     case 'stop': {
-      const result = await stopOpenAICompatProxy();
+      const profileName = args[1] && !args[1]?.startsWith('-') ? args[1] : undefined;
+      const result = await stopOpenAICompatProxy(profileName);
       if (!result.success) {
         console.error(fail(result.error || 'Failed to stop proxy'));
         return 1;
       }
-      console.log(ok('Proxy stopped'));
+      console.log(ok(profileName ? `Proxy stopped for profile ${profileName}` : 'Proxy stopped'));
       return 0;
     }
     case 'status':
-      return handleStatus();
+      return handleStatus(args.slice(1));
     case 'activate':
       return handleActivate(args.slice(1));
     default:

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -199,7 +199,7 @@ export async function handleProxyCommand(args: string[]): Promise<number> {
     case 'start':
       return handleStart(args.slice(1));
     case 'stop': {
-      const profileName = args[1] && !args[1]?.startsWith('-') ? args[1] : undefined;
+      const profileName = args[1] && !args[1].startsWith('-') ? args[1] : undefined;
       const result = await stopOpenAICompatProxy(profileName);
       if (!result.success) {
         console.error(fail(result.error || 'Failed to stop proxy'));

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -133,29 +133,55 @@ async function handleStatus(args: string[] = []): Promise<number> {
     return showHelp();
   }
   const profileName = findPositionalArg(args);
-  const running = profileName
-    ? [await getOpenAICompatProxyStatus(profileName)].filter((status) => status.running)
-    : (await listOpenAICompatProxyStatuses()).filter((status) => status.running);
-  if (running.length === 0) {
-    console.log(info('Proxy is not running'));
-    return 0;
-  }
-
-  for (const status of running) {
-    console.log(ok(`Proxy running on port ${status.port}`));
-    if (status.host) {
+  const printStatus = (status: Awaited<ReturnType<typeof getOpenAICompatProxyStatus>>) => {
+    console.log(
+      status.running
+        ? ok(`Proxy running on port ${status.port}`)
+        : info(`Proxy is not running${status.port ? ` (last known port ${status.port})` : ''}`)
+    );
+    if (status.host && status.port) {
       console.log(`  Host: ${status.host}`);
       console.log(`  Local URL: http://${status.host}:${status.port}`);
     }
-    console.log(`  Profile: ${status.profileName}`);
-    console.log(`  Base URL: ${status.baseUrl}`);
+    if (status.profileName) {
+      console.log(`  Profile: ${status.profileName}`);
+    }
+    if (status.baseUrl) {
+      console.log(`  Base URL: ${status.baseUrl}`);
+    }
     if (status.model) {
       console.log(`  Model: ${status.model}`);
     }
     if (status.pid) {
       console.log(`  PID: ${status.pid}`);
     }
+  };
+
+  if (profileName) {
+    const status = await getOpenAICompatProxyStatus(profileName);
+    if (!status.running && !status.profileName) {
+      console.log(info('Proxy is not running'));
+      return 0;
+    }
+    printStatus(status);
+    return 0;
   }
+
+  const status = await getOpenAICompatProxyStatus();
+  if (!status.running && !status.profileName) {
+    console.log(info('Proxy is not running'));
+    return 0;
+  }
+
+  if (status.running && !status.profileName) {
+    const running = (await listOpenAICompatProxyStatuses()).filter((entry) => entry.running);
+    for (const entry of running) {
+      printStatus(entry);
+    }
+    return 0;
+  }
+
+  printStatus(status);
   return 0;
 }
 

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -22,6 +22,10 @@ function parseOptionValue(args: string[], key: string): string | undefined {
   return withEquals ? withEquals.slice(prefix.length) : undefined;
 }
 
+function hasHelpFlag(args: string[]): boolean {
+  return args.includes('--help') || args.includes('-h');
+}
+
 export function findPositionalArg(
   args: string[],
   optionsWithValues: string[] = []
@@ -83,6 +87,9 @@ function resolveProfile(profileName: string) {
 }
 
 async function handleStart(args: string[]): Promise<number> {
+  if (hasHelpFlag(args)) {
+    return showHelp();
+  }
   const profileName = findPositionalArg(args, ['--port', '--host']);
   if (!profileName) {
     console.error(
@@ -122,6 +129,9 @@ async function handleStart(args: string[]): Promise<number> {
 }
 
 async function handleStatus(args: string[] = []): Promise<number> {
+  if (hasHelpFlag(args)) {
+    return showHelp();
+  }
   const profileName = findPositionalArg(args);
   const running = profileName
     ? [await getOpenAICompatProxyStatus(profileName)].filter((status) => status.running)
@@ -150,6 +160,9 @@ async function handleStatus(args: string[] = []): Promise<number> {
 }
 
 async function handleActivate(args: string[]): Promise<number> {
+  if (hasHelpFlag(args)) {
+    return showHelp();
+  }
   const profileName = findPositionalArg(args, ['--shell']);
   if (!profileName) {
     const running = (await listOpenAICompatProxyStatuses()).filter((entry) => entry.running);
@@ -199,6 +212,9 @@ export async function handleProxyCommand(args: string[]): Promise<number> {
     case 'start':
       return handleStart(args.slice(1));
     case 'stop': {
+      if (hasHelpFlag(args.slice(1))) {
+        return showHelp();
+      }
       const profileName = args[1] && !args[1].startsWith('-') ? args[1] : undefined;
       const result = await stopOpenAICompatProxy(profileName);
       if (!result.success) {

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -33,7 +33,7 @@ export function findPositionalArg(
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === '--') {
-      return args[i + 1];
+      return i + 1 < args.length ? args[i + 1] : undefined;
     }
     if (arg.startsWith('-')) {
       if (optionsWithValues.includes(arg)) {

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -22,9 +22,15 @@ function parseOptionValue(args: string[], key: string): string | undefined {
   return withEquals ? withEquals.slice(prefix.length) : undefined;
 }
 
-function findPositionalArg(args: string[], optionsWithValues: string[] = []): string | undefined {
+export function findPositionalArg(
+  args: string[],
+  optionsWithValues: string[] = []
+): string | undefined {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
+    if (arg === '--') {
+      return args[i + 1];
+    }
     if (arg.startsWith('-')) {
       if (optionsWithValues.includes(arg)) {
         i += 1;

--- a/src/commands/proxy-command.ts
+++ b/src/commands/proxy-command.ts
@@ -22,6 +22,20 @@ function parseOptionValue(args: string[], key: string): string | undefined {
   return withEquals ? withEquals.slice(prefix.length) : undefined;
 }
 
+function findPositionalArg(args: string[], optionsWithValues: string[] = []): string | undefined {
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg.startsWith('-')) {
+      if (optionsWithValues.includes(arg)) {
+        i += 1;
+      }
+      continue;
+    }
+    return arg;
+  }
+  return undefined;
+}
+
 function showHelp(): number {
   console.log('OpenAI-Compatible Proxy');
   console.log('');
@@ -63,7 +77,7 @@ function resolveProfile(profileName: string) {
 }
 
 async function handleStart(args: string[]): Promise<number> {
-  const profileName = args.find((arg) => !arg.startsWith('-'));
+  const profileName = findPositionalArg(args, ['--port', '--host']);
   if (!profileName) {
     console.error(
       fail('Usage: ccs proxy start <profile> [--port <n>] [--host <addr>] [--insecure]')
@@ -102,7 +116,7 @@ async function handleStart(args: string[]): Promise<number> {
 }
 
 async function handleStatus(args: string[] = []): Promise<number> {
-  const profileName = args.find((arg) => !arg.startsWith('-'));
+  const profileName = findPositionalArg(args);
   const running = profileName
     ? [await getOpenAICompatProxyStatus(profileName)].filter((status) => status.running)
     : (await listOpenAICompatProxyStatuses()).filter((status) => status.running);
@@ -130,12 +144,7 @@ async function handleStatus(args: string[] = []): Promise<number> {
 }
 
 async function handleActivate(args: string[]): Promise<number> {
-  const profileName = args.find((arg) => !arg.startsWith('-'));
-  const status = await getOpenAICompatProxyStatus(profileName);
-  if (!status.running || !status.profileName || !status.port || !status.authToken) {
-    console.error(fail('Proxy is not running. Start it with: ccs proxy start <profile>'));
-    return 1;
-  }
+  const profileName = findPositionalArg(args, ['--shell']);
   if (!profileName) {
     const running = (await listOpenAICompatProxyStatuses()).filter((entry) => entry.running);
     if (running.length > 1) {
@@ -144,6 +153,11 @@ async function handleActivate(args: string[]): Promise<number> {
       );
       return 1;
     }
+  }
+  const status = await getOpenAICompatProxyStatus(profileName);
+  if (!status.running || !status.profileName || !status.port || !status.authToken) {
+    console.error(fail('Proxy is not running. Start it with: ccs proxy start <profile>'));
+    return 1;
   }
 
   const shell = detectShell(args.includes('--fish') ? 'fish' : parseOptionValue(args, '--shell'));

--- a/src/config/unified-config-loader.ts
+++ b/src/config/unified-config-loader.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_GLOBAL_ENV,
   DEFAULT_CLIPROXY_SERVER_CONFIG,
   DEFAULT_CLIPROXY_SAFETY_CONFIG,
+  DEFAULT_OPENAI_COMPAT_PROXY_CONFIG,
   DEFAULT_QUOTA_MANAGEMENT_CONFIG,
   DEFAULT_THINKING_CONFIG,
   DEFAULT_OFFICIAL_CHANNELS_CONFIG,
@@ -414,6 +415,10 @@ function mergeWithDefaults(partial: Partial<UnifiedConfig>): UnifiedConfig {
       },
     },
     proxy: {
+      port: partial.proxy?.port ?? DEFAULT_OPENAI_COMPAT_PROXY_CONFIG.port,
+      profile_ports: partial.proxy?.profile_ports ?? {
+        ...DEFAULT_OPENAI_COMPAT_PROXY_CONFIG.profile_ports,
+      },
       routing: {
         default: partial.proxy?.routing?.default ?? defaults.proxy?.routing?.default,
         background: partial.proxy?.routing?.background ?? defaults.proxy?.routing?.background,

--- a/src/config/unified-config-types.ts
+++ b/src/config/unified-config-types.ts
@@ -508,6 +508,10 @@ export interface OpenAICompatProxyRoutingConfig {
 }
 
 export interface OpenAICompatProxyConfig {
+  /** Default local port for OpenAI-compatible proxy instances */
+  port?: number;
+  /** Optional profile-scoped local port overrides */
+  profile_ports?: Record<string, number>;
   routing?: OpenAICompatProxyRoutingConfig;
 }
 
@@ -986,6 +990,8 @@ export const DEFAULT_CLIPROXY_SERVER_CONFIG: CliproxyServerConfig = {
 };
 
 export const DEFAULT_OPENAI_COMPAT_PROXY_CONFIG: OpenAICompatProxyConfig = {
+  port: 3456,
+  profile_ports: {},
   routing: {
     longContextThreshold: 60_000,
   },
@@ -1016,6 +1022,8 @@ export function createEmptyUnifiedConfig(): UnifiedConfig {
       },
     },
     proxy: {
+      port: DEFAULT_OPENAI_COMPAT_PROXY_CONFIG.port,
+      profile_ports: { ...DEFAULT_OPENAI_COMPAT_PROXY_CONFIG.profile_ports },
       routing: {
         ...DEFAULT_OPENAI_COMPAT_PROXY_CONFIG.routing,
       },

--- a/src/proxy/index.ts
+++ b/src/proxy/index.ts
@@ -2,6 +2,7 @@ export * from './profile-router';
 export * from './proxy-daemon';
 export * from './proxy-daemon-paths';
 export * from './proxy-env';
+export * from './proxy-port-resolver';
 export * from './upstream-url';
 export * from './transformers/request-transformer';
 export * from './transformers/sse-stream-transformer';

--- a/src/proxy/proxy-daemon-paths.ts
+++ b/src/proxy/proxy-daemon-paths.ts
@@ -8,10 +8,20 @@ export function getOpenAICompatProxyDir(): string {
   return path.join(getCcsDir(), 'proxy');
 }
 
-export function getOpenAICompatProxyPidPath(): string {
-  return path.join(getOpenAICompatProxyDir(), 'daemon.pid');
+export function getOpenAICompatProxyProfileKey(profileName: string): string {
+  return encodeURIComponent(profileName.trim());
 }
 
-export function getOpenAICompatProxySessionPath(): string {
-  return path.join(getOpenAICompatProxyDir(), 'session.json');
+export function getOpenAICompatProxyPidPath(profileName: string): string {
+  return path.join(
+    getOpenAICompatProxyDir(),
+    `${getOpenAICompatProxyProfileKey(profileName)}.daemon.pid`
+  );
+}
+
+export function getOpenAICompatProxySessionPath(profileName: string): string {
+  return path.join(
+    getOpenAICompatProxyDir(),
+    `${getOpenAICompatProxyProfileKey(profileName)}.session.json`
+  );
 }

--- a/src/proxy/proxy-daemon-paths.ts
+++ b/src/proxy/proxy-daemon-paths.ts
@@ -25,3 +25,11 @@ export function getOpenAICompatProxySessionPath(profileName: string): string {
     `${getOpenAICompatProxyProfileKey(profileName)}.session.json`
   );
 }
+
+export function getLegacyOpenAICompatProxyPidPath(): string {
+  return path.join(getOpenAICompatProxyDir(), 'daemon.pid');
+}
+
+export function getLegacyOpenAICompatProxySessionPath(): string {
+  return path.join(getOpenAICompatProxyDir(), 'session.json');
+}

--- a/src/proxy/proxy-daemon-state.ts
+++ b/src/proxy/proxy-daemon-state.ts
@@ -21,9 +21,9 @@ function ensureProxyDir(): void {
   fs.mkdirSync(getOpenAICompatProxyDir(), { recursive: true });
 }
 
-export function getOpenAICompatProxyPid(): number | null {
+export function getOpenAICompatProxyPid(profileName: string): number | null {
   try {
-    const raw = fs.readFileSync(getOpenAICompatProxyPidPath(), 'utf8').trim();
+    const raw = fs.readFileSync(getOpenAICompatProxyPidPath(profileName), 'utf8').trim();
     const pid = Number.parseInt(raw, 10);
     return Number.isInteger(pid) ? pid : null;
   } catch {
@@ -31,23 +31,23 @@ export function getOpenAICompatProxyPid(): number | null {
   }
 }
 
-export function writeOpenAICompatProxyPid(pid: number): void {
+export function writeOpenAICompatProxyPid(profileName: string, pid: number): void {
   ensureProxyDir();
-  fs.writeFileSync(getOpenAICompatProxyPidPath(), String(pid), 'utf8');
+  fs.writeFileSync(getOpenAICompatProxyPidPath(profileName), String(pid), 'utf8');
 }
 
-export function removeOpenAICompatProxyPid(): void {
+export function removeOpenAICompatProxyPid(profileName: string): void {
   try {
-    fs.unlinkSync(getOpenAICompatProxyPidPath());
+    fs.unlinkSync(getOpenAICompatProxyPidPath(profileName));
   } catch {
     // Best-effort cleanup.
   }
 }
 
-export function readOpenAICompatProxySession(): OpenAICompatProxySession | null {
+export function readOpenAICompatProxySession(profileName: string): OpenAICompatProxySession | null {
   try {
     return JSON.parse(
-      fs.readFileSync(getOpenAICompatProxySessionPath(), 'utf8')
+      fs.readFileSync(getOpenAICompatProxySessionPath(profileName), 'utf8')
     ) as OpenAICompatProxySession;
   } catch {
     return null;
@@ -57,17 +57,45 @@ export function readOpenAICompatProxySession(): OpenAICompatProxySession | null 
 export function writeOpenAICompatProxySession(session: OpenAICompatProxySession): void {
   ensureProxyDir();
   fs.writeFileSync(
-    getOpenAICompatProxySessionPath(),
+    getOpenAICompatProxySessionPath(session.profileName),
     JSON.stringify(session, null, 2) + '\n',
     'utf8'
   );
 }
 
-export function removeOpenAICompatProxySession(): void {
+export function removeOpenAICompatProxySession(profileName: string): void {
   try {
-    fs.unlinkSync(getOpenAICompatProxySessionPath());
+    fs.unlinkSync(getOpenAICompatProxySessionPath(profileName));
   } catch {
     // Best-effort cleanup.
+  }
+}
+
+export function listOpenAICompatProxyProfileNames(): string[] {
+  try {
+    const entries = fs.readdirSync(getOpenAICompatProxyDir(), { withFileTypes: true });
+    const profileKeys = new Set<string>();
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.session.json')) {
+        continue;
+      }
+      profileKeys.add(entry.name.slice(0, -'.session.json'.length));
+    }
+    return [...profileKeys].map((profileKey) => decodeURIComponent(profileKey));
+  } catch {
+    return [];
+  }
+}
+
+export function cleanupLegacyOpenAICompatProxyState(): void {
+  ensureProxyDir();
+  const legacyNames = ['daemon.pid', 'session.json'];
+  for (const legacyName of legacyNames) {
+    try {
+      fs.unlinkSync(path.join(getOpenAICompatProxyDir(), legacyName));
+    } catch {
+      // Best-effort cleanup.
+    }
   }
 }
 

--- a/src/proxy/proxy-daemon-state.ts
+++ b/src/proxy/proxy-daemon-state.ts
@@ -121,7 +121,13 @@ export function listOpenAICompatProxyProfileNames(): string[] {
       }
       profileKeys.add(profileKey);
     }
-    return [...profileKeys].map((profileKey) => decodeURIComponent(profileKey));
+    return [...profileKeys].flatMap((profileKey) => {
+      try {
+        return [decodeURIComponent(profileKey)];
+      } catch {
+        return [];
+      }
+    });
   } catch {
     return [];
   }

--- a/src/proxy/proxy-daemon-state.ts
+++ b/src/proxy/proxy-daemon-state.ts
@@ -103,34 +103,41 @@ export function removeLegacyOpenAICompatProxySession(): void {
   }
 }
 
-export function listOpenAICompatProxyProfileNames(): string[] {
+function decodeProfileKey(profileKey: string): string[] {
+  try {
+    return [decodeURIComponent(profileKey)];
+  } catch {
+    return [];
+  }
+}
+
+function listProfileNamesForSuffix(suffix: string, legacyName?: string): string[] {
   try {
     const entries = fs.readdirSync(getOpenAICompatProxyDir(), { withFileTypes: true });
     const profileKeys = new Set<string>();
     for (const entry of entries) {
-      if (
-        !entry.isFile() ||
-        entry.name === 'session.json' ||
-        !entry.name.endsWith('.session.json')
-      ) {
+      if (!entry.isFile() || entry.name === legacyName || !entry.name.endsWith(suffix)) {
         continue;
       }
-      const profileKey = entry.name.slice(0, -'.session.json'.length);
+      const profileKey = entry.name.slice(0, -suffix.length);
       if (!profileKey) {
         continue;
       }
       profileKeys.add(profileKey);
     }
-    return [...profileKeys].flatMap((profileKey) => {
-      try {
-        return [decodeURIComponent(profileKey)];
-      } catch {
-        return [];
-      }
-    });
+    return [...profileKeys].flatMap(decodeProfileKey);
   } catch {
     return [];
   }
+}
+
+export function listOpenAICompatProxyProfileNames(): string[] {
+  return [
+    ...new Set([
+      ...listProfileNamesForSuffix('.session.json', 'session.json'),
+      ...listProfileNamesForSuffix('.daemon.pid', 'daemon.pid'),
+    ]),
+  ];
 }
 
 export function resolveOpenAICompatProxyEntrypointCandidates(): string[] {

--- a/src/proxy/proxy-daemon-state.ts
+++ b/src/proxy/proxy-daemon-state.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {
   getOpenAICompatProxyDir,
+  getLegacyOpenAICompatProxyPidPath,
+  getLegacyOpenAICompatProxySessionPath,
   getOpenAICompatProxyPidPath,
   getOpenAICompatProxySessionPath,
 } from './proxy-daemon-paths';
@@ -21,14 +23,22 @@ function ensureProxyDir(): void {
   fs.mkdirSync(getOpenAICompatProxyDir(), { recursive: true });
 }
 
-export function getOpenAICompatProxyPid(profileName: string): number | null {
+function readPid(pidPath: string): number | null {
   try {
-    const raw = fs.readFileSync(getOpenAICompatProxyPidPath(profileName), 'utf8').trim();
+    const raw = fs.readFileSync(pidPath, 'utf8').trim();
     const pid = Number.parseInt(raw, 10);
     return Number.isInteger(pid) ? pid : null;
   } catch {
     return null;
   }
+}
+
+export function getOpenAICompatProxyPid(profileName: string): number | null {
+  return readPid(getOpenAICompatProxyPidPath(profileName));
+}
+
+export function getLegacyOpenAICompatProxyPid(): number | null {
+  return readPid(getLegacyOpenAICompatProxyPidPath());
 }
 
 export function writeOpenAICompatProxyPid(profileName: string, pid: number): void {
@@ -44,14 +54,28 @@ export function removeOpenAICompatProxyPid(profileName: string): void {
   }
 }
 
-export function readOpenAICompatProxySession(profileName: string): OpenAICompatProxySession | null {
+export function removeLegacyOpenAICompatProxyPid(): void {
   try {
-    return JSON.parse(
-      fs.readFileSync(getOpenAICompatProxySessionPath(profileName), 'utf8')
-    ) as OpenAICompatProxySession;
+    fs.unlinkSync(getLegacyOpenAICompatProxyPidPath());
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+function readSession(sessionPath: string): OpenAICompatProxySession | null {
+  try {
+    return JSON.parse(fs.readFileSync(sessionPath, 'utf8')) as OpenAICompatProxySession;
   } catch {
     return null;
   }
+}
+
+export function readOpenAICompatProxySession(profileName: string): OpenAICompatProxySession | null {
+  return readSession(getOpenAICompatProxySessionPath(profileName));
+}
+
+export function readLegacyOpenAICompatProxySession(): OpenAICompatProxySession | null {
+  return readSession(getLegacyOpenAICompatProxySessionPath());
 }
 
 export function writeOpenAICompatProxySession(session: OpenAICompatProxySession): void {
@@ -71,6 +95,14 @@ export function removeOpenAICompatProxySession(profileName: string): void {
   }
 }
 
+export function removeLegacyOpenAICompatProxySession(): void {
+  try {
+    fs.unlinkSync(getLegacyOpenAICompatProxySessionPath());
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
 export function listOpenAICompatProxyProfileNames(): string[] {
   try {
     const entries = fs.readdirSync(getOpenAICompatProxyDir(), { withFileTypes: true });
@@ -84,18 +116,6 @@ export function listOpenAICompatProxyProfileNames(): string[] {
     return [...profileKeys].map((profileKey) => decodeURIComponent(profileKey));
   } catch {
     return [];
-  }
-}
-
-export function cleanupLegacyOpenAICompatProxyState(): void {
-  ensureProxyDir();
-  const legacyNames = ['daemon.pid', 'session.json'];
-  for (const legacyName of legacyNames) {
-    try {
-      fs.unlinkSync(path.join(getOpenAICompatProxyDir(), legacyName));
-    } catch {
-      // Best-effort cleanup.
-    }
   }
 }
 

--- a/src/proxy/proxy-daemon-state.ts
+++ b/src/proxy/proxy-daemon-state.ts
@@ -108,10 +108,18 @@ export function listOpenAICompatProxyProfileNames(): string[] {
     const entries = fs.readdirSync(getOpenAICompatProxyDir(), { withFileTypes: true });
     const profileKeys = new Set<string>();
     for (const entry of entries) {
-      if (!entry.isFile() || !entry.name.endsWith('.session.json')) {
+      if (
+        !entry.isFile() ||
+        entry.name === 'session.json' ||
+        !entry.name.endsWith('.session.json')
+      ) {
         continue;
       }
-      profileKeys.add(entry.name.slice(0, -'.session.json'.length));
+      const profileKey = entry.name.slice(0, -'.session.json'.length);
+      if (!profileKey) {
+        continue;
+      }
+      profileKeys.add(profileKey);
     }
     return [...profileKeys].map((profileKey) => decodeURIComponent(profileKey));
   } catch {

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -47,6 +47,31 @@ interface OpenAICompatProxyLaunchResult extends StartOpenAICompatProxyResult {
   bindConflict?: boolean;
 }
 
+interface OpenAICompatProxyHealthPayload {
+  service?: string;
+  profile?: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function verifyProxyProcessOwnership(
+  pid: number,
+  profileName?: string
+): ReturnType<typeof verifyProcessOwnership> {
+  const profilePattern = profileName
+    ? new RegExp(`(^|\\s)--profile(?:\\s+|=)${escapeRegExp(profileName)}(?=\\s|$)`)
+    : null;
+  return verifyProcessOwnership(
+    pid,
+    (commandLine) =>
+      commandLine.includes('--ccs-openai-proxy-daemon') &&
+      commandLine.includes('proxy-daemon-entry') &&
+      (!profilePattern || profilePattern.test(commandLine))
+  );
+}
+
 function generateProxyAuthToken(): string {
   return crypto.randomBytes(24).toString('hex');
 }
@@ -162,7 +187,10 @@ async function resolveDaemonEntrypoint(): Promise<string | null> {
   return null;
 }
 
-export async function isOpenAICompatProxyRunning(port: number): Promise<boolean> {
+export async function isOpenAICompatProxyRunning(
+  port: number,
+  expectedProfileName?: string
+): Promise<boolean> {
   return new Promise((resolve) => {
     const req = http.request(
       { hostname: '127.0.0.1', port, path: '/health', method: 'GET', timeout: 3000 },
@@ -176,8 +204,11 @@ export async function isOpenAICompatProxyRunning(port: number): Promise<boolean>
             return;
           }
           try {
-            const payload = JSON.parse(body) as { service?: string };
-            resolve(payload.service === OPENAI_COMPAT_PROXY_SERVICE_NAME);
+            const payload = JSON.parse(body) as OpenAICompatProxyHealthPayload;
+            resolve(
+              payload.service === OPENAI_COMPAT_PROXY_SERVICE_NAME &&
+                (!expectedProfileName || payload.profile === expectedProfileName)
+            );
           } catch {
             resolve(false);
           }
@@ -199,11 +230,11 @@ async function getOpenAICompatProxyStatusForProfile(
   const state = getOpenAICompatProxyStateForProfile(profileName);
   const session = state.session;
   if (!session) {
-    return { running: false, profileName };
+    return { running: false, profileName, pid: state.pid || undefined };
   }
 
   const port = session.port;
-  const running = await isOpenAICompatProxyRunning(port);
+  const running = await isOpenAICompatProxyRunning(port, profileName);
   return {
     running,
     pid: running ? state.pid || undefined : undefined,
@@ -219,7 +250,8 @@ async function getLegacyOpenAICompatProxyStatus(): Promise<OpenAICompatProxyStat
   }
 
   const port = session?.port;
-  const running = typeof port === 'number' ? await isOpenAICompatProxyRunning(port) : false;
+  const running =
+    typeof port === 'number' ? await isOpenAICompatProxyRunning(port, session?.profileName) : false;
   return {
     running,
     pid: running ? pid || undefined : pid || undefined,
@@ -297,12 +329,7 @@ async function stopOpenAICompatProxyUnlocked(
     return { success: true };
   }
 
-  const ownership = verifyProcessOwnership(
-    pid,
-    (commandLine) =>
-      commandLine.includes('--ccs-openai-proxy-daemon') &&
-      commandLine.includes('proxy-daemon-entry')
-  );
+  const ownership = verifyProxyProcessOwnership(pid, profileName);
 
   if (ownership === 'not-owned') {
     removeOpenAICompatProxyState(state, profileName);
@@ -368,12 +395,7 @@ async function stopLegacyOpenAICompatProxyUnlocked(): Promise<{
     return { success: true };
   }
 
-  const ownership = verifyProcessOwnership(
-    pid,
-    (commandLine) =>
-      commandLine.includes('--ccs-openai-proxy-daemon') &&
-      commandLine.includes('proxy-daemon-entry')
-  );
+  const ownership = verifyProxyProcessOwnership(pid);
 
   if (ownership === 'not-owned' || ownership === 'not-running') {
     removeLegacyOpenAICompatProxyPid();
@@ -490,6 +512,16 @@ export async function startOpenAICompatProxy(
     if (!Number.isInteger(preferredPort) || preferredPort < 1 || preferredPort > 65535) {
       return { success: false, port: preferredPort, error: `Invalid port: ${preferredPort}` };
     }
+    if (status.pid && !status.port) {
+      const stopped = await stopOpenAICompatProxyUnlocked(profile.profileName);
+      if (!stopped.success) {
+        return {
+          success: false,
+          port: preferredPort,
+          error: stopped.error || 'Failed to clear stale proxy state',
+        };
+      }
+    }
 
     const daemonEntry = await resolveDaemonEntrypoint();
     if (!daemonEntry) {
@@ -565,7 +597,7 @@ export async function startOpenAICompatProxy(
         let attempts = 0;
         const poll = async () => {
           attempts += 1;
-          if (await isOpenAICompatProxyRunning(port)) {
+          if (await isOpenAICompatProxyRunning(port, profile.profileName)) {
             if (persistState) {
               commitState();
             }

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -2,7 +2,6 @@ import { spawn, type ChildProcess } from 'child_process';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as http from 'http';
-import * as net from 'net';
 import * as lockfile from 'proper-lockfile';
 import { verifyProcessOwnership } from '../cursor/daemon-process-ownership';
 import type { OpenAICompatProfileConfig } from './profile-router';
@@ -45,6 +44,7 @@ export interface StartOpenAICompatProxyResult {
 interface OpenAICompatProxyLaunchResult extends StartOpenAICompatProxyResult {
   commitState?: () => void;
   stop?: () => Promise<void>;
+  bindConflict?: boolean;
 }
 
 function generateProxyAuthToken(): string {
@@ -81,23 +81,6 @@ async function withOpenAICompatProxyLock<T>(operation: () => Promise<T>): Promis
   }
 }
 
-async function isPortOccupied(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const socket = net.createConnection({ host: '127.0.0.1', port });
-    const finish = (occupied: boolean) => {
-      socket.removeAllListeners();
-      socket.destroy();
-      resolve(occupied);
-    };
-
-    socket.once('connect', () => finish(true));
-    socket.once('error', () => finish(false));
-    socket.setTimeout(500, () => {
-      finish(false);
-    });
-  });
-}
-
 async function terminateDaemonProcess(pid?: number): Promise<void> {
   if (!pid) {
     return;
@@ -122,33 +105,47 @@ async function terminateDaemonProcess(pid?: number): Promise<void> {
   }
 }
 
-async function findOpenAICompatProxyPort(
+function listOpenAICompatProxyCandidatePorts(
+  preferredPort: number,
+  exact: boolean,
   excludedPorts: ReadonlySet<number> = new Set()
-): Promise<number> {
+): number[] {
+  if (exact) {
+    return excludedPorts.has(preferredPort) ? [] : [preferredPort];
+  }
+
+  const candidates = new Set<number>();
+  if (
+    preferredPort >= OPENAI_COMPAT_PROXY_DEFAULT_PORT &&
+    preferredPort <= OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10 &&
+    !excludedPorts.has(preferredPort)
+  ) {
+    candidates.add(preferredPort);
+  }
+
   for (
     let candidate = OPENAI_COMPAT_PROXY_DEFAULT_PORT;
     candidate <= OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10;
     candidate += 1
   ) {
-    if (excludedPorts.has(candidate)) {
-      continue;
-    }
-    if (!(await isPortOccupied(candidate))) {
-      return candidate;
+    if (!excludedPorts.has(candidate)) {
+      candidates.add(candidate);
     }
   }
 
-  return 0;
+  return [...candidates];
 }
 
-async function findOpenAICompatProxyPortNear(
-  preferredPort: number,
-  excludedPorts: ReadonlySet<number> = new Set()
-): Promise<number> {
-  if (!excludedPorts.has(preferredPort) && !(await isPortOccupied(preferredPort))) {
-    return preferredPort;
+function isPortBindConflictMessage(message?: string): boolean {
+  if (!message) {
+    return false;
   }
-  return findOpenAICompatProxyPort(excludedPorts);
+  const normalized = message.toLowerCase();
+  return (
+    message.includes('EADDRINUSE') ||
+    normalized.includes('address already in use') ||
+    (normalized.includes('is port') && normalized.includes('in use'))
+  );
 }
 
 interface OpenAICompatProxyStateRecord {
@@ -399,23 +396,6 @@ export async function startOpenAICompatProxy(
     if (!Number.isInteger(preferredPort) || preferredPort < 1 || preferredPort > 65535) {
       return { success: false, port: preferredPort, error: `Invalid port: ${preferredPort}` };
     }
-    if (requiresExactPort && (await isPortOccupied(preferredPort))) {
-      return {
-        success: false,
-        port: preferredPort,
-        error: `Requested proxy port ${preferredPort} is already in use`,
-      };
-    }
-    if (status.running) {
-      const stopped = await stopOpenAICompatProxyUnlocked(profile.profileName);
-      if (!stopped.success) {
-        return {
-          success: false,
-          port: preferredPort,
-          error: stopped.error || 'Failed to restart the running proxy',
-        };
-      }
-    }
 
     const daemonEntry = await resolveDaemonEntrypoint();
     if (!daemonEntry) {
@@ -433,6 +413,7 @@ export async function startOpenAICompatProxy(
       new Promise((resolve) => {
         let resolved = false;
         let timeout: NodeJS.Timeout | null = null;
+        let stderr = '';
         const authToken = generateProxyAuthToken();
         const commitState = () => {
           if (proc.pid) {
@@ -478,10 +459,14 @@ export async function startOpenAICompatProxy(
             ...(options.insecure ? ['--insecure'] : []),
             '--ccs-openai-proxy-daemon',
           ],
-          { stdio: 'ignore', detached: true }
+          { stdio: ['ignore', 'ignore', 'pipe'], detached: true }
         );
 
         proc.unref();
+        proc.stderr?.setEncoding('utf8');
+        proc.stderr?.on('data', (chunk) => {
+          stderr += chunk;
+        });
         if (persistState) {
           commitState();
         }
@@ -519,14 +504,21 @@ export async function startOpenAICompatProxy(
 
         timeout = setTimeout(poll, 1000);
         proc.on('error', (error) => {
-          finish({ success: false, port, error: error.message });
+          finish({
+            success: false,
+            port,
+            error: error.message,
+            bindConflict: isPortBindConflictMessage(error.message),
+          });
         });
         proc.on('exit', (code, signal) => {
+          const bindConflict = isPortBindConflictMessage(stderr);
           if (code === 0) {
             finish({
               success: false,
               port,
               error: 'Proxy daemon exited before becoming healthy',
+              bindConflict,
             });
             return;
           }
@@ -534,7 +526,8 @@ export async function startOpenAICompatProxy(
             finish({
               success: false,
               port,
-              error: `Proxy daemon exited with code ${code}`,
+              error: stderr.trim() || `Proxy daemon exited with code ${code}`,
+              bindConflict,
             });
             return;
           }
@@ -542,35 +535,42 @@ export async function startOpenAICompatProxy(
             success: false,
             port,
             error: `Proxy daemon was killed by signal ${signal}`,
+            bindConflict,
           });
         });
       });
 
     const launchProxy = async (persistState: boolean): Promise<OpenAICompatProxyLaunchResult> => {
-      if (requiresExactPort) {
-        return launchOnPort(preferredPort, persistState);
-      }
-
       const attemptedPorts = new Set<number>();
       let lastResult: OpenAICompatProxyLaunchResult | null = null;
-      for (let attempt = 0; attempt < 3; attempt += 1) {
-        const port = await findOpenAICompatProxyPortNear(preferredPort, attemptedPorts);
-        if (port === 0) {
-          return {
-            success: false,
-            port: preferredPort,
-            error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
-          };
-        }
+      const candidates = listOpenAICompatProxyCandidatePorts(
+        preferredPort,
+        requiresExactPort,
+        attemptedPorts
+      );
+      if (candidates.length === 0) {
+        return {
+          success: false,
+          port: preferredPort,
+          error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
+        };
+      }
 
+      for (const port of candidates) {
         const result = await launchOnPort(port, persistState);
         if (result.success) {
           return result;
         }
+        if (requiresExactPort && result.bindConflict) {
+          return {
+            ...result,
+            error: `Requested proxy port ${preferredPort} is already in use`,
+          };
+        }
 
         lastResult = result;
         attemptedPorts.add(port);
-        if (!(await isPortOccupied(port))) {
+        if (!result.bindConflict) {
           return result;
         }
       }
@@ -579,7 +579,9 @@ export async function startOpenAICompatProxy(
         lastResult ?? {
           success: false,
           port: preferredPort,
-          error: 'Failed to start proxy',
+          error: requiresExactPort
+            ? `Requested proxy port ${preferredPort} is already in use`
+            : 'No free proxy port found in the proxy port range',
         }
       );
     };

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -13,7 +13,9 @@ import {
 } from './proxy-daemon-paths';
 import {
   getOpenAICompatProxyPid,
+  listOpenAICompatProxyProfileNames,
   readOpenAICompatProxySession,
+  cleanupLegacyOpenAICompatProxyState,
   removeOpenAICompatProxyPid,
   removeOpenAICompatProxySession,
   resolveOpenAICompatProxyEntrypointCandidates,
@@ -21,6 +23,7 @@ import {
   writeOpenAICompatProxyPid,
   writeOpenAICompatProxySession,
 } from './proxy-daemon-state';
+import { resolveOpenAICompatProxyPreferredPort } from './proxy-port-resolver';
 
 export interface OpenAICompatProxyStatus extends Partial<OpenAICompatProxySession> {
   running: boolean;
@@ -101,6 +104,13 @@ async function findOpenAICompatProxyPort(): Promise<number> {
   return 0;
 }
 
+async function findOpenAICompatProxyPortNear(preferredPort: number): Promise<number> {
+  if (!(await isPortOccupied(preferredPort))) {
+    return preferredPort;
+  }
+  return findOpenAICompatProxyPort();
+}
+
 async function resolveDaemonEntrypoint(): Promise<string | null> {
   for (const candidate of resolveOpenAICompatProxyEntrypointCandidates()) {
     try {
@@ -144,21 +154,52 @@ export async function isOpenAICompatProxyRunning(port: number): Promise<boolean>
   });
 }
 
-export async function getOpenAICompatProxyStatus(): Promise<OpenAICompatProxyStatus> {
-  const session = readOpenAICompatProxySession();
+async function getOpenAICompatProxyStatusForProfile(
+  profileName: string
+): Promise<OpenAICompatProxyStatus> {
+  const session = readOpenAICompatProxySession(profileName);
   const port = session?.port ?? OPENAI_COMPAT_PROXY_DEFAULT_PORT;
   const running = await isOpenAICompatProxyRunning(port);
   return {
     running,
-    pid: running ? getOpenAICompatProxyPid() || undefined : undefined,
+    pid: running ? getOpenAICompatProxyPid(profileName) || undefined : undefined,
     ...session,
   };
 }
 
-async function stopOpenAICompatProxyUnlocked(): Promise<{ success: boolean; error?: string }> {
-  const pid = getOpenAICompatProxyPid();
+export async function listOpenAICompatProxyStatuses(): Promise<OpenAICompatProxyStatus[]> {
+  const profileNames = listOpenAICompatProxyProfileNames();
+  const statuses = await Promise.all(
+    profileNames.map((profileName) => getOpenAICompatProxyStatusForProfile(profileName))
+  );
+  return statuses.filter((status) => status.profileName);
+}
+
+export async function getOpenAICompatProxyStatus(
+  profileName?: string
+): Promise<OpenAICompatProxyStatus> {
+  if (profileName) {
+    return getOpenAICompatProxyStatusForProfile(profileName);
+  }
+
+  const statuses = await listOpenAICompatProxyStatuses();
+  const running = statuses.filter((status) => status.running);
+  if (running.length === 1) {
+    return running[0] || { running: false };
+  }
+  if (running.length > 1) {
+    return { running: true };
+  }
+  const latestKnown = statuses[0];
+  return latestKnown ?? { running: false };
+}
+
+async function stopOpenAICompatProxyUnlocked(
+  profileName: string
+): Promise<{ success: boolean; error?: string }> {
+  const pid = getOpenAICompatProxyPid(profileName);
   if (!pid) {
-    removeOpenAICompatProxySession();
+    removeOpenAICompatProxySession(profileName);
     return { success: true };
   }
 
@@ -170,7 +211,8 @@ async function stopOpenAICompatProxyUnlocked(): Promise<{ success: boolean; erro
   );
 
   if (ownership === 'not-owned') {
-    removeOpenAICompatProxyPid();
+    removeOpenAICompatProxyPid(profileName);
+    removeOpenAICompatProxySession(profileName);
     return { success: true };
   }
 
@@ -182,8 +224,8 @@ async function stopOpenAICompatProxyUnlocked(): Promise<{ success: boolean; erro
   }
 
   if (ownership === 'not-running') {
-    removeOpenAICompatProxyPid();
-    removeOpenAICompatProxySession();
+    removeOpenAICompatProxyPid(profileName);
+    removeOpenAICompatProxySession(profileName);
     return { success: true };
   }
 
@@ -214,13 +256,32 @@ async function stopOpenAICompatProxyUnlocked(): Promise<{ success: boolean; erro
     }
   }
 
-  removeOpenAICompatProxyPid();
-  removeOpenAICompatProxySession();
+  removeOpenAICompatProxyPid(profileName);
+  removeOpenAICompatProxySession(profileName);
   return { success: true };
 }
 
-export async function stopOpenAICompatProxy(): Promise<{ success: boolean; error?: string }> {
-  return withOpenAICompatProxyLock(() => stopOpenAICompatProxyUnlocked());
+export async function stopOpenAICompatProxy(
+  profileName?: string
+): Promise<{ success: boolean; error?: string }> {
+  return withOpenAICompatProxyLock(async () => {
+    cleanupLegacyOpenAICompatProxyState();
+    if (profileName) {
+      return stopOpenAICompatProxyUnlocked(profileName);
+    }
+
+    const statuses = await listOpenAICompatProxyStatuses();
+    for (const status of statuses) {
+      if (!status.profileName) {
+        continue;
+      }
+      const stopped = await stopOpenAICompatProxyUnlocked(status.profileName);
+      if (!stopped.success) {
+        return stopped;
+      }
+    }
+    return { success: true };
+  });
 }
 
 export async function startOpenAICompatProxy(
@@ -228,30 +289,28 @@ export async function startOpenAICompatProxy(
   options: { port?: number; host?: string; insecure?: boolean } = {}
 ): Promise<StartOpenAICompatProxyResult> {
   return withOpenAICompatProxyLock(async () => {
-    const status = await getOpenAICompatProxyStatus();
+    cleanupLegacyOpenAICompatProxyState();
+    const status = await getOpenAICompatProxyStatus(profile.profileName);
     const host = options.host?.trim() || status.host || '127.0.0.1';
-    const port =
+    const preferredPort =
       typeof options.port === 'number'
         ? options.port
-        : status.running && status.profileName === profile.profileName && status.port
-          ? status.port
-          : await findOpenAICompatProxyPort();
+        : status.port || resolveOpenAICompatProxyPreferredPort(profile.profileName);
+    const port =
+      status.running && status.port && (status.host || '127.0.0.1') === host
+        ? status.port
+        : await findOpenAICompatProxyPortNear(preferredPort);
     if (port === 0) {
       return {
         success: false,
-        port: OPENAI_COMPAT_PROXY_DEFAULT_PORT,
+        port: preferredPort,
         error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
       };
     }
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
       return { success: false, port, error: `Invalid port: ${port}` };
     }
-    if (
-      status.running &&
-      status.profileName === profile.profileName &&
-      status.port === port &&
-      (status.host || '127.0.0.1') === host
-    ) {
+    if (status.running && status.port === port && (status.host || '127.0.0.1') === host) {
       return {
         success: true,
         alreadyRunning: true,
@@ -261,15 +320,7 @@ export async function startOpenAICompatProxy(
       };
     }
     if (status.running) {
-      if (status.profileName !== profile.profileName) {
-        return {
-          success: false,
-          port,
-          error: `Proxy already running for profile "${status.profileName}" on port ${status.port}. Stop it before starting a different profile.`,
-        };
-      }
-
-      const stopped = await stopOpenAICompatProxyUnlocked();
+      const stopped = await stopOpenAICompatProxyUnlocked(profile.profileName);
       if (!stopped.success) {
         return {
           success: false,
@@ -298,8 +349,8 @@ export async function startOpenAICompatProxy(
         resolved = true;
         if (timeout) clearTimeout(timeout);
         if (!result.success) {
-          removeOpenAICompatProxyPid();
-          removeOpenAICompatProxySession();
+          removeOpenAICompatProxyPid(profile.profileName);
+          removeOpenAICompatProxySession(profile.profileName);
         }
         resolve(result);
       };
@@ -326,7 +377,7 @@ export async function startOpenAICompatProxy(
 
       proc.unref();
       if (proc.pid) {
-        writeOpenAICompatProxyPid(proc.pid);
+        writeOpenAICompatProxyPid(profile.profileName, proc.pid);
       }
       writeOpenAICompatProxySession({
         profileName: profile.profileName,

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -42,6 +42,11 @@ export interface StartOpenAICompatProxyResult {
   error?: string;
 }
 
+interface OpenAICompatProxyLaunchResult extends StartOpenAICompatProxyResult {
+  commitState?: () => void;
+  stop?: () => Promise<void>;
+}
+
 function generateProxyAuthToken(): string {
   return crypto.randomBytes(24).toString('hex');
 }
@@ -91,6 +96,30 @@ async function isPortOccupied(port: number): Promise<boolean> {
       finish(false);
     });
   });
+}
+
+async function terminateDaemonProcess(pid?: number): Promise<void> {
+  if (!pid) {
+    return;
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+    let attempts = 0;
+    while (attempts < 10) {
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      try {
+        process.kill(pid, 0);
+        attempts += 1;
+      } catch {
+        return;
+      }
+    }
+
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Best-effort cleanup for a daemon we just spawned.
+  }
 }
 
 async function findOpenAICompatProxyPort(
@@ -397,17 +426,35 @@ export async function startOpenAICompatProxy(
       };
     }
 
-    const startOnPort = (port: number): Promise<StartOpenAICompatProxyResult> =>
+    const launchOnPort = (
+      port: number,
+      persistState: boolean
+    ): Promise<OpenAICompatProxyLaunchResult> =>
       new Promise((resolve) => {
         let resolved = false;
         let timeout: NodeJS.Timeout | null = null;
         const authToken = generateProxyAuthToken();
+        const commitState = () => {
+          if (proc.pid) {
+            writeOpenAICompatProxyPid(profile.profileName, proc.pid);
+          }
+          writeOpenAICompatProxySession({
+            profileName: profile.profileName,
+            settingsPath: profile.settingsPath,
+            host,
+            port,
+            baseUrl: profile.baseUrl,
+            authToken,
+            model: profile.model,
+            insecure: options.insecure,
+          });
+        };
 
-        const finish = (result: StartOpenAICompatProxyResult) => {
+        const finish = (result: OpenAICompatProxyLaunchResult) => {
           if (resolved) return;
           resolved = true;
           if (timeout) clearTimeout(timeout);
-          if (!result.success) {
+          if (!result.success && persistState) {
             removeOpenAICompatProxyPid(profile.profileName);
             removeOpenAICompatProxySession(profile.profileName);
           }
@@ -435,25 +482,28 @@ export async function startOpenAICompatProxy(
         );
 
         proc.unref();
-        if (proc.pid) {
-          writeOpenAICompatProxyPid(profile.profileName, proc.pid);
+        if (persistState) {
+          commitState();
         }
-        writeOpenAICompatProxySession({
-          profileName: profile.profileName,
-          settingsPath: profile.settingsPath,
-          host,
-          port,
-          baseUrl: profile.baseUrl,
-          authToken,
-          model: profile.model,
-          insecure: options.insecure,
-        });
 
         let attempts = 0;
         const poll = async () => {
           attempts += 1;
           if (await isOpenAICompatProxyRunning(port)) {
-            finish({ success: true, pid: proc.pid, port, authToken });
+            finish({
+              success: true,
+              pid: proc.pid,
+              port,
+              authToken,
+              ...(persistState
+                ? {}
+                : {
+                    commitState,
+                    stop: async () => {
+                      await terminateDaemonProcess(proc.pid);
+                    },
+                  }),
+            });
             return;
           }
           if (attempts >= 30) {
@@ -496,40 +546,64 @@ export async function startOpenAICompatProxy(
         });
       });
 
-    if (requiresExactPort) {
-      return startOnPort(preferredPort);
-    }
+    const launchProxy = async (persistState: boolean): Promise<OpenAICompatProxyLaunchResult> => {
+      if (requiresExactPort) {
+        return launchOnPort(preferredPort, persistState);
+      }
 
-    const attemptedPorts = new Set<number>();
-    let lastResult: StartOpenAICompatProxyResult | null = null;
-    for (let attempt = 0; attempt < 3; attempt += 1) {
-      const port = await findOpenAICompatProxyPortNear(preferredPort, attemptedPorts);
-      if (port === 0) {
-        return {
+      const attemptedPorts = new Set<number>();
+      let lastResult: OpenAICompatProxyLaunchResult | null = null;
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        const port = await findOpenAICompatProxyPortNear(preferredPort, attemptedPorts);
+        if (port === 0) {
+          return {
+            success: false,
+            port: preferredPort,
+            error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
+          };
+        }
+
+        const result = await launchOnPort(port, persistState);
+        if (result.success) {
+          return result;
+        }
+
+        lastResult = result;
+        attemptedPorts.add(port);
+        if (!(await isPortOccupied(port))) {
+          return result;
+        }
+      }
+
+      return (
+        lastResult ?? {
           success: false,
           port: preferredPort,
-          error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
+          error: 'Failed to start proxy',
+        }
+      );
+    };
+
+    if (status.running) {
+      const launched = await launchProxy(false);
+      if (!launched.success) {
+        return launched;
+      }
+
+      const stopped = await stopOpenAICompatProxyUnlocked(profile.profileName);
+      if (!stopped.success) {
+        await launched.stop?.();
+        return {
+          success: false,
+          port: launched.port,
+          error: stopped.error || 'Failed to replace the running proxy',
         };
       }
 
-      const result = await startOnPort(port);
-      if (result.success) {
-        return result;
-      }
-
-      lastResult = result;
-      attemptedPorts.add(port);
-      if (!(await isPortOccupied(port))) {
-        return result;
-      }
+      launched.commitState?.();
+      return launched;
     }
 
-    return (
-      lastResult ?? {
-        success: false,
-        port: preferredPort,
-        error: 'Failed to start proxy',
-      }
-    );
+    return launchProxy(true);
   });
 }

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -93,12 +93,17 @@ async function isPortOccupied(port: number): Promise<boolean> {
   });
 }
 
-async function findOpenAICompatProxyPort(): Promise<number> {
+async function findOpenAICompatProxyPort(
+  excludedPorts: ReadonlySet<number> = new Set()
+): Promise<number> {
   for (
     let candidate = OPENAI_COMPAT_PROXY_DEFAULT_PORT;
     candidate <= OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10;
     candidate += 1
   ) {
+    if (excludedPorts.has(candidate)) {
+      continue;
+    }
     if (!(await isPortOccupied(candidate))) {
       return candidate;
     }
@@ -107,11 +112,14 @@ async function findOpenAICompatProxyPort(): Promise<number> {
   return 0;
 }
 
-async function findOpenAICompatProxyPortNear(preferredPort: number): Promise<number> {
-  if (!(await isPortOccupied(preferredPort))) {
+async function findOpenAICompatProxyPortNear(
+  preferredPort: number,
+  excludedPorts: ReadonlySet<number> = new Set()
+): Promise<number> {
+  if (!excludedPorts.has(preferredPort) && !(await isPortOccupied(preferredPort))) {
     return preferredPort;
   }
-  return findOpenAICompatProxyPort();
+  return findOpenAICompatProxyPort(excludedPorts);
 }
 
 interface OpenAICompatProxyStateRecord {
@@ -350,36 +358,23 @@ export async function startOpenAICompatProxy(
         ? portPreference.port
         : status.port || portPreference.port);
     const requiresExactPort = explicitPort !== undefined || portPreference.source === 'profile';
-    const port =
-      status.running && status.port && (status.host || '127.0.0.1') === host
-        ? status.port
-        : requiresExactPort
-          ? preferredPort
-          : await findOpenAICompatProxyPortNear(preferredPort);
-    if (port === 0) {
-      return {
-        success: false,
-        port: preferredPort,
-        error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
-      };
-    }
-    if (!Number.isInteger(port) || port < 1 || port > 65535) {
-      return { success: false, port, error: `Invalid port: ${port}` };
-    }
-    if (status.running && status.port === port && (status.host || '127.0.0.1') === host) {
+    if (status.running && status.port === preferredPort && (status.host || '127.0.0.1') === host) {
       return {
         success: true,
         alreadyRunning: true,
         pid: status.pid,
-        port,
+        port: preferredPort,
         authToken: status.authToken,
       };
     }
-    if (requiresExactPort && (await isPortOccupied(port))) {
+    if (!Number.isInteger(preferredPort) || preferredPort < 1 || preferredPort > 65535) {
+      return { success: false, port: preferredPort, error: `Invalid port: ${preferredPort}` };
+    }
+    if (requiresExactPort && (await isPortOccupied(preferredPort))) {
       return {
         success: false,
-        port,
-        error: `Requested proxy port ${port} is already in use`,
+        port: preferredPort,
+        error: `Requested proxy port ${preferredPort} is already in use`,
       };
     }
     if (status.running) {
@@ -387,7 +382,7 @@ export async function startOpenAICompatProxy(
       if (!stopped.success) {
         return {
           success: false,
-          port,
+          port: preferredPort,
           error: stopped.error || 'Failed to restart the running proxy',
         };
       }
@@ -397,107 +392,144 @@ export async function startOpenAICompatProxy(
     if (!daemonEntry) {
       return {
         success: false,
-        port,
+        port: preferredPort,
         error: 'OpenAI proxy daemon entrypoint not found. Run `bun run build` and retry.',
       };
     }
 
-    return new Promise((resolve) => {
-      let resolved = false;
-      let timeout: NodeJS.Timeout | null = null;
-      const authToken = generateProxyAuthToken();
+    const startOnPort = (port: number): Promise<StartOpenAICompatProxyResult> =>
+      new Promise((resolve) => {
+        let resolved = false;
+        let timeout: NodeJS.Timeout | null = null;
+        const authToken = generateProxyAuthToken();
 
-      const finish = (result: StartOpenAICompatProxyResult) => {
-        if (resolved) return;
-        resolved = true;
-        if (timeout) clearTimeout(timeout);
-        if (!result.success) {
-          removeOpenAICompatProxyPid(profile.profileName);
-          removeOpenAICompatProxySession(profile.profileName);
+        const finish = (result: StartOpenAICompatProxyResult) => {
+          if (resolved) return;
+          resolved = true;
+          if (timeout) clearTimeout(timeout);
+          if (!result.success) {
+            removeOpenAICompatProxyPid(profile.profileName);
+            removeOpenAICompatProxySession(profile.profileName);
+          }
+          resolve(result);
+        };
+
+        const proc: ChildProcess = spawn(
+          process.execPath,
+          [
+            daemonEntry,
+            '--port',
+            String(port),
+            '--host',
+            host,
+            '--profile',
+            profile.profileName,
+            '--settings-path',
+            profile.settingsPath,
+            '--auth-token',
+            authToken,
+            ...(options.insecure ? ['--insecure'] : []),
+            '--ccs-openai-proxy-daemon',
+          ],
+          { stdio: 'ignore', detached: true }
+        );
+
+        proc.unref();
+        if (proc.pid) {
+          writeOpenAICompatProxyPid(profile.profileName, proc.pid);
         }
-        resolve(result);
-      };
-
-      const proc: ChildProcess = spawn(
-        process.execPath,
-        [
-          daemonEntry,
-          '--port',
-          String(port),
-          '--host',
+        writeOpenAICompatProxySession({
+          profileName: profile.profileName,
+          settingsPath: profile.settingsPath,
           host,
-          '--profile',
-          profile.profileName,
-          '--settings-path',
-          profile.settingsPath,
-          '--auth-token',
-          authToken,
-          ...(options.insecure ? ['--insecure'] : []),
-          '--ccs-openai-proxy-daemon',
-        ],
-        { stdio: 'ignore', detached: true }
-      );
-
-      proc.unref();
-      if (proc.pid) {
-        writeOpenAICompatProxyPid(profile.profileName, proc.pid);
-      }
-      writeOpenAICompatProxySession({
-        profileName: profile.profileName,
-        settingsPath: profile.settingsPath,
-        host,
-        port,
-        baseUrl: profile.baseUrl,
-        authToken,
-        model: profile.model,
-        insecure: options.insecure,
-      });
-
-      let attempts = 0;
-      const poll = async () => {
-        attempts += 1;
-        if (await isOpenAICompatProxyRunning(port)) {
-          finish({ success: true, pid: proc.pid, port, authToken });
-          return;
-        }
-        if (attempts >= 30) {
-          finish({
-            success: false,
-            port,
-            error: `Proxy daemon did not start within 30 seconds on port ${port}`,
-          });
-          return;
-        }
-        timeout = setTimeout(poll, 1000);
-      };
-
-      timeout = setTimeout(poll, 1000);
-      proc.on('error', (error) => {
-        finish({ success: false, port, error: error.message });
-      });
-      proc.on('exit', (code, signal) => {
-        if (code === 0) {
-          finish({
-            success: false,
-            port,
-            error: 'Proxy daemon exited before becoming healthy',
-          });
-          return;
-        }
-        if (code !== null) {
-          finish({
-            success: false,
-            port,
-            error: `Proxy daemon exited with code ${code}`,
-          });
-          return;
-        }
-        finish({
-          success: false,
           port,
-          error: `Proxy daemon was killed by signal ${signal}`,
+          baseUrl: profile.baseUrl,
+          authToken,
+          model: profile.model,
+          insecure: options.insecure,
+        });
+
+        let attempts = 0;
+        const poll = async () => {
+          attempts += 1;
+          if (await isOpenAICompatProxyRunning(port)) {
+            finish({ success: true, pid: proc.pid, port, authToken });
+            return;
+          }
+          if (attempts >= 30) {
+            finish({
+              success: false,
+              port,
+              error: `Proxy daemon did not start within 30 seconds on port ${port}`,
+            });
+            return;
+          }
+          timeout = setTimeout(poll, 1000);
+        };
+
+        timeout = setTimeout(poll, 1000);
+        proc.on('error', (error) => {
+          finish({ success: false, port, error: error.message });
+        });
+        proc.on('exit', (code, signal) => {
+          if (code === 0) {
+            finish({
+              success: false,
+              port,
+              error: 'Proxy daemon exited before becoming healthy',
+            });
+            return;
+          }
+          if (code !== null) {
+            finish({
+              success: false,
+              port,
+              error: `Proxy daemon exited with code ${code}`,
+            });
+            return;
+          }
+          finish({
+            success: false,
+            port,
+            error: `Proxy daemon was killed by signal ${signal}`,
+          });
         });
       });
-    });
+
+    if (requiresExactPort) {
+      return startOnPort(preferredPort);
+    }
+
+    const attemptedPorts = new Set<number>();
+    let lastResult: StartOpenAICompatProxyResult | null = null;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const port = await findOpenAICompatProxyPortNear(preferredPort, attemptedPorts);
+      if (port === 0) {
+        return {
+          success: false,
+          port: preferredPort,
+          error: `No free proxy port found in range ${OPENAI_COMPAT_PROXY_DEFAULT_PORT}-${OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10}`,
+        };
+      }
+
+      const result = await startOnPort(port);
+      if (result.success) {
+        return result;
+      }
+
+      lastResult = result;
+      attemptedPorts.add(port);
+      if (!(await isPortOccupied(port))) {
+        return result;
+      }
+    }
+
+    return (
+      lastResult ?? {
+        success: false,
+        port: preferredPort,
+        error: 'Failed to start proxy',
+      }
+    );
   });
 }

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -467,14 +467,14 @@ export async function startOpenAICompatProxy(
         proc.stderr?.on('data', (chunk) => {
           stderr += chunk;
         });
-        if (persistState) {
-          commitState();
-        }
 
         let attempts = 0;
         const poll = async () => {
           attempts += 1;
           if (await isOpenAICompatProxyRunning(port)) {
+            if (persistState) {
+              commitState();
+            }
             finish({
               success: true,
               pid: proc.pid,

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -12,10 +12,13 @@ import {
   getOpenAICompatProxyDir,
 } from './proxy-daemon-paths';
 import {
+  getLegacyOpenAICompatProxyPid,
   getOpenAICompatProxyPid,
   listOpenAICompatProxyProfileNames,
+  readLegacyOpenAICompatProxySession,
   readOpenAICompatProxySession,
-  cleanupLegacyOpenAICompatProxyState,
+  removeLegacyOpenAICompatProxyPid,
+  removeLegacyOpenAICompatProxySession,
   removeOpenAICompatProxyPid,
   removeOpenAICompatProxySession,
   resolveOpenAICompatProxyEntrypointCandidates,
@@ -23,7 +26,7 @@ import {
   writeOpenAICompatProxyPid,
   writeOpenAICompatProxySession,
 } from './proxy-daemon-state';
-import { resolveOpenAICompatProxyPreferredPort } from './proxy-port-resolver';
+import { resolveOpenAICompatProxyPortPreference } from './proxy-port-resolver';
 
 export interface OpenAICompatProxyStatus extends Partial<OpenAICompatProxySession> {
   running: boolean;
@@ -111,6 +114,12 @@ async function findOpenAICompatProxyPortNear(preferredPort: number): Promise<num
   return findOpenAICompatProxyPort();
 }
 
+interface OpenAICompatProxyStateRecord {
+  pid: number | null;
+  session: OpenAICompatProxySession | null;
+  source: 'profile' | 'legacy';
+}
+
 async function resolveDaemonEntrypoint(): Promise<string | null> {
   for (const candidate of resolveOpenAICompatProxyEntrypointCandidates()) {
     try {
@@ -157,20 +166,51 @@ export async function isOpenAICompatProxyRunning(port: number): Promise<boolean>
 async function getOpenAICompatProxyStatusForProfile(
   profileName: string
 ): Promise<OpenAICompatProxyStatus> {
-  const session = readOpenAICompatProxySession(profileName);
-  const port = session?.port ?? OPENAI_COMPAT_PROXY_DEFAULT_PORT;
+  const state = getOpenAICompatProxyStateForProfile(profileName);
+  const session = state.session;
+  if (!session) {
+    return { running: false };
+  }
+
+  const port = session.port;
   const running = await isOpenAICompatProxyRunning(port);
   return {
     running,
-    pid: running ? getOpenAICompatProxyPid(profileName) || undefined : undefined,
+    pid: running ? state.pid || undefined : undefined,
     ...session,
   };
 }
 
+function getOpenAICompatProxyStateForProfile(profileName: string): OpenAICompatProxyStateRecord {
+  const session = readOpenAICompatProxySession(profileName);
+  if (session) {
+    return {
+      pid: getOpenAICompatProxyPid(profileName),
+      session,
+      source: 'profile',
+    };
+  }
+
+  const legacySession = readLegacyOpenAICompatProxySession();
+  if (legacySession?.profileName === profileName) {
+    return {
+      pid: getLegacyOpenAICompatProxyPid(),
+      session: legacySession,
+      source: 'legacy',
+    };
+  }
+
+  return { pid: null, session: null, source: 'profile' };
+}
+
 export async function listOpenAICompatProxyStatuses(): Promise<OpenAICompatProxyStatus[]> {
-  const profileNames = listOpenAICompatProxyProfileNames();
+  const profileNames = new Set(listOpenAICompatProxyProfileNames());
+  const legacySession = readLegacyOpenAICompatProxySession();
+  if (legacySession?.profileName) {
+    profileNames.add(legacySession.profileName);
+  }
   const statuses = await Promise.all(
-    profileNames.map((profileName) => getOpenAICompatProxyStatusForProfile(profileName))
+    [...profileNames].map((profileName) => getOpenAICompatProxyStatusForProfile(profileName))
   );
   return statuses.filter((status) => status.profileName);
 }
@@ -197,9 +237,10 @@ export async function getOpenAICompatProxyStatus(
 async function stopOpenAICompatProxyUnlocked(
   profileName: string
 ): Promise<{ success: boolean; error?: string }> {
-  const pid = getOpenAICompatProxyPid(profileName);
+  const state = getOpenAICompatProxyStateForProfile(profileName);
+  const pid = state.pid;
   if (!pid) {
-    removeOpenAICompatProxySession(profileName);
+    removeOpenAICompatProxyState(state, profileName);
     return { success: true };
   }
 
@@ -211,8 +252,7 @@ async function stopOpenAICompatProxyUnlocked(
   );
 
   if (ownership === 'not-owned') {
-    removeOpenAICompatProxyPid(profileName);
-    removeOpenAICompatProxySession(profileName);
+    removeOpenAICompatProxyState(state, profileName);
     return { success: true };
   }
 
@@ -224,8 +264,7 @@ async function stopOpenAICompatProxyUnlocked(
   }
 
   if (ownership === 'not-running') {
-    removeOpenAICompatProxyPid(profileName);
-    removeOpenAICompatProxySession(profileName);
+    removeOpenAICompatProxyState(state, profileName);
     return { success: true };
   }
 
@@ -256,16 +295,28 @@ async function stopOpenAICompatProxyUnlocked(
     }
   }
 
+  removeOpenAICompatProxyState(state, profileName);
+  return { success: true };
+}
+
+function removeOpenAICompatProxyState(
+  state: OpenAICompatProxyStateRecord,
+  profileName: string
+): void {
+  if (state.source === 'legacy') {
+    removeLegacyOpenAICompatProxyPid();
+    removeLegacyOpenAICompatProxySession();
+    return;
+  }
+
   removeOpenAICompatProxyPid(profileName);
   removeOpenAICompatProxySession(profileName);
-  return { success: true };
 }
 
 export async function stopOpenAICompatProxy(
   profileName?: string
 ): Promise<{ success: boolean; error?: string }> {
   return withOpenAICompatProxyLock(async () => {
-    cleanupLegacyOpenAICompatProxyState();
     if (profileName) {
       return stopOpenAICompatProxyUnlocked(profileName);
     }
@@ -289,17 +340,22 @@ export async function startOpenAICompatProxy(
   options: { port?: number; host?: string; insecure?: boolean } = {}
 ): Promise<StartOpenAICompatProxyResult> {
   return withOpenAICompatProxyLock(async () => {
-    cleanupLegacyOpenAICompatProxyState();
     const status = await getOpenAICompatProxyStatus(profile.profileName);
     const host = options.host?.trim() || status.host || '127.0.0.1';
+    const portPreference = resolveOpenAICompatProxyPortPreference(profile.profileName);
+    const explicitPort = typeof options.port === 'number' ? options.port : undefined;
     const preferredPort =
-      typeof options.port === 'number'
-        ? options.port
-        : status.port || resolveOpenAICompatProxyPreferredPort(profile.profileName);
+      explicitPort ??
+      (portPreference.source === 'profile'
+        ? portPreference.port
+        : status.port || portPreference.port);
+    const requiresExactPort = explicitPort !== undefined || portPreference.source === 'profile';
     const port =
       status.running && status.port && (status.host || '127.0.0.1') === host
         ? status.port
-        : await findOpenAICompatProxyPortNear(preferredPort);
+        : requiresExactPort
+          ? preferredPort
+          : await findOpenAICompatProxyPortNear(preferredPort);
     if (port === 0) {
       return {
         success: false,
@@ -317,6 +373,13 @@ export async function startOpenAICompatProxy(
         pid: status.pid,
         port,
         authToken: status.authToken,
+      };
+    }
+    if (requiresExactPort && (await isPortOccupied(port))) {
+      return {
+        success: false,
+        port,
+        error: `Requested proxy port ${port} is already in use`,
       };
     }
     if (status.running) {

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -115,11 +115,7 @@ function listOpenAICompatProxyCandidatePorts(
   }
 
   const candidates = new Set<number>();
-  if (
-    preferredPort >= OPENAI_COMPAT_PROXY_DEFAULT_PORT &&
-    preferredPort <= OPENAI_COMPAT_PROXY_DEFAULT_PORT + 10 &&
-    !excludedPorts.has(preferredPort)
-  ) {
+  if (!excludedPorts.has(preferredPort)) {
     candidates.add(preferredPort);
   }
 
@@ -215,6 +211,22 @@ async function getOpenAICompatProxyStatusForProfile(
   };
 }
 
+async function getLegacyOpenAICompatProxyStatus(): Promise<OpenAICompatProxyStatus | null> {
+  const session = readLegacyOpenAICompatProxySession();
+  const pid = getLegacyOpenAICompatProxyPid();
+  if (!session && !pid) {
+    return null;
+  }
+
+  const port = session?.port;
+  const running = typeof port === 'number' ? await isOpenAICompatProxyRunning(port) : false;
+  return {
+    running,
+    pid: running ? pid || undefined : pid || undefined,
+    ...session,
+  };
+}
+
 function getOpenAICompatProxyStateForProfile(profileName: string): OpenAICompatProxyStateRecord {
   const session = readOpenAICompatProxySession(profileName);
   if (session) {
@@ -243,10 +255,17 @@ export async function listOpenAICompatProxyStatuses(): Promise<OpenAICompatProxy
   if (legacySession?.profileName) {
     profileNames.add(legacySession.profileName);
   }
-  const statuses = await Promise.all(
+  const profileStatuses = await Promise.all(
     [...profileNames].map((profileName) => getOpenAICompatProxyStatusForProfile(profileName))
   );
-  return statuses.filter((status) => status.profileName);
+  const statuses = profileStatuses.filter((status) => status.profileName);
+  if (!legacySession?.profileName) {
+    const legacyStatus = await getLegacyOpenAICompatProxyStatus();
+    if (legacyStatus) {
+      statuses.push(legacyStatus);
+    }
+  }
+  return statuses;
 }
 
 export async function getOpenAICompatProxyStatus(
@@ -333,6 +352,74 @@ async function stopOpenAICompatProxyUnlocked(
   return { success: true };
 }
 
+async function stopLegacyOpenAICompatProxyUnlocked(): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  const legacySession = readLegacyOpenAICompatProxySession();
+  if (legacySession?.profileName) {
+    return stopOpenAICompatProxyUnlocked(legacySession.profileName);
+  }
+
+  const pid = getLegacyOpenAICompatProxyPid();
+  if (!pid) {
+    removeLegacyOpenAICompatProxyPid();
+    removeLegacyOpenAICompatProxySession();
+    return { success: true };
+  }
+
+  const ownership = verifyProcessOwnership(
+    pid,
+    (commandLine) =>
+      commandLine.includes('--ccs-openai-proxy-daemon') &&
+      commandLine.includes('proxy-daemon-entry')
+  );
+
+  if (ownership === 'not-owned' || ownership === 'not-running') {
+    removeLegacyOpenAICompatProxyPid();
+    removeLegacyOpenAICompatProxySession();
+    return { success: true };
+  }
+
+  if (ownership === 'unknown') {
+    return {
+      success: false,
+      error: `Refusing to stop PID ${pid}: unable to verify daemon ownership`,
+    };
+  }
+
+  try {
+    process.kill(pid, 'SIGTERM');
+    let attempts = 0;
+    while (attempts < 10) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      try {
+        process.kill(pid, 0);
+        attempts += 1;
+      } catch {
+        break;
+      }
+    }
+
+    if (attempts >= 10) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // Already exited.
+      }
+    }
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== 'ESRCH') {
+      return { success: false, error: `Failed to stop daemon: ${err.message}` };
+    }
+  }
+
+  removeLegacyOpenAICompatProxyPid();
+  removeLegacyOpenAICompatProxySession();
+  return { success: true };
+}
+
 function removeOpenAICompatProxyState(
   state: OpenAICompatProxyStateRecord,
   profileName: string
@@ -356,14 +443,21 @@ export async function stopOpenAICompatProxy(
     }
 
     const statuses = await listOpenAICompatProxyStatuses();
+    const failures: string[] = [];
     for (const status of statuses) {
-      if (!status.profileName) {
-        continue;
-      }
-      const stopped = await stopOpenAICompatProxyUnlocked(status.profileName);
+      const stopped = status.profileName
+        ? await stopOpenAICompatProxyUnlocked(status.profileName)
+        : await stopLegacyOpenAICompatProxyUnlocked();
       if (!stopped.success) {
-        return stopped;
+        failures.push(
+          status.profileName
+            ? `${status.profileName}: ${stopped.error || 'failed to stop proxy'}`
+            : `legacy proxy: ${stopped.error || 'failed to stop proxy'}`
+        );
       }
+    }
+    if (failures.length > 0) {
+      return { success: false, error: `Failed to stop some proxies: ${failures.join('; ')}` };
     }
     return { success: true };
   });

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -199,7 +199,7 @@ async function getOpenAICompatProxyStatusForProfile(
   const state = getOpenAICompatProxyStateForProfile(profileName);
   const session = state.session;
   if (!session) {
-    return { running: false };
+    return { running: false, profileName };
   }
 
   const port = session.port;

--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -185,7 +185,7 @@ export async function getOpenAICompatProxyStatus(
   const statuses = await listOpenAICompatProxyStatuses();
   const running = statuses.filter((status) => status.running);
   if (running.length === 1) {
-    return running[0] || { running: false };
+    return running[0];
   }
   if (running.length > 1) {
     return { running: true };

--- a/src/proxy/proxy-port-resolver.ts
+++ b/src/proxy/proxy-port-resolver.ts
@@ -1,0 +1,11 @@
+import { loadOrCreateUnifiedConfig } from '../config/unified-config-loader';
+import { OPENAI_COMPAT_PROXY_DEFAULT_PORT } from './proxy-daemon-paths';
+
+export function resolveOpenAICompatProxyPreferredPort(profileName: string): number {
+  const config = loadOrCreateUnifiedConfig();
+  const profilePort = config.proxy?.profile_ports?.[profileName];
+  if (typeof profilePort === 'number') {
+    return profilePort;
+  }
+  return config.proxy?.port ?? OPENAI_COMPAT_PROXY_DEFAULT_PORT;
+}

--- a/src/proxy/proxy-port-resolver.ts
+++ b/src/proxy/proxy-port-resolver.ts
@@ -1,11 +1,25 @@
 import { loadOrCreateUnifiedConfig } from '../config/unified-config-loader';
 import { OPENAI_COMPAT_PROXY_DEFAULT_PORT } from './proxy-daemon-paths';
 
-export function resolveOpenAICompatProxyPreferredPort(profileName: string): number {
+export interface OpenAICompatProxyPortPreference {
+  port: number;
+  source: 'default' | 'profile';
+}
+
+export function resolveOpenAICompatProxyPortPreference(
+  profileName: string
+): OpenAICompatProxyPortPreference {
   const config = loadOrCreateUnifiedConfig();
   const profilePort = config.proxy?.profile_ports?.[profileName];
   if (typeof profilePort === 'number') {
-    return profilePort;
+    return { port: profilePort, source: 'profile' };
   }
-  return config.proxy?.port ?? OPENAI_COMPAT_PROXY_DEFAULT_PORT;
+  return {
+    port: config.proxy?.port ?? OPENAI_COMPAT_PROXY_DEFAULT_PORT,
+    source: 'default',
+  };
+}
+
+export function resolveOpenAICompatProxyPreferredPort(profileName: string): number {
+  return resolveOpenAICompatProxyPortPreference(profileName).port;
 }

--- a/tests/e2e/proxy-command.e2e.test.ts
+++ b/tests/e2e/proxy-command.e2e.test.ts
@@ -22,6 +22,10 @@ function runCli(args: string[], extraEnv: Record<string, string> = {}) {
 }
 
 beforeAll(() => {
+  if (process.env.CCS_E2E_SKIP_BUILD === '1') {
+    expect(fs.existsSync(DIST_ENTRY)).toBe(true);
+    return;
+  }
   const result = spawnSync(process.execPath, ['run', 'build'], {
     encoding: 'utf8',
     env: process.env,

--- a/tests/e2e/proxy-command.e2e.test.ts
+++ b/tests/e2e/proxy-command.e2e.test.ts
@@ -45,6 +45,13 @@ afterEach(() => {
 });
 
 describe('proxy command e2e', () => {
+  it('shows help for subcommand help flags without executing the subcommand', () => {
+    const help = runCli(['proxy', 'stop', '--help']);
+    expect(help.status).toBe(0);
+    expect(help.stdout).toContain('Usage: ccs proxy <start|stop|status|activate> [profile] [options]');
+    expect(help.stdout).toContain('stop [profile]    Stop the running proxy (or all proxies when omitted)');
+  });
+
   it('starts, reports status, activates, and stops via the built CLI', async () => {
     const port = await getPort();
     const ccsDir = path.join(tempDir, '.ccs');

--- a/tests/e2e/proxy-command.e2e.test.ts
+++ b/tests/e2e/proxy-command.e2e.test.ts
@@ -52,6 +52,34 @@ describe('proxy command e2e', () => {
     expect(help.stdout).toContain('stop [profile]    Stop the running proxy (or all proxies when omitted)');
   });
 
+  it('shows the last-known proxy state when no proxy is currently running', async () => {
+    const stalePort = await getPort();
+    const proxyDir = path.join(tempDir, '.ccs', 'proxy');
+    fs.mkdirSync(proxyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(proxyDir, 'stale.session.json'),
+      JSON.stringify(
+        {
+          profileName: 'stale',
+          settingsPath: path.join(tempDir, '.ccs', 'stale.settings.json'),
+          host: '127.0.0.1',
+          port: stalePort,
+          baseUrl: 'http://127.0.0.1:11434',
+          authToken: 'deadbeef',
+          model: 'qwen3-coder',
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+
+    const status = runCli(['proxy', 'status']);
+    expect(status.status).toBe(0);
+    expect(status.stdout).toContain(`Proxy is not running (last known port ${stalePort})`);
+    expect(status.stdout).toContain('Profile: stale');
+  });
+
   it('starts, reports status, activates, and stops via the built CLI', async () => {
     const port = await getPort();
     const ccsDir = path.join(tempDir, '.ccs');

--- a/tests/e2e/proxy-command.e2e.test.ts
+++ b/tests/e2e/proxy-command.e2e.test.ts
@@ -107,4 +107,50 @@ describe('proxy command e2e', () => {
     const stopped = runCli(['proxy', 'stop']);
     expect(stopped.status).toBe(0);
   }, 35000);
+
+  it('requires an explicit profile when activating with multiple running proxies', async () => {
+    const firstPort = await getPort();
+    const ccsDir = path.join(tempDir, '.ccs');
+    fs.mkdirSync(ccsDir, { recursive: true });
+    const firstSettingsPath = path.join(ccsDir, 'ccg.settings.json');
+    const secondSettingsPath = path.join(ccsDir, 'ccgm.settings.json');
+    fs.writeFileSync(
+      path.join(ccsDir, 'config.json'),
+      JSON.stringify({ profiles: { ccg: firstSettingsPath, ccgm: secondSettingsPath } }, null, 2),
+      'utf8'
+    );
+    fs.writeFileSync(
+      firstSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+          ANTHROPIC_AUTH_TOKEN: 'ollama-ccg',
+          ANTHROPIC_MODEL: 'qwen3-coder',
+          CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+        },
+      }),
+      'utf8'
+    );
+    fs.writeFileSync(
+      secondSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-ccgm',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+
+    expect(runCli(['proxy', 'start', 'ccg', '--port', String(firstPort)]).status).toBe(0);
+    const secondPort = await getPort();
+    expect(runCli(['proxy', 'start', 'ccgm', '--port', String(secondPort)]).status).toBe(0);
+
+    const activate = runCli(['proxy', 'activate', '--shell', 'bash']);
+    expect(activate.status).toBe(1);
+    expect(activate.stderr).toContain(
+      'Multiple proxies are running. Specify a profile: ccs proxy activate <profile>'
+    );
+  }, 35000);
 });

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -13,6 +13,7 @@ import { resolveOpenAICompatProfileConfig } from '../../../src/proxy/profile-rou
 import {
   getLegacyOpenAICompatProxyPidPath,
   getLegacyOpenAICompatProxySessionPath,
+  getOpenAICompatProxyPidPath,
   getOpenAICompatProxySessionPath,
 } from '../../../src/proxy/proxy-daemon-paths';
 import { mutateUnifiedConfig } from '../../../src/config/unified-config-loader';
@@ -469,5 +470,182 @@ describe('openai proxy daemon lifecycle', () => {
     const status = await getOpenAICompatProxyStatus('never-started');
     expect(status.running).toBe(false);
     expect(status.profileName).toBe('never-started');
+  });
+
+  it('does not treat another profile on the same port as already running', async () => {
+    const sharedPort = await getPort();
+    const firstSettingsPath = path.join(tempDir, 'profile-b.settings.json');
+    fs.writeFileSync(
+      firstSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-profile-b',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+
+    const firstProfile = resolveOpenAICompatProfileConfig('profile-b', firstSettingsPath, {
+      ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-profile-b',
+      ANTHROPIC_MODEL: 'gpt-4.1',
+    });
+    if (!firstProfile) {
+      throw new Error('Expected first OpenAI-compatible profile');
+    }
+
+    const firstStart = await startOpenAICompatProxy(firstProfile, { port: sharedPort });
+    expect(firstStart.success).toBe(true);
+
+    const secondSettingsPath = path.join(tempDir, 'profile-a.settings.json');
+    fs.writeFileSync(
+      secondSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-profile-a',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+
+    const secondProfile = resolveOpenAICompatProfileConfig('profile-a', secondSettingsPath, {
+      ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-profile-a',
+      ANTHROPIC_MODEL: 'gpt-4.1',
+    });
+    if (!secondProfile) {
+      throw new Error('Expected second OpenAI-compatible profile');
+    }
+
+    fs.writeFileSync(
+      getOpenAICompatProxySessionPath('profile-a'),
+      JSON.stringify(
+        {
+          profileName: 'profile-a',
+          settingsPath: secondProfile.settingsPath,
+          host: '127.0.0.1',
+          port: sharedPort,
+          baseUrl: secondProfile.baseUrl,
+          authToken: 'stale-token-a',
+          model: secondProfile.model,
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+
+    const secondStart = await startOpenAICompatProxy(secondProfile);
+    expect(secondStart.success).toBe(true);
+    expect(secondStart.alreadyRunning).not.toBe(true);
+    expect(secondStart.authToken).not.toBe('stale-token-a');
+  });
+
+  it('replaces pid-only proxy state before starting a new daemon', async () => {
+    const firstPort = await getPort();
+    const replacementPort = await getPort();
+    const settingsPath = path.join(tempDir, 'pid-only.settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-pid-only',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+
+    const profile = resolveOpenAICompatProfileConfig('pid-only', settingsPath, {
+      ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-pid-only',
+      ANTHROPIC_MODEL: 'gpt-4.1',
+    });
+    if (!profile) {
+      throw new Error('Expected pid-only OpenAI-compatible profile');
+    }
+
+    const firstStart = await startOpenAICompatProxy(profile, { port: firstPort });
+    expect(firstStart.success).toBe(true);
+    expect(firstStart.pid).toBeDefined();
+
+    fs.unlinkSync(getOpenAICompatProxySessionPath('pid-only'));
+
+    const replacement = await startOpenAICompatProxy(profile, { port: replacementPort });
+    expect(replacement.success).toBe(true);
+    expect(replacement.port).toBe(replacementPort);
+    expect(replacement.pid).toBeDefined();
+    expect(replacement.pid).not.toBe(firstStart.pid);
+
+    const stalePidPath = getOpenAICompatProxyPidPath('pid-only');
+    expect(fs.readFileSync(stalePidPath, 'utf8').trim()).toBe(String(replacement.pid));
+    expect((await fetch(`http://127.0.0.1:${replacementPort}/health`)).status).toBe(200);
+  });
+
+  it('does not stop another profile when a stale pid file points at its daemon', async () => {
+    const firstPort = await getPort();
+    const secondPort = await getPort();
+    const firstSettingsPath = path.join(tempDir, 'profile-b-stale-pid.settings.json');
+    fs.writeFileSync(
+      firstSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-profile-b-stale-pid',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+    const firstProfile = resolveOpenAICompatProfileConfig('profile-b-stale-pid', firstSettingsPath, {
+      ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-profile-b-stale-pid',
+      ANTHROPIC_MODEL: 'gpt-4.1',
+    });
+    if (!firstProfile) {
+      throw new Error('Expected first OpenAI-compatible profile');
+    }
+
+    const firstStart = await startOpenAICompatProxy(firstProfile, { port: firstPort });
+    expect(firstStart.success).toBe(true);
+    expect(firstStart.pid).toBeDefined();
+
+    const secondSettingsPath = path.join(tempDir, 'profile-a-stale-pid.settings.json');
+    fs.writeFileSync(
+      secondSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-profile-a-stale-pid',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+    const secondProfile = resolveOpenAICompatProfileConfig('profile-a-stale-pid', secondSettingsPath, {
+      ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-profile-a-stale-pid',
+      ANTHROPIC_MODEL: 'gpt-4.1',
+    });
+    if (!secondProfile) {
+      throw new Error('Expected second OpenAI-compatible profile');
+    }
+
+    fs.writeFileSync(
+      getOpenAICompatProxyPidPath('profile-a-stale-pid'),
+      String(firstStart.pid),
+      'utf8'
+    );
+
+    const secondStart = await startOpenAICompatProxy(secondProfile, { port: secondPort });
+    expect(secondStart.success).toBe(true);
+    expect(secondStart.port).toBe(secondPort);
+    expect((await fetch(`http://127.0.0.1:${firstPort}/health`)).status).toBe(200);
+    expect((await fetch(`http://127.0.0.1:${secondPort}/health`)).status).toBe(200);
   });
 });

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -9,6 +9,11 @@ import {
   stopOpenAICompatProxy,
 } from '../../../src/proxy/proxy-daemon';
 import { resolveOpenAICompatProfileConfig } from '../../../src/proxy/profile-router';
+import {
+  getLegacyOpenAICompatProxyPidPath,
+  getLegacyOpenAICompatProxySessionPath,
+} from '../../../src/proxy/proxy-daemon-paths';
+import { mutateUnifiedConfig } from '../../../src/config/unified-config-loader';
 
 let originalCcsHome: string | undefined;
 let tempDir: string;
@@ -139,5 +144,163 @@ describe('openai proxy daemon lifecycle', () => {
 
     const secondHealth = await fetch(`http://127.0.0.1:${secondPort}/health`);
     expect(secondHealth.status).toBe(200);
+  });
+
+  it('keeps a legacy singleton daemon visible across upgrade', async () => {
+    const port = await getPort();
+    const settingsPath = path.join(tempDir, 'legacy.settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+          ANTHROPIC_AUTH_TOKEN: 'ollama-legacy',
+          ANTHROPIC_MODEL: 'qwen3-coder',
+          CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+        },
+      }),
+      'utf8'
+    );
+
+    const profile = resolveOpenAICompatProfileConfig('legacy', settingsPath, {
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+      ANTHROPIC_AUTH_TOKEN: 'ollama-legacy',
+      ANTHROPIC_MODEL: 'qwen3-coder',
+      CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+    });
+    if (!profile) {
+      throw new Error('Expected a legacy OpenAI-compatible profile');
+    }
+
+    const started = await startOpenAICompatProxy(profile, { port });
+    expect(started.success).toBe(true);
+    expect(started.pid).toBeDefined();
+
+    const proxyDir = path.dirname(getLegacyOpenAICompatProxyPidPath());
+    fs.writeFileSync(getLegacyOpenAICompatProxyPidPath(), String(started.pid), 'utf8');
+    fs.writeFileSync(
+      getLegacyOpenAICompatProxySessionPath(),
+      JSON.stringify(
+        {
+          profileName: profile.profileName,
+          settingsPath: profile.settingsPath,
+          host: '127.0.0.1',
+          port,
+          baseUrl: profile.baseUrl,
+          authToken: started.authToken,
+          model: profile.model,
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+    fs.rmSync(path.join(proxyDir, 'legacy.daemon.pid'), { force: true });
+    fs.rmSync(path.join(proxyDir, 'legacy.session.json'), { force: true });
+
+    const status = await getOpenAICompatProxyStatus('legacy');
+    expect(status.running).toBe(true);
+    expect(status.port).toBe(port);
+
+    const restarted = await startOpenAICompatProxy(profile);
+    expect(restarted.success).toBe(true);
+    expect(restarted.alreadyRunning).toBe(true);
+    expect(restarted.port).toBe(port);
+
+    const stopped = await stopOpenAICompatProxy('legacy');
+    expect(stopped.success).toBe(true);
+    expect(fs.existsSync(getLegacyOpenAICompatProxyPidPath())).toBe(false);
+    expect(fs.existsSync(getLegacyOpenAICompatProxySessionPath())).toBe(false);
+  }, 35000);
+
+  it('fails when an explicit port is already occupied', async () => {
+    const occupiedPort = await getPort();
+    const server = Bun.serve({
+      port: occupiedPort,
+      hostname: '127.0.0.1',
+      fetch: () => new Response('busy'),
+    });
+
+    try {
+      const settingsPath = path.join(tempDir, 'occupied-explicit.settings.json');
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+            ANTHROPIC_AUTH_TOKEN: 'ollama-explicit',
+            ANTHROPIC_MODEL: 'qwen3-coder',
+            CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+          },
+        }),
+        'utf8'
+      );
+
+      const profile = resolveOpenAICompatProfileConfig('explicit', settingsPath, {
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+        ANTHROPIC_AUTH_TOKEN: 'ollama-explicit',
+        ANTHROPIC_MODEL: 'qwen3-coder',
+        CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+      });
+      if (!profile) {
+        throw new Error('Expected an explicit-port OpenAI-compatible profile');
+      }
+
+      const started = await startOpenAICompatProxy(profile, { port: occupiedPort });
+      expect(started.success).toBe(false);
+      expect(started.port).toBe(occupiedPort);
+      expect(started.error).toContain(`Requested proxy port ${occupiedPort} is already in use`);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  it('fails when a configured profile port is already occupied', async () => {
+    const occupiedPort = await getPort();
+    const server = Bun.serve({
+      port: occupiedPort,
+      hostname: '127.0.0.1',
+      fetch: () => new Response('busy'),
+    });
+
+    try {
+      mutateUnifiedConfig((config) => {
+        config.proxy = {
+          ...(config.proxy ?? {}),
+          profile_ports: { mapped: occupiedPort },
+        };
+      });
+
+      const settingsPath = path.join(tempDir, 'occupied-mapped.settings.json');
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+            ANTHROPIC_AUTH_TOKEN: 'ollama-mapped',
+            ANTHROPIC_MODEL: 'qwen3-coder',
+            CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+          },
+        }),
+        'utf8'
+      );
+
+      const profile = resolveOpenAICompatProfileConfig('mapped', settingsPath, {
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+        ANTHROPIC_AUTH_TOKEN: 'ollama-mapped',
+        ANTHROPIC_MODEL: 'qwen3-coder',
+        CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+      });
+      if (!profile) {
+        throw new Error('Expected a mapped-port OpenAI-compatible profile');
+      }
+
+      const started = await startOpenAICompatProxy(profile);
+      expect(started.success).toBe(false);
+      expect(started.port).toBe(occupiedPort);
+      expect(started.error).toContain(`Requested proxy port ${occupiedPort} is already in use`);
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import getPort from 'get-port';
 import {
   getOpenAICompatProxyStatus,
+  listOpenAICompatProxyStatuses,
   startOpenAICompatProxy,
   stopOpenAICompatProxy,
 } from '../../../src/proxy/proxy-daemon';
@@ -12,6 +13,7 @@ import { resolveOpenAICompatProfileConfig } from '../../../src/proxy/profile-rou
 import {
   getLegacyOpenAICompatProxyPidPath,
   getLegacyOpenAICompatProxySessionPath,
+  getOpenAICompatProxySessionPath,
 } from '../../../src/proxy/proxy-daemon-paths';
 import { mutateUnifiedConfig } from '../../../src/config/unified-config-loader';
 
@@ -352,4 +354,114 @@ describe('openai proxy daemon lifecycle', () => {
       busyServer.stop(true);
     }
   });
+
+  it('reuses the last-known port even when it is outside the default fallback range', async () => {
+    const preferredPort = await getPort();
+    const settingsPath = path.join(tempDir, 'outside-range.settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+          ANTHROPIC_AUTH_TOKEN: 'ollama-outside-range',
+          ANTHROPIC_MODEL: 'qwen3-coder',
+          CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+        },
+      }),
+      'utf8'
+    );
+
+    const profile = resolveOpenAICompatProfileConfig('outside-range', settingsPath, {
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+      ANTHROPIC_AUTH_TOKEN: 'ollama-outside-range',
+      ANTHROPIC_MODEL: 'qwen3-coder',
+      CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+    });
+    if (!profile) {
+      throw new Error('Expected an outside-range OpenAI-compatible profile');
+    }
+
+    fs.mkdirSync(path.dirname(getOpenAICompatProxySessionPath('outside-range')), { recursive: true });
+    fs.writeFileSync(
+      getOpenAICompatProxySessionPath('outside-range'),
+      JSON.stringify(
+        {
+          profileName: profile.profileName,
+          settingsPath: profile.settingsPath,
+          host: '127.0.0.1',
+          port: preferredPort,
+          baseUrl: profile.baseUrl,
+          authToken: 'stale-token',
+          model: profile.model,
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+
+    const started = await startOpenAICompatProxy(profile);
+    expect(started.success).toBe(true);
+    expect(started.port).toBe(preferredPort);
+  });
+
+  it('stops legacy daemons even when the legacy session is missing a profile name', async () => {
+    const port = await getPort();
+    const settingsPath = path.join(tempDir, 'legacy-missing-profile.settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+          ANTHROPIC_AUTH_TOKEN: 'ollama-legacy-missing-profile',
+          ANTHROPIC_MODEL: 'qwen3-coder',
+          CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+        },
+      }),
+      'utf8'
+    );
+
+    const profile = resolveOpenAICompatProfileConfig('legacy-missing-profile', settingsPath, {
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+      ANTHROPIC_AUTH_TOKEN: 'ollama-legacy-missing-profile',
+      ANTHROPIC_MODEL: 'qwen3-coder',
+      CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+    });
+    if (!profile) {
+      throw new Error('Expected a legacy fallback OpenAI-compatible profile');
+    }
+
+    const started = await startOpenAICompatProxy(profile, { port });
+    expect(started.success).toBe(true);
+    expect(started.pid).toBeDefined();
+
+    const proxyDir = path.dirname(getLegacyOpenAICompatProxyPidPath());
+    fs.writeFileSync(getLegacyOpenAICompatProxyPidPath(), String(started.pid), 'utf8');
+    fs.writeFileSync(
+      getLegacyOpenAICompatProxySessionPath(),
+      JSON.stringify(
+        {
+          settingsPath: profile.settingsPath,
+          host: '127.0.0.1',
+          port,
+          baseUrl: profile.baseUrl,
+          authToken: started.authToken,
+          model: profile.model,
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+    fs.rmSync(path.join(proxyDir, 'legacy-missing-profile.daemon.pid'), { force: true });
+    fs.rmSync(path.join(proxyDir, 'legacy-missing-profile.session.json'), { force: true });
+
+    const statuses = await listOpenAICompatProxyStatuses();
+    expect(statuses.some((status) => status.port === port)).toBe(true);
+
+    const stopped = await stopOpenAICompatProxy();
+    expect(stopped.success).toBe(true);
+    expect(fs.existsSync(getLegacyOpenAICompatProxyPidPath())).toBe(false);
+    expect(fs.existsSync(getLegacyOpenAICompatProxySessionPath())).toBe(false);
+  }, 35000);
 });

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -303,4 +303,53 @@ describe('openai proxy daemon lifecycle', () => {
       server.stop(true);
     }
   });
+
+  it('keeps the existing proxy running if replacement startup fails', async () => {
+    const firstPort = await getPort();
+    const occupiedPort = await getPort();
+    const busyServer = Bun.serve({
+      port: occupiedPort,
+      hostname: '127.0.0.1',
+      fetch: () => new Response('busy'),
+    });
+
+    try {
+      const settingsPath = path.join(tempDir, 'rollback.settings.json');
+      fs.writeFileSync(
+        settingsPath,
+        JSON.stringify({
+          env: {
+            ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+            ANTHROPIC_AUTH_TOKEN: 'ollama-rollback',
+            ANTHROPIC_MODEL: 'qwen3-coder',
+            CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+          },
+        }),
+        'utf8'
+      );
+
+      const profile = resolveOpenAICompatProfileConfig('rollback', settingsPath, {
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434',
+        ANTHROPIC_AUTH_TOKEN: 'ollama-rollback',
+        ANTHROPIC_MODEL: 'qwen3-coder',
+        CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+      });
+      if (!profile) {
+        throw new Error('Expected a rollback OpenAI-compatible profile');
+      }
+
+      const firstStart = await startOpenAICompatProxy(profile, { port: firstPort });
+      expect(firstStart.success).toBe(true);
+
+      const restarted = await startOpenAICompatProxy(profile, { port: occupiedPort });
+      expect(restarted.success).toBe(false);
+
+      const status = await getOpenAICompatProxyStatus('rollback');
+      expect(status.running).toBe(true);
+      expect(status.port).toBe(firstPort);
+      expect((await fetch(`http://127.0.0.1:${firstPort}/health`)).status).toBe(200);
+    } finally {
+      busyServer.stop(true);
+    }
+  });
 });

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -464,4 +464,10 @@ describe('openai proxy daemon lifecycle', () => {
     expect(fs.existsSync(getLegacyOpenAICompatProxyPidPath())).toBe(false);
     expect(fs.existsSync(getLegacyOpenAICompatProxySessionPath())).toBe(false);
   }, 35000);
+
+  it('keeps the requested profile name in stopped status results', async () => {
+    const status = await getOpenAICompatProxyStatus('never-started');
+    expect(status.running).toBe(false);
+    expect(status.profileName).toBe('never-started');
+  });
 });

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -80,7 +80,7 @@ describe('openai proxy daemon lifecycle', () => {
     expect((await getOpenAICompatProxyStatus()).running).toBe(false);
   }, 35000);
 
-  it('refuses to replace a running proxy for a different profile', async () => {
+  it('allows different profiles to run on different ports', async () => {
     const firstPort = await getPort();
     const firstSettingsPath = path.join(tempDir, 'hf.settings.json');
     fs.writeFileSync(
@@ -108,7 +108,20 @@ describe('openai proxy daemon lifecycle', () => {
     const firstStart = await startOpenAICompatProxy(firstProfile, { port: firstPort });
     expect(firstStart.success).toBe(true);
 
-    const secondProfile = resolveOpenAICompatProfileConfig('openai', path.join(tempDir, 'openai.settings.json'), {
+    const secondPort = await getPort();
+    const secondSettingsPath = path.join(tempDir, 'openai.settings.json');
+    fs.writeFileSync(
+      secondSettingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-openai',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+    const secondProfile = resolveOpenAICompatProfileConfig('openai', secondSettingsPath, {
       ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
       ANTHROPIC_AUTH_TOKEN: 'sk-openai',
       ANTHROPIC_MODEL: 'gpt-4.1',
@@ -117,11 +130,14 @@ describe('openai proxy daemon lifecycle', () => {
       throw new Error('Expected second OpenAI-compatible profile');
     }
 
-    const secondStart = await startOpenAICompatProxy(secondProfile, { port: await getPort() });
-    expect(secondStart.success).toBe(false);
-    expect(secondStart.error).toContain('Proxy already running for profile "hf"');
+    const secondStart = await startOpenAICompatProxy(secondProfile, { port: secondPort });
+    expect(secondStart.success).toBe(true);
+    expect(secondStart.port).toBe(secondPort);
 
     const health = await fetch(`http://127.0.0.1:${firstPort}/health`);
     expect(health.status).toBe(200);
+
+    const secondHealth = await fetch(`http://127.0.0.1:${secondPort}/health`);
+    expect(secondHealth.status).toBe(200);
   });
 });

--- a/tests/unit/commands/proxy-command.test.ts
+++ b/tests/unit/commands/proxy-command.test.ts
@@ -6,6 +6,12 @@ describe('findPositionalArg', () => {
     expect(findPositionalArg(['--port', '3456', 'ccg'], ['--port'])).toBe('ccg');
   });
 
+  it('skips flag options that do not take values', () => {
+    expect(findPositionalArg(['--insecure', 'ccg'], ['--port', '--host'], ['--insecure'])).toBe(
+      'ccg'
+    );
+  });
+
   it('treats arguments after -- as positional', () => {
     expect(findPositionalArg(['--', '--port', '3456'], ['--port'])).toBe('--port');
   });

--- a/tests/unit/commands/proxy-command.test.ts
+++ b/tests/unit/commands/proxy-command.test.ts
@@ -9,4 +9,8 @@ describe('findPositionalArg', () => {
   it('treats arguments after -- as positional', () => {
     expect(findPositionalArg(['--', '--port', '3456'], ['--port'])).toBe('--port');
   });
+
+  it('returns undefined when -- is the final argument', () => {
+    expect(findPositionalArg(['--'], ['--port'])).toBeUndefined();
+  });
 });

--- a/tests/unit/commands/proxy-command.test.ts
+++ b/tests/unit/commands/proxy-command.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'bun:test';
+import { findPositionalArg } from '../../../src/commands/proxy-command';
+
+describe('findPositionalArg', () => {
+  it('skips option values before returning the first positional argument', () => {
+    expect(findPositionalArg(['--port', '3456', 'ccg'], ['--port'])).toBe('ccg');
+  });
+
+  it('treats arguments after -- as positional', () => {
+    expect(findPositionalArg(['--', '--port', '3456'], ['--port'])).toBe('--port');
+  });
+});

--- a/tests/unit/proxy/proxy-daemon-state.test.ts
+++ b/tests/unit/proxy/proxy-daemon-state.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import {
   getLegacyOpenAICompatProxySessionPath,
+  getOpenAICompatProxyPidPath,
   getOpenAICompatProxySessionPath,
 } from '../../../src/proxy/proxy-daemon-paths';
 import { listOpenAICompatProxyProfileNames } from '../../../src/proxy/proxy-daemon-state';
@@ -39,6 +40,13 @@ describe('listOpenAICompatProxyProfileNames', () => {
     fs.mkdirSync(path.dirname(getLegacyOpenAICompatProxySessionPath()), { recursive: true });
     fs.writeFileSync(path.join(path.dirname(getLegacyOpenAICompatProxySessionPath()), '%E0%A4%.session.json'), '{}\n', 'utf8');
     fs.writeFileSync(getOpenAICompatProxySessionPath('ccg'), '{}\n', 'utf8');
+
+    expect(listOpenAICompatProxyProfileNames()).toEqual(['ccg']);
+  });
+
+  it('includes pid-only profile state in the discovered profile list', () => {
+    fs.mkdirSync(path.dirname(getLegacyOpenAICompatProxySessionPath()), { recursive: true });
+    fs.writeFileSync(getOpenAICompatProxyPidPath('ccg'), '123\n', 'utf8');
 
     expect(listOpenAICompatProxyProfileNames()).toEqual(['ccg']);
   });

--- a/tests/unit/proxy/proxy-daemon-state.test.ts
+++ b/tests/unit/proxy/proxy-daemon-state.test.ts
@@ -34,4 +34,12 @@ describe('listOpenAICompatProxyProfileNames', () => {
 
     expect(listOpenAICompatProxyProfileNames()).toEqual(['ccg']);
   });
+
+  it('skips malformed percent-encoded profile keys', () => {
+    fs.mkdirSync(path.dirname(getLegacyOpenAICompatProxySessionPath()), { recursive: true });
+    fs.writeFileSync(path.join(path.dirname(getLegacyOpenAICompatProxySessionPath()), '%E0%A4%.session.json'), '{}\n', 'utf8');
+    fs.writeFileSync(getOpenAICompatProxySessionPath('ccg'), '{}\n', 'utf8');
+
+    expect(listOpenAICompatProxyProfileNames()).toEqual(['ccg']);
+  });
 });

--- a/tests/unit/proxy/proxy-daemon-state.test.ts
+++ b/tests/unit/proxy/proxy-daemon-state.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  getLegacyOpenAICompatProxySessionPath,
+  getOpenAICompatProxySessionPath,
+} from '../../../src/proxy/proxy-daemon-paths';
+import { listOpenAICompatProxyProfileNames } from '../../../src/proxy/proxy-daemon-state';
+
+let originalCcsHome: string | undefined;
+let tempDir: string;
+
+beforeEach(() => {
+  originalCcsHome = process.env.CCS_HOME;
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-proxy-state-'));
+  process.env.CCS_HOME = tempDir;
+});
+
+afterEach(() => {
+  if (originalCcsHome !== undefined) {
+    process.env.CCS_HOME = originalCcsHome;
+  } else {
+    delete process.env.CCS_HOME;
+  }
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('listOpenAICompatProxyProfileNames', () => {
+  it('ignores the legacy singleton session file', () => {
+    fs.mkdirSync(path.dirname(getLegacyOpenAICompatProxySessionPath()), { recursive: true });
+    fs.writeFileSync(getLegacyOpenAICompatProxySessionPath(), '{}\n', 'utf8');
+    fs.writeFileSync(getOpenAICompatProxySessionPath('ccg'), '{}\n', 'utf8');
+
+    expect(listOpenAICompatProxyProfileNames()).toEqual(['ccg']);
+  });
+});

--- a/tests/unit/proxy/proxy-port-resolver.test.ts
+++ b/tests/unit/proxy/proxy-port-resolver.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { mutateUnifiedConfig } from '../../../src/config/unified-config-loader';
+import { resolveOpenAICompatProxyPreferredPort } from '../../../src/proxy/proxy-port-resolver';
+
+let originalCcsHome: string | undefined;
+let tempDir: string;
+
+beforeEach(() => {
+  originalCcsHome = process.env.CCS_HOME;
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-proxy-config-'));
+  process.env.CCS_HOME = tempDir;
+});
+
+afterEach(() => {
+  if (originalCcsHome !== undefined) {
+    process.env.CCS_HOME = originalCcsHome;
+  } else {
+    delete process.env.CCS_HOME;
+  }
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe('resolveOpenAICompatProxyPreferredPort', () => {
+  it('returns the configured profile-scoped port when present', () => {
+    mutateUnifiedConfig((config) => {
+      config.proxy = {
+        ...(config.proxy ?? {}),
+        port: 3456,
+        profile_ports: { ccgm: 3461 },
+      };
+    });
+
+    expect(resolveOpenAICompatProxyPreferredPort('ccgm')).toBe(3461);
+  });
+
+  it('falls back to the shared default port when no profile mapping exists', () => {
+    expect(resolveOpenAICompatProxyPreferredPort('ccg')).toBe(3456);
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes a structural limitation in the OpenAI-compatible local proxy path used by CCS settings profiles.

Today, the proxy lifecycle is effectively global:

- the daemon PID/session state is stored in a single shared location
- the startup path treats the running proxy as a singleton
- the default lifecycle assumes one shared local port
- starting a second OpenAI-compatible settings profile is rejected even when a different port would be valid

That design causes real profile collisions for aliases that should remain independent. In practice, profiles such as `ccg` and `ccgm` can end up contending for the same local proxy runtime and port, even though their settings and intended routing differ.

This change makes the OpenAI-compatible proxy lifecycle profile-scoped while preserving the existing UX for the common single-profile case.

As a small repo hygiene follow-up, this PR also updates `.gitignore` to ignore local-only agent override files so personal Codex/Claude guidance does not get accidentally staged into future commits.

## Problem Background

The issue here is not just that `3456` was the default port.

The deeper problem was that CCS modeled the OpenAI-compatible proxy as a single global daemon:

- proxy state lived in one PID file and one session file
- `startOpenAICompatProxy()` would treat any running proxy as the active instance
- if that running instance belonged to a different profile, CCS refused to start a second one instead of allocating another port
- `ccs proxy status` / `activate` / `stop` also assumed one active proxy

Because of that structure, different OpenAI-compatible settings profiles were forced into one shared runtime lane. That is exactly the failure mode behind collisions like:

`Proxy already running for profile "gpt-oauth-mini" on port 3456. Stop it before starting a different profile.`

From a user perspective, this means profile separation breaks down specifically in the local proxy bridge layer.

## Root Cause

The collision came from a combination of behaviors in the existing implementation:

1. `OPENAI_COMPAT_PROXY_DEFAULT_PORT` was a single shared default.
2. PID/session files were global rather than profile-specific.
3. The daemon lifecycle only tracked one running proxy at a time.
4. Starting a different profile while one proxy was already running returned an error instead of creating another isolated proxy instance.
5. There was no first-class place in unified config to express profile-specific proxy port preferences.

So even though the CLI accepted `--port`, the lifecycle itself was still singleton-oriented.

## What Changed

### 1. Profile-scoped proxy state

The proxy daemon state is now stored per profile rather than globally.

Instead of a single:

- `daemon.pid`
- `session.json`

CCS now stores profile-specific daemon/session files under the proxy state directory.

This is the key structural change that allows multiple OpenAI-compatible profile proxies to coexist safely.

### 2. Profile-aware lifecycle management

The daemon lifecycle now:

- reads status per profile
- reuses the existing daemon only when the same profile is already running on the same bind target
- stops/restarts only that profile's daemon when needed
- allows another profile to start on a different port instead of failing simply because some other profile is already active

This keeps same-profile behavior intuitive while removing the cross-profile singleton constraint.

### 3. Config support for optional profile-scoped port mapping

The unified `proxy` config now supports:

- `proxy.port`: shared preferred default for OpenAI-compatible proxy instances
- `proxy.profile_ports`: optional per-profile port overrides

That means users can keep the current default behavior, or explicitly pin certain profiles to known ports when they need deterministic separation.

The important point is that profile-specific ports are now supported without forcing every user to configure them.

### 4. Minimal CLI behavior changes

The `ccs proxy` UX remains mostly intact for the normal case.

Single-profile usage still works as before.

The only meaningful CLI behavior adjustment is when multiple proxies are running at once:

- `ccs proxy status` can now report multiple running profile proxies
- `ccs proxy stop` can stop all proxies, or a specific profile when one is provided
- `ccs proxy activate` now asks for an explicit profile only when activation would otherwise be ambiguous

That preserves the current DX for most users while making the multi-profile case tractable instead of broken.

### 5. Ignore local-only agent override files

This PR also updates `.gitignore` to exclude local agent override files such as `AGENTS.override.md` and `CLAUDE.local.md`.

These files are useful for local assistant workflows, but they are repository-local/private guidance rather than shareable project source. Ignoring them reduces the chance of accidentally committing machine-local or user-local agent instructions.

## Why This Design

I intentionally kept this fix narrow.

I considered broader routing or dashboard-level redesigns, but the underlying problem here was lifecycle/state isolation, not request transformation or provider resolution.

This implementation was chosen because it is the smallest viable structural fix that:

- removes the singleton assumption
- supports profile-scoped port mapping
- avoids breaking the existing default path
- keeps the current CLI mental model largely unchanged
- does not require invasive changes to request routing or provider adapters

In other words: this fixes the actual architectural pressure point without over-expanding the scope.

## User / Developer Impact

### What gets better

- Different OpenAI-compatible settings profiles can run concurrently on separate local ports.
- Profile aliases like `ccg` and `ccgm` no longer have to collide in one shared proxy runtime.
- Users who need stable per-profile ports can configure them explicitly.
- Users who do not care about multi-profile separation keep nearly the same workflow they already had.
- Local-only agent override files are less likely to leak into commits accidentally.

### What stays the same

- The default shared proxy port remains `3456` unless overridden.
- Existing single-profile usage remains straightforward.
- Request routing and upstream model transformation behavior are unchanged.

## Testing

I validated the change at multiple levels.

### Targeted proxy tests

- Added/updated integration coverage to verify that two different OpenAI-compatible profiles can run at the same time on different ports.
- Added unit coverage for profile-scoped preferred port resolution.

### Full repository validation

Ran:

- [x] `bun run validate`
- [x] `bun run validate:ci-parity`
- [x] `cd ui && bun run validate`

Notable validation results:

- Full backend/unit/integration/npm test suite passed
- CI parity gate passed
- UI validation passed

## Checklist

- [x] Base branch is `dev` unless this is an approved hotfix
- [x] Branch name follows `feat/*`, `fix/*`, `docs/*`, or approved hotfix naming
- [x] Relevant `--help` output updated if CLI behavior changed
- [x] Tests added or updated if behavior changed
- [ ] README or local docs updated if user-facing behavior changed
- [x] No secrets, tokens, or private config data are included

## Docs Impact

Docs impact: `minor`

Action: `no update needed`

Reasoning: this changes runtime behavior and CLI help output, but it does not add a large new user-facing surface area. The main discoverability points are already reflected in `ccs proxy --help`, and the config shape is intentionally small (`proxy.port` and `proxy.profile_ports`). If maintainers want, I can follow up with a short config example in docs, but I kept this PR focused on the structural fix itself.

## Notes for Review

A few things I expect reviewers may care about:

- This PR does not change the OpenAI-compatible request/response transformation layer.
- It does not alter upstream model routing semantics.
- It does not force profile-specific ports; it only enables them.
- It explicitly favors backward-compatible default behavior for the single-profile case.
- The `.gitignore` update is intentionally small and only targets local assistant override files.

If preferred, I can split the config support and lifecycle isolation into separate PRs, but they are closely coupled enough that reviewing them together felt more coherent.
