### PR TITLE
fix(settings-profile): preserve nested model intent for agent team launches

### DIFF
--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -1359,8 +1359,20 @@ async function main(): Promise<void> {
         console.error(info(`Global env: ${envNames}`));
       }
 
-      // Explicitly inject effective settings env vars so stale ANTHROPIC_*
-      // values from prior sessions cannot leak into the active profile.
+      // For Claude target launches that already pass `--settings`, keep runtime
+      // env limited to CCS-managed flags so nested Team/subagent sessions do not
+      // inherit profile-specific ANTHROPIC_* routing from the parent process.
+      const claudeRuntimeEnvVars: NodeJS.ProcessEnv = {
+        ...globalEnv,
+        ...(inheritedClaudeConfigDir ? { CLAUDE_CONFIG_DIR: inheritedClaudeConfigDir } : {}),
+        ...webSearchEnv,
+        ...imageAnalysisEnv,
+        ...(browserRuntimeEnv || {}),
+        CCS_PROFILE_TYPE: 'settings',
+        CCS_STRIP_INHERITED_ANTHROPIC_ENV: '1',
+      };
+
+      // Non-Claude targets still need effective credentials injected directly.
       const envVars: NodeJS.ProcessEnv = {
         ...globalEnv,
         ...settingsEnv,
@@ -1472,7 +1484,7 @@ async function main(): Promise<void> {
         settingsPath: expandedSettingsPath,
       });
 
