### PR TITLE
fix(ci): use PAT token for dev release pushes

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -26,8 +26,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: dev
-          # Always use the built-in workflow token; PAT rotation/breakage must not block dev releases.
-          token: ${{ github.token }}
+          # PAT_TOKEN required: dev-release pushes version bump commits to dev,
+          # and protected branches reject github.token writes once status checks are required.
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -58,10 +59,10 @@ jobs:
         id: release
         env:
           HUSKY: 0
-          # Use built-in GITHUB_TOKEN for release + issue operations.
-          # Checkout credentials are resolved above with PAT fallback.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT_TOKEN bypasses branch protection so the workflow can push
+          # the dev release commit and tag back to the protected dev branch.
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |

--- a/tests/unit/scripts/github/dev-release-workflow.test.ts
+++ b/tests/unit/scripts/github/dev-release-workflow.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function resolvePath(relativePath: string) {
+  return path.resolve(import.meta.dir, relativePath);
+}
+
+describe('dev release workflow', () => {
+  test('uses PAT_TOKEN for protected dev branch release pushes', () => {
+    const workflowPath = resolvePath('../../../../.github/workflows/dev-release.yml');
+
+    expect(fs.existsSync(workflowPath)).toBe(true);
+
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    const checkoutSection = workflow.slice(
+      workflow.indexOf('- name: Checkout'),
+      workflow.indexOf('- name: Setup Bun')
+    );
+    const releaseSection = workflow.slice(
+      workflow.indexOf('- name: Release'),
+      workflow.indexOf('- name: Notify Discord')
+    );
+
+    expect(workflow).toContain('name: Dev Release');
+    expect(workflow).toContain('branches: [dev]');
+    expect(checkoutSection).toContain("token: ${{ secrets.PAT_TOKEN }}");
+    expect(checkoutSection).not.toContain('token: ${{ github.token }}');
+    expect(releaseSection).toContain('GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}');
+    expect(releaseSection).toContain('GH_TOKEN: ${{ secrets.PAT_TOKEN }}');
+    expect(releaseSection).not.toContain('GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}');
+    expect(releaseSection).not.toContain('GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}');
+  });
+});


### PR DESCRIPTION
## Summary
- align `dev-release.yml` with `release.yml` by using `PAT_TOKEN` for checkout and release-step auth
- restore direct protected-branch push capability for the automated dev release commit/tag flow
- add a workflow regression test so the auth path cannot drift back to `github.token`

## Root Cause
`Dev Release` creates a new release commit on `dev` and then tries to push it back to protected `dev`. The workflow was using `github.token`, but branch protection on `dev` requires `typecheck`, `lint`, `format`, `build`, and `test` on the new commit, so GitHub rejected the push with `GH006`.

`release.yml` already solved this for `main` by using `PAT_TOKEN`.

## Testing
- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/dev-release.yml','utf8')); console.log('yaml-ok')"`
- `bun test tests/unit/scripts/github`
- `bun run typecheck && bun run lint`