-      execClaude(claudeCli, launchArgs, { ...envVars, ...traceEnv });
+      execClaude(claudeCli, launchArgs, { ...claudeRuntimeEnvVars, ...traceEnv });
     } else if (profileInfo.type === 'account') {
       // NEW FLOW: Account-based profile (work, personal)
       // All platforms: Use instance isolation with CLAUDE_CONFIG_DIR

--- a/src/ccs.ts
+++ b/src/ccs.ts
@@ -80,7 +80,7 @@ import { handleError, runCleanup } from './errors';
 import { tryHandleRootCommand } from './commands/root-command-router';
 
 // Import extracted utility functions
-import { execClaude } from './utils/shell-executor';
+import { execClaude, stripAnthropicRoutingEnv } from './utils/shell-executor';
 import { isDeprecatedGlmtProfileName, normalizeDeprecatedGlmtEnv } from './utils/glmt-deprecation';
 import { maybeWarnAboutResumeLaneMismatch } from './auth/resume-lane-warning';
 import { createLogger } from './services/logging';
@@ -1360,10 +1360,11 @@ async function main(): Promise<void> {
       }
 
       // For Claude target launches that already pass `--settings`, keep runtime
-      // env limited to CCS-managed flags so nested Team/subagent sessions do not
-      // inherit profile-specific ANTHROPIC_* routing from the parent process.
+      // env free of ANTHROPIC routing/auth while preserving non-routing profile
+      // env so nested Team/subagent sessions can still inherit model intent and
+      // other profile-scoped runtime flags.
       const claudeRuntimeEnvVars: NodeJS.ProcessEnv = {
-        ...globalEnv,
+        ...stripAnthropicRoutingEnv({ ...globalEnv, ...settingsEnv }),
         ...(inheritedClaudeConfigDir ? { CLAUDE_CONFIG_DIR: inheritedClaudeConfigDir } : {}),
         ...webSearchEnv,
         ...imageAnalysisEnv,

--- a/src/delegation/headless-executor.ts
+++ b/src/delegation/headless-executor.ts
@@ -16,8 +16,13 @@ import { type ExecutionOptions, type ExecutionResult, type StreamMessage } from 
 import { StreamBuffer, formatToolVerbose } from './executor/stream-parser';
 import { buildExecutionResult } from './executor/result-aggregator';
 import { getCcsDir, getModelDisplayName, loadSettings } from '../utils/config-manager';
+import { getGlobalEnvConfig } from '../config/unified-config-loader';
 import { getProfileLookupCandidates } from '../utils/profile-compat';
-import { getClaudeLaunchEnvOverrides, stripClaudeCodeEnv } from '../utils/shell-executor';
+import {
+  getClaudeLaunchEnvOverrides,
+  stripAnthropicRoutingEnv,
+  stripClaudeCodeEnv,
+} from '../utils/shell-executor';
 import { resolveProfileContinuityInheritance } from '../auth/profile-continuity-inheritance';
 import {
   appendThirdPartyImageAnalysisToolArgs,
@@ -38,6 +43,11 @@ import {
 import { resolveCliproxyBridgeMetadata } from '../api/services';
 import { ensureCliproxyService } from '../cliproxy';
 import { CLIPROXY_DEFAULT_PORT } from '../cliproxy/config/port-manager';
+import {
+  buildOpenAICompatProxyEnv,
+  resolveOpenAICompatProfileConfig,
+  startOpenAICompatProxy,
+} from '../proxy';
 import {
   appendThirdPartyWebSearchToolArgs,
   appendWebSearchTrace,
@@ -129,6 +139,14 @@ export class HeadlessExecutor {
     syncImageAnalysisMcpToConfigDir(inheritedClaudeConfigDir);
 
     const settings = loadSettings(settingsPath);
+    const globalEnvConfig = getGlobalEnvConfig();
+    const globalEnv = globalEnvConfig.enabled ? globalEnvConfig.env : {};
+    const settingsEnv = settings.env || {};
+    const openAICompatProfile = resolveOpenAICompatProfileConfig(
+      profile,
+      settingsPath,
+      settingsEnv
+    );
     const cliproxyBridge = resolveCliproxyBridgeMetadata(settings);
     let imageAnalysisFallbackHookReady: boolean | undefined;
     if (imageAnalysisMcpReady) {
@@ -205,6 +223,33 @@ export class HeadlessExecutor {
           CCS_IMAGE_ANALYSIS_SKIP: '1',
         };
       }
+    }
+
+    let runtimeEnvVars: NodeJS.ProcessEnv = {
+      ...stripAnthropicRoutingEnv({ ...globalEnv, ...settingsEnv }),
+      ...(inheritedClaudeConfigDir ? { CLAUDE_CONFIG_DIR: inheritedClaudeConfigDir } : {}),
+      CCS_PROFILE_TYPE: 'settings',
+      CCS_STRIP_INHERITED_ANTHROPIC_ENV: '1',
+    };
+
+    if (openAICompatProfile) {
+      const proxyStart = await startOpenAICompatProxy(openAICompatProfile, {
+        insecure: openAICompatProfile.insecure,
+      });
+      if (!proxyStart.success) {
+        throw new Error(proxyStart.error || 'Failed to start local OpenAI-compatible proxy');
+      }
+
+      runtimeEnvVars = {
+        ...runtimeEnvVars,
+        ...buildOpenAICompatProxyEnv(
+          openAICompatProfile,
+          proxyStart.port,
+          proxyStart.authToken || '',
+          inheritedClaudeConfigDir
+        ),
+      };
+      delete runtimeEnvVars.ANTHROPIC_API_KEY;
     }
 
     // Smart slash command detection and preservation
@@ -321,6 +366,7 @@ export class HeadlessExecutor {
       sessionMgr,
       claudeConfigDir: inheritedClaudeConfigDir,
       imageAnalysisEnv,
+      runtimeEnvVars,
       traceEnv,
     });
   }
@@ -340,6 +386,7 @@ export class HeadlessExecutor {
       sessionMgr: SessionManager;
       claudeConfigDir?: string;
       imageAnalysisEnv?: Record<string, string>;
+      runtimeEnvVars?: NodeJS.ProcessEnv;
       traceEnv?: Record<string, string>;
     }
   ): Promise<ExecutionResult> {
@@ -352,6 +399,7 @@ export class HeadlessExecutor {
       sessionMgr,
       claudeConfigDir,
       imageAnalysisEnv = {},
+      runtimeEnvVars = {},
       traceEnv = {},
     } = ctx;
 
@@ -368,9 +416,10 @@ export class HeadlessExecutor {
       // Strip Claude Code nested session guard env var to allow CCS delegation
       // (Claude Code v2.1.39+ sets CLAUDECODE to detect nested sessions)
       const cleanEnv = stripClaudeCodeEnv({
-        ...process.env,
+        ...stripAnthropicRoutingEnv(process.env),
         ...getClaudeLaunchEnvOverrides(),
         ...getWebSearchHookEnv(),
+        ...runtimeEnvVars,
         ...imageAnalysisEnv,
         ...traceEnv,
         ...(claudeConfigDir ? { CLAUDE_CONFIG_DIR: claudeConfigDir } : {}),

--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -177,10 +177,13 @@ export function execClaude(
   const mergedEnv = envVars
     ? { ...baseEnv, ...claudeLaunchEnv, ...envVars, ...webSearchEnv }
     : { ...baseEnv, ...claudeLaunchEnv, ...webSearchEnv };
+  const effectiveMergedEnv = stripInheritedAnthropicRoutingEnv
+    ? stripAnthropicRoutingEnv(mergedEnv)
+    : mergedEnv;
 
   // Strip Claude Code nested session guard env var to allow CCS delegation
   // (Claude Code v2.1.39+ sets CLAUDECODE to detect nested sessions)
-  const env = stripClaudeCodeEnv(mergedEnv);
+  const env = stripClaudeCodeEnv(effectiveMergedEnv);
 
   if (profileType !== 'account') {
     try {

--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -26,11 +26,28 @@ export function stripAnthropicEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return result;
 }
 
-const ANTHROPIC_ROUTING_ENV_KEYS = new Set([
+const ANTHROPIC_ROUTING_ENV_KEYS = [
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_API_KEY',
-]);
+];
+const ANTHROPIC_ROUTING_ENV_KEY_SET = new Set(ANTHROPIC_ROUTING_ENV_KEYS);
+const ANTHROPIC_MODEL_ENV_KEYS = [
+  'ANTHROPIC_MODEL',
+  'ANTHROPIC_DEFAULT_OPUS_MODEL',
+  'ANTHROPIC_DEFAULT_SONNET_MODEL',
+  'ANTHROPIC_DEFAULT_HAIKU_MODEL',
+  'ANTHROPIC_SMALL_FAST_MODEL',
+];
+const TMUX_SYNC_ENV_KEYS = [
+  'CLAUDE_CONFIG_DIR',
+  'CCS_PROFILE_TYPE',
+  'CCS_WEBSEARCH_SKIP',
+  'CCS_STRIP_INHERITED_ANTHROPIC_ENV',
+  'CLAUDE_CODE_MAX_OUTPUT_TOKENS',
+  ...ANTHROPIC_MODEL_ENV_KEYS,
+  ...ANTHROPIC_ROUTING_ENV_KEYS,
+];
 
 /**
  * Strip inherited Anthropic routing/auth env while preserving model intent.
@@ -41,11 +58,37 @@ const ANTHROPIC_ROUTING_ENV_KEYS = new Set([
 export function stripAnthropicRoutingEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const result: NodeJS.ProcessEnv = {};
   for (const key of Object.keys(env)) {
-    if (!ANTHROPIC_ROUTING_ENV_KEYS.has(key)) {
+    if (!ANTHROPIC_ROUTING_ENV_KEY_SET.has(key.toUpperCase())) {
       result[key] = env[key];
     }
   }
   return result;
+}
+
+function syncTmuxNestedSessionEnv(env: NodeJS.ProcessEnv, profileType: string | undefined): void {
+  if (!process.env.TMUX) {
+    return;
+  }
+
+  const nestedSessionEnv =
+    profileType === 'account' || profileType === 'default'
+      ? stripAnthropicEnv(env)
+      : profileType === 'settings'
+        ? stripAnthropicRoutingEnv(env)
+        : env;
+
+  for (const key of TMUX_SYNC_ENV_KEYS) {
+    try {
+      const value = nestedSessionEnv[key];
+      if (value !== undefined) {
+        spawnSync('tmux', ['setenv', key, value], { stdio: 'ignore' });
+      } else {
+        spawnSync('tmux', ['setenv', '-u', key], { stdio: 'ignore' });
+      }
+    } catch {
+      // tmux setenv can fail if not in a tmux session; safe to ignore
+    }
+  }
 }
 
 /**
@@ -193,20 +236,9 @@ export function execClaude(
     }
   }
 
-  // propagate key env vars to tmux session so agent team teammates
-  // (spawned via tmux split-window) inherit the correct config dir
-  if (process.env.TMUX && envVars) {
-    const tmuxPropagateVars = ['CLAUDE_CONFIG_DIR', 'CCS_PROFILE_TYPE', 'CCS_WEBSEARCH_SKIP'];
-    for (const key of tmuxPropagateVars) {
-      if (envVars[key]) {
-        try {
-          spawnSync('tmux', ['setenv', key, envVars[key] ?? ''], { stdio: 'ignore' });
-        } catch {
-          // tmux setenv can fail if not in a tmux session; safe to ignore
-        }
-      }
-    }
-  }
+  // Keep tmux teammate panes aligned with the nested-safe Claude runtime env
+  // rather than the tmux server's original shell environment.
+  syncTmuxNestedSessionEnv(env, profileType);
 
   let child: ChildProcess;
   if (isPowerShellScript) {

--- a/src/utils/shell-executor.ts
+++ b/src/utils/shell-executor.ts
@@ -26,6 +26,28 @@ export function stripAnthropicEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return result;
 }
 
+const ANTHROPIC_ROUTING_ENV_KEYS = new Set([
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_API_KEY',
+]);
+
+/**
+ * Strip inherited Anthropic routing/auth env while preserving model intent.
+ * Used for nested settings-profile Claude launches where `--settings` already
+ * defines the provider transport and the parent process should only lend model
+ * defaults or effort hints.
+ */
+export function stripAnthropicRoutingEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {};
+  for (const key of Object.keys(env)) {
+    if (!ANTHROPIC_ROUTING_ENV_KEYS.has(key)) {
+      result[key] = env[key];
+    }
+  }
+  return result;
+}
+
 /**
  * Strip Claude Code nested-session guard env var from a process environment.
  *
@@ -137,14 +159,18 @@ export function execClaude(
   const webSearchEnv = getWebSearchHookEnv();
   const claudeLaunchEnv = getClaudeLaunchEnvOverrides();
 
-  // For account/default profiles, strip ANTHROPIC_* from parent env to prevent
-  // stale proxy config (e.g., from prior CLIProxy sessions) from interfering
-  // with native Claude API routing. Settings-based profiles explicitly inject
-  // their own ANTHROPIC_* values, so they don't need this protection.
+  // Strip inherited ANTHROPIC_* when the launch should not reuse parent routing.
+  // Account/default profiles need full isolation from prior proxy sessions.
+  // Settings profiles can selectively strip only routing/auth when `--settings`
+  // already carries the provider source of truth but the parent model intent
+  // should still flow into nested Team/subagent launches.
   const profileType = envVars?.CCS_PROFILE_TYPE;
-  const baseEnv =
-    profileType === 'account' || profileType === 'default'
-      ? stripAnthropicEnv(process.env)
+  const stripInheritedAnthropicEnv = profileType === 'account' || profileType === 'default';
+  const stripInheritedAnthropicRoutingEnv = envVars?.CCS_STRIP_INHERITED_ANTHROPIC_ENV === '1';
+  const baseEnv = stripInheritedAnthropicEnv
+    ? stripAnthropicEnv(process.env)
+    : stripInheritedAnthropicRoutingEnv
+      ? stripAnthropicRoutingEnv(process.env)
       : process.env;
 
   // Prepare environment (merge with base env if envVars provided)

--- a/tests/unit/targets/settings-profile-browser-launch.test.ts
+++ b/tests/unit/targets/settings-profile-browser-launch.test.ts
@@ -135,6 +135,12 @@ printf "%s\n" "$@" > "${claudeArgsLogPath}"
   printf "port=%s\n" "$CCS_BROWSER_DEVTOOLS_PORT"
   printf "httpUrl=%s\n" "$CCS_BROWSER_DEVTOOLS_HTTP_URL"
   printf "wsUrl=%s\n" "$CCS_BROWSER_DEVTOOLS_WS_URL"
+  printf "stripAnthropic=%s\n" "$CCS_STRIP_INHERITED_ANTHROPIC_ENV"
+  printf "anthropicBaseUrl=%s\n" "$ANTHROPIC_BASE_URL"
+  printf "anthropicAuthToken=%s\n" "$ANTHROPIC_AUTH_TOKEN"
+  printf "anthropicApiKey=%s\n" "$ANTHROPIC_API_KEY"
+  printf "anthropicModel=%s\n" "$ANTHROPIC_MODEL"
+  printf "anthropicSonnet=%s\n" "$ANTHROPIC_DEFAULT_SONNET_MODEL"
 } > "${claudeEnvLogPath}"
 exit 0
 `,
@@ -177,6 +183,44 @@ exit 0
     expect(result.status).toBe(0);
     expect(result.stderr).not.toContain('DevToolsActivePort');
     expect(fs.existsSync(claudeArgsLogPath)).toBe(true);
+  });
+
+  it('passes selective Anthropic env stripping to settings-profile Claude launches while preserving model defaults', () => {
+    if (process.platform === 'win32') return;
+
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify(
+        {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.z.ai/api/anthropic',
+            ANTHROPIC_AUTH_TOKEN: 'profile-token',
+            ANTHROPIC_MODEL: 'gpt-5.4',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+          },
+        },
+        null,
+        2
+      ) + '\n'
+    );
+
+    const result = runCcs(['glm', 'smoke'], {
+      ...baseEnv,
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:8317/api/provider/codex',
+      ANTHROPIC_AUTH_TOKEN: 'parent-routing-token',
+      ANTHROPIC_API_KEY: 'parent-api-key',
+      ANTHROPIC_MODEL: 'gpt-5.4',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+    });
+
+    expect(result.status).toBe(0);
+    const launchedEnv = fs.readFileSync(claudeEnvLogPath, 'utf8');
+    expect(launchedEnv).toContain('stripAnthropic=1');
+    expect(launchedEnv).toContain('anthropicBaseUrl=');
+    expect(launchedEnv).toContain('anthropicAuthToken=');
+    expect(launchedEnv).toContain('anthropicApiKey=');
+    expect(launchedEnv).toContain('anthropicModel=gpt-5.4');
+    expect(launchedEnv).toContain('anthropicSonnet=gpt-5.4');
   });
 
   it('does not auto-enable browser reuse for settings-profile launches from env overrides alone', async () => {

--- a/tests/unit/targets/settings-profile-browser-launch.test.ts
+++ b/tests/unit/targets/settings-profile-browser-launch.test.ts
@@ -141,6 +141,7 @@ printf "%s\n" "$@" > "${claudeArgsLogPath}"
   printf "anthropicApiKey=%s\n" "$ANTHROPIC_API_KEY"
   printf "anthropicModel=%s\n" "$ANTHROPIC_MODEL"
   printf "anthropicSonnet=%s\n" "$ANTHROPIC_DEFAULT_SONNET_MODEL"
+  printf "maxOutputTokens=%s\n" "$CLAUDE_CODE_MAX_OUTPUT_TOKENS"
 } > "${claudeEnvLogPath}"
 exit 0
 `,
@@ -197,6 +198,7 @@ exit 0
             ANTHROPIC_AUTH_TOKEN: 'profile-token',
             ANTHROPIC_MODEL: 'gpt-5.4',
             ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+            CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12345',
           },
         },
         null,
@@ -204,23 +206,47 @@ exit 0
       ) + '\n'
     );
 
-    const result = runCcs(['glm', 'smoke'], {
-      ...baseEnv,
-      ANTHROPIC_BASE_URL: 'http://127.0.0.1:8317/api/provider/codex',
-      ANTHROPIC_AUTH_TOKEN: 'parent-routing-token',
-      ANTHROPIC_API_KEY: 'parent-api-key',
-      ANTHROPIC_MODEL: 'gpt-5.4',
-      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
-    });
+    const originalCcsHome = process.env.CCS_HOME;
+    process.env.CCS_HOME = tmpHome;
 
-    expect(result.status).toBe(0);
-    const launchedEnv = fs.readFileSync(claudeEnvLogPath, 'utf8');
-    expect(launchedEnv).toContain('stripAnthropic=1');
-    expect(launchedEnv).toContain('anthropicBaseUrl=');
-    expect(launchedEnv).toContain('anthropicAuthToken=');
-    expect(launchedEnv).toContain('anthropicApiKey=');
-    expect(launchedEnv).toContain('anthropicModel=gpt-5.4');
-    expect(launchedEnv).toContain('anthropicSonnet=gpt-5.4');
+    try {
+      mutateUnifiedConfig((config) => {
+        config.global_env = {
+          enabled: true,
+          env: {
+            ANTHROPIC_BASE_URL: 'http://127.0.0.1:9999/api/provider/global',
+            ANTHROPIC_AUTH_TOKEN: 'global-routing-token',
+            ANTHROPIC_API_KEY: 'global-api-key',
+            CLAUDE_CODE_MAX_OUTPUT_TOKENS: '54321',
+          },
+        };
+      });
+
+      const result = runCcs(['glm', 'smoke'], {
+        ...baseEnv,
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:8317/api/provider/codex',
+        ANTHROPIC_AUTH_TOKEN: 'parent-routing-token',
+        ANTHROPIC_API_KEY: 'parent-api-key',
+        ANTHROPIC_MODEL: 'gpt-5.4',
+        ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+      });
+
+      expect(result.status).toBe(0);
+      const launchedEnv = fs.readFileSync(claudeEnvLogPath, 'utf8');
+      expect(launchedEnv).toContain('stripAnthropic=1');
+      expect(launchedEnv).toContain('anthropicBaseUrl=');
+      expect(launchedEnv).toContain('anthropicAuthToken=');
+      expect(launchedEnv).toContain('anthropicApiKey=');
+      expect(launchedEnv).toContain('anthropicModel=gpt-5.4');
+      expect(launchedEnv).toContain('anthropicSonnet=gpt-5.4');
+      expect(launchedEnv).toContain('maxOutputTokens=12345');
+    } finally {
+      if (originalCcsHome !== undefined) {
+        process.env.CCS_HOME = originalCcsHome;
+      } else {
+        delete process.env.CCS_HOME;
+      }
+    }
   });
 
   it('does not auto-enable browser reuse for settings-profile launches from env overrides alone', async () => {

--- a/tests/unit/utils/claudecode-env-stripping.test.ts
+++ b/tests/unit/utils/claudecode-env-stripping.test.ts
@@ -367,6 +367,26 @@ describe('CLAUDECODE environment stripping', () => {
     expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5-codex-mini');
   });
 
+  it('execClaude strips routing env reintroduced by explicit settings-profile overrides', () => {
+    execClaude('claude', ['--help'], {
+      CCS_PROFILE_TYPE: 'settings',
+      CCS_STRIP_INHERITED_ANTHROPIC_ENV: '1',
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:8317/api/provider/codex',
+      ANTHROPIC_AUTH_TOKEN: 'reintroduced-routing-token',
+      ANTHROPIC_API_KEY: 'reintroduced-api-key',
+      ANTHROPIC_MODEL: 'gpt-5.4',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+    });
+
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    const env = spawnCalls[0].options?.env as NodeJS.ProcessEnv;
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.4');
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4');
+  });
+
   it('headless executor spawn path strips CLAUDECODE before spawn', async () => {
     writeConfigWithAutoUpdatePreference(false);
     process.env.CLAUDECODE = 'nested';

--- a/tests/unit/utils/claudecode-env-stripping.test.ts
+++ b/tests/unit/utils/claudecode-env-stripping.test.ts
@@ -336,6 +336,37 @@ describe('CLAUDECODE environment stripping', () => {
     expect(normalizeSpy).toHaveBeenCalledWith(instancePath);
   });
 
+  it('execClaude strips inherited ANTHROPIC routing env but keeps model intent for settings-profile Claude launches', () => {
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:8317/api/provider/codex';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'ccs-internal-managed';
+    process.env.ANTHROPIC_API_KEY = 'stale-api-key';
+    process.env.ANTHROPIC_MODEL = 'gpt-5.4';
+    process.env.ANTHROPIC_DEFAULT_OPUS_MODEL = 'gpt-5.4';
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'gpt-5.4';
+    process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL = 'gpt-5.4-mini';
+    process.env.ANTHROPIC_SMALL_FAST_MODEL = 'gpt-5-codex-mini';
+
+    execClaude('claude', ['--help'], {
+      CCS_PROFILE_TYPE: 'settings',
+      CCS_STRIP_INHERITED_ANTHROPIC_ENV: '1',
+      CLAUDE_CONFIG_DIR: path.join(os.tmpdir(), 'ccs-settings-profile-instance'),
+      CCS_WEBSEARCH_SKIP: '1',
+    });
+
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    const env = spawnCalls[0].options?.env as NodeJS.ProcessEnv;
+    expect(env.CCS_PROFILE_TYPE).toBe('settings');
+    expect(env.CLAUDE_CONFIG_DIR).toContain('ccs-settings-profile-instance');
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.4');
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.4');
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4');
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini');
+    expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBe('gpt-5-codex-mini');
+  });
+
   it('headless executor spawn path strips CLAUDECODE before spawn', async () => {
     writeConfigWithAutoUpdatePreference(false);
     process.env.CLAUDECODE = 'nested';

--- a/tests/unit/utils/claudecode-env-stripping.test.ts
+++ b/tests/unit/utils/claudecode-env-stripping.test.ts
@@ -21,8 +21,16 @@ type SpawnCall = {
   options: Record<string, unknown> | undefined;
 };
 
-const STEERING_PROMPT_SNIPPET = 'prefer the CCS MCP tool WebSearch instead of Bash/curl/http fetches';
+type SpawnSyncCall = {
+  command: string;
+  args: string[];
+  options: Record<string, unknown> | undefined;
+};
+
+const STEERING_PROMPT_SNIPPET =
+  'prefer the CCS MCP tool WebSearch instead of Bash/curl/http fetches';
 const spawnCalls: SpawnCall[] = [];
+const spawnSyncCalls: SpawnSyncCall[] = [];
 const originalPlatform = process.platform;
 let baselineSigintListeners: Array<(...args: unknown[]) => void> = [];
 let baselineSigtermListeners: Array<(...args: unknown[]) => void> = [];
@@ -31,6 +39,7 @@ let originalCcsHome: string | undefined;
 let originalCcsClaudePath: string | undefined;
 let originalDisableAutoUpdater: string | undefined;
 let originalClaudeConfigDir: string | undefined;
+let originalTmux: string | undefined;
 const realSpawn = childProcess.spawn.bind(childProcess);
 const realSpawnSync = childProcess.spawnSync.bind(childProcess);
 const realExecSync = childProcess.execSync.bind(childProcess);
@@ -103,6 +112,18 @@ function registerChildProcessMock(): void {
         | Record<string, unknown>
         | undefined;
 
+      if (command === 'tmux') {
+        spawnSyncCalls.push({ command, args, options });
+        return {
+          pid: process.pid,
+          output: ['', '', ''],
+          stdout: '',
+          stderr: '',
+          status: 0,
+          signal: null,
+        };
+      }
+
       return realSpawnSync(command, args, options as Parameters<typeof childProcess.spawnSync>[2]);
     },
     execSync: (...execArgs: unknown[]) =>
@@ -140,6 +161,7 @@ ${yamlBody}
 }
 
 let execClaude: typeof import('../../../src/utils/shell-executor').execClaude;
+let stripAnthropicRoutingEnv: typeof import('../../../src/utils/shell-executor').stripAnthropicRoutingEnv;
 let stripClaudeCodeEnv: typeof import('../../../src/utils/shell-executor').stripClaudeCodeEnv;
 let HeadlessExecutor: typeof import('../../../src/delegation/headless-executor').HeadlessExecutor;
 let SharedManager: typeof import('../../../src/management/shared-manager').default;
@@ -149,6 +171,7 @@ beforeAll(async () => {
 
   const shellExecutor = await import('../../../src/utils/shell-executor');
   execClaude = shellExecutor.execClaude;
+  stripAnthropicRoutingEnv = shellExecutor.stripAnthropicRoutingEnv;
   stripClaudeCodeEnv = shellExecutor.stripClaudeCodeEnv;
 
   const sharedManagerModule = await import('../../../src/management/shared-manager');
@@ -165,6 +188,7 @@ afterAll(() => {
 describe('CLAUDECODE environment stripping', () => {
   beforeEach(() => {
     spawnCalls.length = 0;
+    spawnSyncCalls.length = 0;
     process.env.CCS_QUIET = '1';
 
     // Save original env values for restoration in afterEach
@@ -172,10 +196,12 @@ describe('CLAUDECODE environment stripping', () => {
     originalCcsClaudePath = process.env.CCS_CLAUDE_PATH;
     originalDisableAutoUpdater = process.env.DISABLE_AUTOUPDATER;
     originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    originalTmux = process.env.TMUX;
 
     // Clear CCS-managed env vars that leak from host sessions
     delete process.env.DISABLE_AUTOUPDATER;
     delete process.env.CLAUDE_CONFIG_DIR;
+    delete process.env.TMUX;
 
     baselineSigintListeners = process.listeners('SIGINT');
     baselineSigtermListeners = process.listeners('SIGTERM');
@@ -197,8 +223,20 @@ describe('CLAUDECODE environment stripping', () => {
     } else {
       delete process.env.DISABLE_AUTOUPDATER;
     }
-    if (originalClaudeConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+    if (originalClaudeConfigDir !== undefined)
+      process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
     else delete process.env.CLAUDE_CONFIG_DIR;
+    if (originalTmux !== undefined) process.env.TMUX = originalTmux;
+    else delete process.env.TMUX;
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.ANTHROPIC_AUTH_TOKEN;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_MODEL;
+    delete process.env.ANTHROPIC_DEFAULT_OPUS_MODEL;
+    delete process.env.ANTHROPIC_DEFAULT_SONNET_MODEL;
+    delete process.env.ANTHROPIC_DEFAULT_HAIKU_MODEL;
+    delete process.env.ANTHROPIC_SMALL_FAST_MODEL;
+    delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS;
 
     for (const listener of process.listeners('SIGINT')) {
       if (!baselineSigintListeners.includes(listener)) {
@@ -227,6 +265,25 @@ describe('CLAUDECODE environment stripping', () => {
 
     const result = stripClaudeCodeEnv(input);
     expect(Object.keys(result).map((k) => k.toUpperCase())).not.toContain('CLAUDECODE');
+    expect(result.PATH).toBe('/usr/bin');
+  });
+
+  it('stripAnthropicRoutingEnv removes routing/auth env case-insensitively while preserving model vars', () => {
+    const input: NodeJS.ProcessEnv = {
+      anthropic_base_url: 'http://127.0.0.1:8317/api/provider/codex',
+      Anthropic_Auth_Token: 'parent-routing-token',
+      ANTHROPIC_API_KEY: 'parent-api-key',
+      ANTHROPIC_MODEL: 'gpt-5.4',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+      PATH: '/usr/bin',
+    };
+
+    const result = stripAnthropicRoutingEnv(input);
+    expect(result.anthropic_base_url).toBeUndefined();
+    expect(result.Anthropic_Auth_Token).toBeUndefined();
+    expect(result.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(result.ANTHROPIC_MODEL).toBe('gpt-5.4');
+    expect(result.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4');
     expect(result.PATH).toBe('/usr/bin');
   });
 
@@ -387,6 +444,46 @@ describe('CLAUDECODE environment stripping', () => {
     expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4');
   });
 
+  it('execClaude sanitizes tmux teammate env for bridge-backed settings launches while keeping the launched child on the runtime proxy', () => {
+    process.env.TMUX = 'session-1';
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:8317/api/provider/codex';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'parent-routing-token';
+    process.env.ANTHROPIC_API_KEY = 'parent-api-key';
+    process.env.ANTHROPIC_MODEL = 'gpt-5.4';
+    process.env.ANTHROPIC_DEFAULT_SONNET_MODEL = 'gpt-5.4';
+
+    execClaude('claude', ['--help'], {
+      CCS_PROFILE_TYPE: 'settings',
+      CLAUDE_CONFIG_DIR: path.join(os.tmpdir(), 'ccs-settings-profile-instance'),
+      ANTHROPIC_BASE_URL: 'http://127.0.0.1:3456',
+      ANTHROPIC_AUTH_TOKEN: 'fresh-runtime-token',
+      ANTHROPIC_MODEL: 'gpt-5.4',
+    });
+
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    const childEnv = spawnCalls[0].options?.env as NodeJS.ProcessEnv;
+    expect(childEnv.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:3456');
+    expect(childEnv.ANTHROPIC_AUTH_TOKEN).toBe('fresh-runtime-token');
+
+    const unsetBaseUrlCall = spawnSyncCalls.find(
+      (call) => call.command === 'tmux' && call.args.join(' ') === 'setenv -u ANTHROPIC_BASE_URL'
+    );
+    const unsetAuthTokenCall = spawnSyncCalls.find(
+      (call) => call.command === 'tmux' && call.args.join(' ') === 'setenv -u ANTHROPIC_AUTH_TOKEN'
+    );
+    const modelCall = spawnSyncCalls.find(
+      (call) =>
+        call.command === 'tmux' &&
+        call.args[0] === 'setenv' &&
+        call.args[1] === 'ANTHROPIC_MODEL' &&
+        call.args[2] === 'gpt-5.4'
+    );
+
+    expect(unsetBaseUrlCall).toBeDefined();
+    expect(unsetAuthTokenCall).toBeDefined();
+    expect(modelCall).toBeDefined();
+  });
+
   it('headless executor spawn path strips CLAUDECODE before spawn', async () => {
     writeConfigWithAutoUpdatePreference(false);
     process.env.CLAUDECODE = 'nested';
@@ -483,6 +580,92 @@ describe('CLAUDECODE environment stripping', () => {
     });
   });
 
+  it('headless executor strips inherited routing env for settings-profile delegation while preserving model intent', async () => {
+    writeConfigWithAutoUpdatePreference(false);
+    const ccsDir = path.join(process.env.CCS_HOME as string, '.ccs');
+    fs.writeFileSync(
+      path.join(ccsDir, 'glm.settings.json'),
+      JSON.stringify(
+        {
+          env: {
+            ANTHROPIC_MODEL: 'gpt-5.4',
+            ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+            CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12345',
+          },
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+    const projectDir = path.join(ccsDir, 'project-headless-settings');
+    fs.mkdirSync(projectDir, { recursive: true });
+    process.env.CCS_CLAUDE_PATH = 'claude';
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:8317/api/provider/codex';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'parent-routing-token';
+    process.env.ANTHROPIC_API_KEY = 'parent-api-key';
+    process.env.ANTHROPIC_MODEL = 'gpt-5.4';
+
+    const result = await HeadlessExecutor.execute('glm', 'latest AI chip news', {
+      cwd: projectDir,
+      permissionMode: 'default',
+      timeout: 1000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    const env = spawnCalls[0].options?.env as NodeJS.ProcessEnv;
+    expect(env.ANTHROPIC_BASE_URL).toBeUndefined();
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.4');
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.4');
+    expect(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('12345');
+  });
+
+  it('headless executor rebuilds OpenAI-compatible bridge env from settings instead of inheriting stale parent routing', async () => {
+    writeConfigWithAutoUpdatePreference(false);
+    const ccsDir = path.join(process.env.CCS_HOME as string, '.ccs');
+    fs.writeFileSync(
+      path.join(ccsDir, 'bridge.settings.json'),
+      JSON.stringify(
+        {
+          env: {
+            ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+            ANTHROPIC_AUTH_TOKEN: 'settings-bridge-token',
+            ANTHROPIC_MODEL: 'gpt-5.4',
+            CLAUDE_CODE_MAX_OUTPUT_TOKENS: '12345',
+          },
+        },
+        null,
+        2
+      ) + '\n',
+      'utf8'
+    );
+    const projectDir = path.join(ccsDir, 'project-headless-bridge');
+    fs.mkdirSync(projectDir, { recursive: true });
+    process.env.CCS_CLAUDE_PATH = 'claude';
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:8317/api/provider/codex';
+    process.env.ANTHROPIC_AUTH_TOKEN = 'parent-routing-token';
+    process.env.ANTHROPIC_API_KEY = 'parent-api-key';
+
+    const result = await HeadlessExecutor.execute('bridge', 'latest AI chip news', {
+      cwd: projectDir,
+      permissionMode: 'default',
+      timeout: 1000,
+    });
+
+    expect(result.success).toBe(true);
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    const env = spawnCalls[0].options?.env as NodeJS.ProcessEnv;
+    expect(env.ANTHROPIC_BASE_URL).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(env.ANTHROPIC_BASE_URL).not.toBe('http://127.0.0.1:8317/api/provider/codex');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeDefined();
+    expect(env.ANTHROPIC_AUTH_TOKEN).not.toBe('parent-routing-token');
+    expect(env.ANTHROPIC_MODEL).toBe('gpt-5.4');
+    expect(env.CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBe('12345');
+  });
+
   it('headless executor prepares image-analysis MCP and suppresses the legacy hook on healthy launches', async () => {
     writeConfigWithAutoUpdatePreference(false);
     const ccsDir = path.join(process.env.CCS_HOME as string, '.ccs');
@@ -519,9 +702,7 @@ describe('CLAUDECODE environment stripping', () => {
       args: [path.join(ccsDir, 'mcp', 'ccs-image-analysis-server.cjs')],
       env: {},
     });
-    expect(fs.existsSync(path.join(ccsDir, 'hooks', 'image-analyzer-transformer.cjs'))).toBe(
-      false
-    );
+    expect(fs.existsSync(path.join(ccsDir, 'hooks', 'image-analyzer-transformer.cjs'))).toBe(false);
     expect(fs.existsSync(path.join(ccsDir, 'hooks', 'image-analysis-runtime.cjs'))).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

This PR fixes the nested environment inheritance bug affecting Claude Code Team and subagent launches from CCS settings profiles.

Today, the settings-profile Claude launch path mixes two different concerns into the same inherited runtime lane:

- the parent session's model intent
- the parent session's provider/auth/routing transport

That sounds subtle, but it is exactly why Team flows break in practice.

When a user launches Claude Code through CCS with a settings profile that ultimately routes through the Codex/OpenAI-compatible bridge, nested teammates can inherit more than they should. Instead of just inheriting the parent model defaults, they can also inherit proxy transport settings like `ANTHROPIC_BASE_URL` and auth state like `ANTHROPIC_AUTH_TOKEN`.

That breaks the runtime boundary.

In practice, the child agent is no longer just "using the same model family as the parent." It is effectively being forced back onto the parent's provider lane. That is how failures like this show up:

```text
API Error: 503 auth_unavailable: no auth available (providers=codex, model=gpt-5-codex-mini)
```

This PR fixes that by preserving nested model intent while selectively stripping inherited Anthropic routing/auth environment variables for settings-profile Claude launches.

The result is the behavior users actually want:

- parent Claude sessions can still express model defaults like `gpt-5.4`
- nested Team/subagent launches can still inherit that model intent
- but they no longer inherit stale or incorrect provider transport/auth state from the parent process


<img width="802" height="114" alt="스크린샷 2026-04-21 오후 3 54 15" src="https://github.com/user-attachments/assets/bc7661b0-ce60-4a78-b3ed-da373c15be9d" />


## Problem Background

The problem was not simply "a haiku mapping bug" or "mini got chosen somewhere."

The deeper issue was boundary leakage between parent and child Claude runtimes.

CCS already had logic to aggressively inject effective settings env into top-level Claude launches. That made sense for the original goal:

- keep stale `ANTHROPIC_*` values from previous sessions from poisoning the active profile
- make the top-level Claude session faithfully reflect the current CCS profile settings

The catch is that this design was optimized for the parent launch, not for nested Team/subagent boundaries.

Once a settings-profile Claude session was up, nested launches could end up inheriting the parent's full `ANTHROPIC_*` lane, including transport/auth values. At that point the child is not making a fresh runtime decision anymore. It is getting dragged through the parent's provider tunnel.

From a user perspective, that means the Team abstraction stops feeling real. You asked for nested agents to keep the parent's model intent, but instead some of them leak into the wrong provider route and fail on spawn.

## Root Cause

The failure came from a combination of behaviors in the existing implementation:

1. `src/ccs.ts` passed effective settings env aggressively for settings-profile launches.
2. `src/utils/shell-executor.ts` merged `process.env` back into nested Claude launches.
3. Settings-profile launches did not have a selective nested-env boundary.
4. The inherited parent env could therefore carry both:
   - model defaults such as `ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, `ANTHROPIC_DEFAULT_HAIKU_MODEL`
   - routing/auth values such as `ANTHROPIC_BASE_URL`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`
5. In Codex bridge scenarios, that meant nested agents could be interpreted through the parent's provider/auth lane instead of only inheriting its model intent.

So the real bug was not "children inherit too much model state."

The real bug was "children inherit the wrong kind of state."

## What Changed

### 1. Added selective Anthropic routing stripping in `shell-executor`

`src/utils/shell-executor.ts` now distinguishes between two isolation modes:

- full `ANTHROPIC_*` stripping for account/default profile cases that need full routing isolation
- selective routing/auth stripping for settings-profile Claude launches that should preserve model intent

Specifically, the new selective path removes inherited:

- `ANTHROPIC_BASE_URL`
- `ANTHROPIC_AUTH_TOKEN`
- `ANTHROPIC_API_KEY`

while preserving model-selection state such as:

- `ANTHROPIC_MODEL`
- `ANTHROPIC_DEFAULT_OPUS_MODEL`
- `ANTHROPIC_DEFAULT_SONNET_MODEL`
- `ANTHROPIC_DEFAULT_HAIKU_MODEL`
- `ANTHROPIC_SMALL_FAST_MODEL`

This is the whole fix.

Keep the parent's model lane. Drop the parent's transport lane.

### 2. Updated settings-profile Claude launch wiring in `src/ccs.ts`

`src/ccs.ts` now builds a dedicated `claudeRuntimeEnvVars` payload for settings-profile Claude launches.

That payload intentionally keeps CCS-managed runtime flags but sets:

- `CCS_PROFILE_TYPE=settings`
- `CCS_STRIP_INHERITED_ANTHROPIC_ENV=1`

Then the settings-profile Claude path calls `execClaude()` with that runtime env instead of blindly passing the broader effective env set.

This means:

- non-Claude targets still receive the effective credentials they need
- Claude launches that already pass `--settings` use that settings file as the provider source of truth
- nested Team/subagent launches inherit the parent's model defaults, not its proxy tunnel

### 3. Added direct unit coverage for the selective filter policy

`tests/unit/utils/claudecode-env-stripping.test.ts` now verifies the core policy directly:

- routing/auth env is removed
- model defaults remain present

This is the low-level guardrail for the new behavior.

### 4. Added launch-path coverage through the real settings-profile wiring

`tests/unit/targets/settings-profile-browser-launch.test.ts` now verifies the higher-level path through `src/ccs.ts`:

- settings-profile Claude launch passes `CCS_STRIP_INHERITED_ANTHROPIC_ENV=1`
- inherited routing/auth env is blank in the child launch
- inherited model defaults like `ANTHROPIC_MODEL=gpt-5.4` and `ANTHROPIC_DEFAULT_SONNET_MODEL=gpt-5.4` are still preserved

That matters because this bug was not purely a helper-function bug. It lived in the interaction between `src/ccs.ts` and `src/utils/shell-executor.ts`.

## Why This Design

I kept this fix narrow on purpose.

I did not change model mapping policy. I did not try to redesign Team spawning. I did not change the Codex bridge itself.

The actual pressure point was the nested runtime boundary.

The right fix here is:

- allow model inheritance
- block provider/auth inheritance

That is the smallest structural change that matches the desired behavior.

It preserves the existing CCS mental model for parent sessions, while stopping nested child launches from getting pinned to the wrong provider/auth route.

Anything broader would have made the diff bigger without solving the core failure mode more cleanly.

## User / Developer Impact

### What gets better

- Nested Team/subagent launches from settings-profile Claude sessions can keep the parent's model intent.
- Child agents no longer inherit stale Codex/OpenAI-compatible routing/auth env from the parent process.
- The specific `providers=codex, model=gpt-5-codex-mini` style failure mode should be much less likely in nested launches.
- The settings file remains the source of truth for provider transport, which is where that decision belongs.

### What stays the same

- CCS still supports the existing settings-profile Claude flow.
- Parent sessions can still carry model defaults like `gpt-5.4`, `gpt-5.4-mini`, and related tier mappings.
- Account/default profile launch isolation behavior remains intact.
- This PR does not change upstream request transformation, provider adapters, or model alias normalization.

## Testing

I validated the change at two layers.

### Targeted unit coverage

Ran:

- [x] `bun test tests/unit/utils/claudecode-env-stripping.test.ts`
- [x] `bun test tests/unit/targets/settings-profile-browser-launch.test.ts`

Results:

- `tests/unit/utils/claudecode-env-stripping.test.ts` → `14 pass, 0 fail`
- `tests/unit/targets/settings-profile-browser-launch.test.ts` → `7 pass, 0 fail`

### Push gate / build verification

The feature branch push also passed the repo's fast pre-push verification path, including:

- `tsc --noEmit`
- `eslint src/ --fix`
- `prettier --check src/`
- `bun run ui:build && bun run build:server`

That gave a clean build on the merged branch state before PR creation.

## Checklist

- [x] Base branch is `dev` unless this is an approved hotfix
- [x] Branch name follows `feat/*`, `fix/*`, `docs/*`, or approved hotfix naming
- [x] Relevant `--help` output updated if CLI behavior changed
- [x] Tests added or updated if behavior changed
- [ ] README or local docs updated if user-facing behavior changed
- [x] No secrets, tokens, or private config data are included

## Docs Impact

Docs impact: `minor`

Action: `no update needed`

Reasoning: this PR changes nested runtime behavior and regression coverage, but it does not add a new end-user command surface or config shape. The main value here is correctness at the Team/subagent boundary, not a new user-facing workflow. If maintainers want, a follow-up note in docs about nested model inheritance vs routing inheritance could make sense, but I kept this PR scoped to the bug fix itself.

## Notes for Review

A few things I expect reviewers may care about:

- This PR intentionally preserves nested model inheritance. It does not remove it.
- The selective filter targets routing/auth keys, not model defaults.
- The bug fix spans both the helper layer and the settings-profile launch wiring. That is why there are two tests at different levels.
- This PR does not claim to fully reproduce every Team runtime path in integration. It hardens the exact boundary that was leaking.
- The uncommitted investigation note under `docs/reports/` is intentionally not part of this PR.
