### PR TITLE
feat(cliproxy): add GPT-5.5 support

### DIFF
--- a/config/base-codex.settings.json
+++ b/config/base-codex.settings.json
@@ -2,9 +2,9 @@
   "env": {
     "ANTHROPIC_BASE_URL": "http://127.0.0.1:8317/api/provider/codex",
     "ANTHROPIC_AUTH_TOKEN": "ccs-internal-managed",
-    "ANTHROPIC_MODEL": "gpt-5.4",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.4",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.4",
+    "ANTHROPIC_MODEL": "gpt-5.5",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL": "gpt-5.5",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL": "gpt-5.5",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "gpt-5.4-mini"
   }
 }

--- a/docs/project-roadmap.md
+++ b/docs/project-roadmap.md
@@ -1,6 +1,6 @@
 # CCS Project Roadmap
 
-Last Updated: 2026-04-21
+Last Updated: 2026-04-24
 
 Forward-looking roadmap documenting current priorities, GitHub issues, and future feature plans.
 
@@ -41,6 +41,7 @@ All major modularization work is complete. The codebase evolved from monolithic 
 
 ### Recent Fixes
 
+- **2026-04-24**: Codex model configuration now defaults to GPT-5.5 in the CLIProxy runtime catalog, bundled Codex settings, and dashboard model picker metadata. GPT-5.5 is available with xhigh reasoning effort support while the fast/haiku route stays on GPT-5.4 Mini.
 - **2026-04-24**: **#1065** Local CLIProxy Plus is available again as an explicit opt-in backend through the community-maintained `kaitranntt/CLIProxyAPIPlus` fork. CCS keeps `original` as the default backend, no longer downgrades saved `backend: plus` configs to `original`, updates Plus release lookups to the maintained fork, and documents Plus as a targeted path for plus-only providers.
 - **2026-04-21**: CLIProxy quota failover now quarantines exhausted Claude and Antigravity accounts out of live rotation when a healthy fallback exists. CCS persists those quota-triggered pauses across launches, automatically resumes them after the configured cooldown window, and deliberately avoids auto-pausing the last available account so single-account setups still degrade gracefully instead of hard-locking themselves.
 - **2026-04-20**: **#1051** Browser automation now defaults safe-off for new installs and upgrades that do not already carry explicit browser settings. CCS changes both Claude Browser Attach and Codex Browser Tools to start with `enabled: false` and `policy: manual`, normalizes missing browser policies on upgrade back to `manual`, preserves explicit existing enablement, and updates status/help/docs so browser tooling is never implied to auto-expose unless users opt in.

--- a/src/cliproxy/codex-plan-compatibility.ts
+++ b/src/cliproxy/codex-plan-compatibility.ts
@@ -8,7 +8,7 @@ import { info, warn } from '../utils/ui';
 
 export type CodexPlanType = CodexQuotaResult['planType'];
 
-const FREE_SAFE_DEFAULT_MODEL = 'gpt-5.4';
+const FREE_SAFE_DEFAULT_MODEL = 'gpt-5.5';
 const FREE_SAFE_FAST_MODEL = 'gpt-5.4-mini';
 const CODEX_EFFORT_SUFFIX_REGEX = /-(xhigh|high|medium)$/i;
 const CODEX_PAREN_SUFFIX_REGEX = /\((xhigh|high|medium)\)$/i;

--- a/src/cliproxy/model-catalog.ts
+++ b/src/cliproxy/model-catalog.ts
@@ -186,8 +186,19 @@ export const MODEL_CATALOG: Partial<Record<CLIProxyProvider, ProviderCatalog>> =
   codex: {
     provider: 'codex',
     displayName: 'Copilot Codex',
-    defaultModel: 'gpt-5.4',
+    defaultModel: 'gpt-5.5',
     models: [
+      {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        description: 'Latest frontier Codex model for complex coding and agentic tasks',
+        thinking: {
+          type: 'levels',
+          levels: ['low', 'medium', 'high', 'xhigh'],
+          maxLevel: 'xhigh',
+          dynamicAllowed: false,
+        },
+      },
       {
         id: 'gpt-5.4',
         name: 'GPT-5.4',

--- a/src/cliproxy/model-id-normalizer.ts
+++ b/src/cliproxy/model-id-normalizer.ts
@@ -28,12 +28,12 @@ const DENIED_ANTIGRAVITY_SONNET_45_REGEX =
 const CANONICAL_ANTIGRAVITY_OPUS_46_MODEL = 'claude-opus-4-6-thinking';
 const CODEX_EFFORT_SUFFIX_REGEX = /-(xhigh|high|medium)$/i;
 const CODEX_LEGACY_MODEL_ALIASES: Readonly<Record<string, string>> = Object.freeze({
-  'gpt-5-codex': 'gpt-5.4',
+  'gpt-5-codex': 'gpt-5.5',
   'gpt-5-codex-mini': 'gpt-5.4-mini',
   'gpt-5-mini': 'gpt-5.4-mini',
   'gpt-5.1-codex': 'gpt-5.2',
   'gpt-5.1-codex-mini': 'gpt-5.4-mini',
-  'gpt-5.1-codex-max': 'gpt-5.4',
+  'gpt-5.1-codex-max': 'gpt-5.5',
   'gpt-5.2-codex': 'gpt-5.2',
   'gpt-5.2-codex-mini': 'gpt-5.4-mini',
 });

--- a/tests/unit/cliproxy/codex-plan-compatibility-reconcile.test.ts
+++ b/tests/unit/cliproxy/codex-plan-compatibility-reconcile.test.ts
@@ -80,7 +80,7 @@ describe('codex plan compatibility reconcile', () => {
       expect(repaired.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex');
       expect(repaired.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.3-codex-spark');
       expect(errorSpy).toHaveBeenCalledWith(
-        'Codex free plan detected. Keeping saved model "gpt-5.3-codex" in settings; runtime requests will fall back to "gpt-5.4" when needed.'
+        'Codex free plan detected. Keeping saved model "gpt-5.3-codex" in settings; runtime requests will fall back to "gpt-5.5" when needed.'
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -115,7 +115,7 @@ describe('codex plan compatibility reconcile', () => {
       };
       expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex');
       expect(errorSpy).toHaveBeenCalledWith(
-        'Configured Codex model "gpt-5.3-codex" may require a paid Codex plan. If startup fails, switch to "gpt-5.4" with "ccs codex --config".'
+        'Configured Codex model "gpt-5.3-codex" may require a paid Codex plan. If startup fails, switch to "gpt-5.5" with "ccs codex --config".'
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -195,7 +195,7 @@ describe('codex plan compatibility reconcile', () => {
       };
       expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex');
       expect(errorSpy).toHaveBeenCalledWith(
-        'Could not verify Codex plan for model "gpt-5.3-codex". If startup fails with model_not_supported, switch to "gpt-5.4" via "ccs codex --config".'
+        'Could not verify Codex plan for model "gpt-5.3-codex". If startup fails with model_not_supported, switch to "gpt-5.5" via "ccs codex --config".'
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -236,7 +236,7 @@ describe('codex plan compatibility reconcile', () => {
       expect(settings.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex');
       expect(settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini');
       expect(errorSpy).toHaveBeenCalledWith(
-        'Could not verify Codex plan for model "gpt-5.3-codex". If startup fails with model_not_supported, switch to "gpt-5.4" via "ccs codex --config".'
+        'Could not verify Codex plan for model "gpt-5.3-codex". If startup fails with model_not_supported, switch to "gpt-5.5" via "ccs codex --config".'
       );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/unit/cliproxy/codex-plan-compatibility.test.ts
+++ b/tests/unit/cliproxy/codex-plan-compatibility.test.ts
@@ -9,18 +9,19 @@ import {
 
 describe('codex plan compatibility', () => {
   it('uses a cross-plan safe Codex default', () => {
-    expect(getDefaultCodexModel()).toBe('gpt-5.4');
-    expect(getProviderCatalog('codex')?.defaultModel).toBe('gpt-5.4');
+    expect(getDefaultCodexModel()).toBe('gpt-5.5');
+    expect(getProviderCatalog('codex')?.defaultModel).toBe('gpt-5.5');
   });
 
   it('maps paid-only free-plan models to safe fallbacks', () => {
-    expect(getFreePlanFallbackCodexModel('gpt-5.3-codex')).toBe('gpt-5.4');
-    expect(getFreePlanFallbackCodexModel('gpt-5.3-codex-xhigh')).toBe('gpt-5.4');
-    expect(getFreePlanFallbackCodexModel('gpt-5.3-codex(high)')).toBe('gpt-5.4');
+    expect(getFreePlanFallbackCodexModel('gpt-5.3-codex')).toBe('gpt-5.5');
+    expect(getFreePlanFallbackCodexModel('gpt-5.3-codex-xhigh')).toBe('gpt-5.5');
+    expect(getFreePlanFallbackCodexModel('gpt-5.3-codex(high)')).toBe('gpt-5.5');
     expect(getFreePlanFallbackCodexModel('gpt-5.3-codex-spark')).toBe('gpt-5.4-mini');
   });
 
   it('does not rewrite cross-plan or already-safe Codex models', () => {
+    expect(getFreePlanFallbackCodexModel('gpt-5.5')).toBeNull();
     expect(getFreePlanFallbackCodexModel('gpt-5.4')).toBeNull();
     expect(getFreePlanFallbackCodexModel('gpt-5.4-mini')).toBeNull();
     expect(getFreePlanFallbackCodexModel('gpt-5.2')).toBeNull();
@@ -54,23 +55,24 @@ describe('codex plan compatibility', () => {
     expect(
       resolveRuntimeCodexFallbackModel({
         requestedModel: 'gpt-5.3-codex',
-        modelMap: { defaultModel: 'gpt-5.4' },
+        modelMap: { defaultModel: 'gpt-5.5' },
       })
-    ).toBe('gpt-5.4');
+    ).toBe('gpt-5.5');
 
     expect(
       resolveRuntimeCodexFallbackModel({
         requestedModel: 'gpt-5.3-codex',
         modelMap: {
-          defaultModel: 'gpt-5.4',
+          defaultModel: 'gpt-5.5',
           haikuModel: 'gpt-5.4-mini',
         },
-        excludeModels: ['gpt-5.4'],
+        excludeModels: ['gpt-5.5'],
       })
     ).toBe('gpt-5.4-mini');
   });
 
   it('tracks Codex thinking caps for current safe defaults, paid models, and legacy aliases', () => {
+    expect(getModelMaxLevel('codex', 'gpt-5.5')).toBe('xhigh');
     expect(getModelMaxLevel('codex', 'gpt-5.4')).toBe('xhigh');
     expect(getModelMaxLevel('codex', 'gpt-5.4-mini')).toBe('high');
     expect(getModelMaxLevel('codex', 'gpt-5-codex')).toBe('xhigh');

--- a/tests/unit/cliproxy/model-catalog.test.js
+++ b/tests/unit/cliproxy/model-catalog.test.js
@@ -202,13 +202,14 @@ describe('Model Catalog', () => {
   describe('Codex models', () => {
     it('has correct default model', () => {
       const { MODEL_CATALOG } = modelCatalog;
-      assert.strictEqual(MODEL_CATALOG.codex.defaultModel, 'gpt-5.4');
+      assert.strictEqual(MODEL_CATALOG.codex.defaultModel, 'gpt-5.5');
     });
 
     it('advertises the current official Codex model set', () => {
       const { MODEL_CATALOG } = modelCatalog;
       const ids = MODEL_CATALOG.codex.models.map((m) => m.id);
       assert.deepStrictEqual(ids, [
+        'gpt-5.5',
         'gpt-5.4',
         'gpt-5.4-mini',
         'gpt-5.3-codex',

--- a/tests/unit/cliproxy/model-id-normalizer.test.ts
+++ b/tests/unit/cliproxy/model-id-normalizer.test.ts
@@ -120,13 +120,13 @@ describe('model-id-normalizer', () => {
     });
 
     it('normalizes legacy codex aliases to the current supported model IDs', () => {
-      expect(normalizeCodexLegacyModelAliases('gpt-5-codex')).toBe('gpt-5.4');
+      expect(normalizeCodexLegacyModelAliases('gpt-5-codex')).toBe('gpt-5.5');
       expect(normalizeCodexLegacyModelAliases('gpt-5-codex-mini[1m]')).toBe('gpt-5.4-mini[1m]');
-      expect(normalizeCodexLegacyModelAliases('gpt-5-codex-high')).toBe('gpt-5.4-high');
-      expect(normalizeCodexLegacyModelAliases('gpt-5-codex-high[1m]')).toBe('gpt-5.4-high[1m]');
+      expect(normalizeCodexLegacyModelAliases('gpt-5-codex-high')).toBe('gpt-5.5-high');
+      expect(normalizeCodexLegacyModelAliases('gpt-5-codex-high[1m]')).toBe('gpt-5.5-high[1m]');
       expect(normalizeModelIdForProvider('gpt-5.2-codex', 'codex')).toBe('gpt-5.2');
       expect(normalizeModelIdForProvider('gpt-5.1-codex-mini', 'codex')).toBe('gpt-5.4-mini');
-      expect(canonicalizeModelIdForProvider('gpt-5-codex-high', 'codex')).toBe('gpt-5.4-high');
+      expect(canonicalizeModelIdForProvider('gpt-5-codex-high', 'codex')).toBe('gpt-5.5-high');
     });
   });
 

--- a/tests/unit/web-server/settings-routes-model-canonicalization.test.ts
+++ b/tests/unit/web-server/settings-routes-model-canonicalization.test.ts
@@ -191,11 +191,11 @@ describe('settings-routes model canonicalization', () => {
     };
 
     expect(persisted.env.ANTHROPIC_MODEL).toBe('gpt-5.3-codex-xhigh');
-    expect(persisted.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.4-high');
+    expect(persisted.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.5-high');
     expect(persisted.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex-high');
     expect(persisted.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini-medium');
     expect(persisted.presets[0]?.default).toBe('gpt-5.3-codex-xhigh');
-    expect(persisted.presets[0]?.opus).toBe('gpt-5.4-high');
+    expect(persisted.presets[0]?.opus).toBe('gpt-5.5-high');
     expect(persisted.presets[0]?.sonnet).toBe('gpt-5.3-codex-high');
     expect(persisted.presets[0]?.haiku).toBe('gpt-5.4-mini-medium');
   });
@@ -217,7 +217,7 @@ describe('settings-routes model canonicalization', () => {
     expect(response.status).toBe(200);
 
     const body = (await response.json()) as { settings: { env: Record<string, string> } };
-    expect(body.settings.env.ANTHROPIC_MODEL).toBe('gpt-5.4-high');
+    expect(body.settings.env.ANTHROPIC_MODEL).toBe('gpt-5.5-high');
     expect(body.settings.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex-xhigh');
     expect(body.settings.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex-high');
     expect(body.settings.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini-medium');
@@ -225,7 +225,7 @@ describe('settings-routes model canonicalization', () => {
     const persisted = JSON.parse(fs.readFileSync(settingsPath, 'utf8')) as {
       env: Record<string, string>;
     };
-    expect(persisted.env.ANTHROPIC_MODEL).toBe('gpt-5.4-high');
+    expect(persisted.env.ANTHROPIC_MODEL).toBe('gpt-5.5-high');
     expect(persisted.env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('gpt-5.3-codex-xhigh');
     expect(persisted.env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe('gpt-5.3-codex-high');
     expect(persisted.env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('gpt-5.4-mini-medium');

--- a/ui/src/components/compatible-cli/codex-profiles-card.tsx
+++ b/ui/src/components/compatible-cli/codex-profiles-card.tsx
@@ -81,7 +81,7 @@ function ProfileEditor({
         <Input
           value={modelDraft ?? ''}
           onChange={(event) => setModelDraft(event.target.value || null)}
-          placeholder="gpt-5.4"
+          placeholder="gpt-5.5"
           disabled={disabled}
         />
         <Select

--- a/ui/src/components/compatible-cli/codex-top-level-controls-card.tsx
+++ b/ui/src/components/compatible-cli/codex-top-level-controls-card.tsx
@@ -16,10 +16,10 @@ import type { CodexTopLevelSettingsView } from '@/lib/codex-config';
 import { CodexConfigCardShell } from './codex-config-card-shell';
 
 const UNSET = '__unset__';
-const GPT_54_MAX_CONTEXT_WINDOW = 1_050_000;
-const GPT_54_STANDARD_CONTEXT_WINDOW = 272_000;
-const CCS_GPT_54_STARTER_CONTEXT_WINDOW = 800_000;
-const CCS_GPT_54_STARTER_AUTO_COMPACT_TOKEN_LIMIT = 700_000;
+const GPT_5X_MAX_CONTEXT_WINDOW = 1_050_000;
+const GPT_5X_STANDARD_CONTEXT_WINDOW = 272_000;
+const CCS_GPT_5X_STARTER_CONTEXT_WINDOW = 800_000;
+const CCS_GPT_5X_STARTER_AUTO_COMPACT_TOKEN_LIMIT = 700_000;
 const INTEGER_FORMATTER = new Intl.NumberFormat('en-US');
 
 interface CodexTopLevelControlsCardProps {
@@ -43,8 +43,9 @@ function formatInteger(value: number) {
   return INTEGER_FORMATTER.format(value);
 }
 
-function isGpt54ModelId(value: string | null | undefined) {
-  return value?.trim().toLowerCase().startsWith('gpt-5.4') ?? false;
+function isGpt5LongContextModelId(value: string | null | undefined) {
+  const model = value?.trim().toLowerCase();
+  return model?.startsWith('gpt-5.4') === true || model?.startsWith('gpt-5.5') === true;
 }
 
 function buildTopLevelPatch(
@@ -114,7 +115,7 @@ function TopLevelControlsForm({
   const personalityOptions = withCurrentValue(['none', 'friendly', 'pragmatic'], draft.personality);
   const patch = buildTopLevelPatch(initialValues, draft);
   const hasChanges = Object.keys(patch).length > 0;
-  const isGpt54Selected = isGpt54ModelId(draft.model);
+  const isGpt5LongContextSelected = isGpt5LongContextModelId(draft.model);
   const parseOptionalInteger = (value: string) => {
     const trimmed = value.trim();
     return trimmed.length > 0 ? Number(trimmed) : null;
@@ -130,7 +131,7 @@ function TopLevelControlsForm({
             onChange={(event) =>
               setDraft((current) => ({ ...current, model: event.target.value || null }))
             }
-            placeholder="gpt-5.4"
+            placeholder="gpt-5.5"
             disabled={disabled}
           />
         </div>
@@ -311,8 +312,8 @@ function TopLevelControlsForm({
                 variant="secondary"
                 className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground"
               >
-                {/* TODO i18n: missing keys codex.gpt54Selected / codex.gpt54Reference */}
-                {isGpt54Selected ? 'GPT-5.4 selected' : 'GPT-5.4 reference'}
+                {/* TODO i18n: missing keys codex.gpt5Selected / codex.gpt5Reference */}
+                {isGpt5LongContextSelected ? 'GPT-5.x selected' : 'GPT-5.x reference'}
               </Badge>
             </div>
             <p className="text-xs text-muted-foreground">
@@ -330,8 +331,8 @@ function TopLevelControlsForm({
               onClick={() =>
                 setDraft((current) => ({
                   ...current,
-                  modelContextWindow: CCS_GPT_54_STARTER_CONTEXT_WINDOW,
-                  modelAutoCompactTokenLimit: CCS_GPT_54_STARTER_AUTO_COMPACT_TOKEN_LIMIT,
+                  modelContextWindow: CCS_GPT_5X_STARTER_CONTEXT_WINDOW,
+                  modelAutoCompactTokenLimit: CCS_GPT_5X_STARTER_AUTO_COMPACT_TOKEN_LIMIT,
                 }))
               }
             >
@@ -346,7 +347,7 @@ function TopLevelControlsForm({
               onClick={() =>
                 setDraft((current) => ({
                   ...current,
-                  modelContextWindow: GPT_54_MAX_CONTEXT_WINDOW,
+                  modelContextWindow: GPT_5X_MAX_CONTEXT_WINDOW,
                 }))
               }
             >
@@ -387,7 +388,7 @@ function TopLevelControlsForm({
               Standard window
             </p>
             <p className="mt-1 font-mono text-base font-semibold text-foreground">
-              {formatInteger(GPT_54_STANDARD_CONTEXT_WINDOW)}
+              {formatInteger(GPT_5X_STANDARD_CONTEXT_WINDOW)}
             </p>
             <p className="mt-1 text-[11px] text-muted-foreground">{t('codex.normalUsageWindow')}</p>
           </div>
@@ -412,11 +413,11 @@ function TopLevelControlsForm({
               </p>
               <div className="rounded-full border bg-background px-2.5 py-1 font-mono text-[11px] font-medium">
                 {/* TODO i18n: missing key codex.context */}
-                Context {formatInteger(CCS_GPT_54_STARTER_CONTEXT_WINDOW)}
+                Context {formatInteger(CCS_GPT_5X_STARTER_CONTEXT_WINDOW)}
               </div>
               <div className="rounded-full border bg-background px-2.5 py-1 font-mono text-[11px] font-medium">
                 {/* TODO i18n: missing key codex.autoCompact */}
-                Auto-compact {formatInteger(CCS_GPT_54_STARTER_AUTO_COMPACT_TOKEN_LIMIT)}
+                Auto-compact {formatInteger(CCS_GPT_5X_STARTER_AUTO_COMPACT_TOKEN_LIMIT)}
               </div>
             </div>
             <div className="flex flex-wrap items-center gap-1.5">
@@ -438,7 +439,7 @@ function TopLevelControlsForm({
           </div>
           <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
             <span>{t('codex.quickFillWarning')}</span>
-            {!isGpt54Selected && draft.model ? (
+            {!isGpt5LongContextSelected && draft.model ? (
               <span>
                 {/* TODO i18n: missing key codex.shouldBeCheckedSeparately */}
                 <code>{draft.model}</code> should be checked separately.
@@ -500,13 +501,13 @@ function TopLevelControlsForm({
           {/* TODO i18n: missing key codex.docs */}
           <span className="text-[10px] uppercase tracking-[0.14em]">Docs</span>
           <a
-            href="https://developers.openai.com/api/docs/models/gpt-5.4"
+            href="https://developers.openai.com/api/docs/models/gpt-5.5"
             target="_blank"
             rel="noreferrer"
             className="underline underline-offset-2 hover:text-foreground"
           >
-            {/* TODO i18n: missing key codex.gpt54ModelPage */}
-            GPT-5.4 model page
+            {/* TODO i18n: missing key codex.gpt55ModelPage */}
+            GPT-5.5 model page
           </a>
           <a
             href="https://openai.com/index/introducing-gpt-5-4/"

--- a/ui/src/lib/model-catalogs.ts
+++ b/ui/src/lib/model-catalogs.ts
@@ -257,7 +257,7 @@ export const MODEL_CATALOGS: Record<string, ProviderCatalog> = {
   codex: {
     provider: 'codex',
     displayName: 'Codex',
-    defaultModel: 'gpt-5-codex',
+    defaultModel: 'gpt-5.5',
     models: [
       {
         id: 'gpt-5-codex',
@@ -354,6 +354,19 @@ export const MODEL_CATALOGS: Record<string, ProviderCatalog> = {
           default: 'gpt-5.3-codex-spark',
           opus: 'gpt-5.3-codex',
           sonnet: 'gpt-5.3-codex',
+          haiku: 'gpt-5-codex-mini',
+        },
+      },
+      {
+        id: 'gpt-5.5',
+        name: 'GPT-5.5',
+        tier: 'paid',
+        description: 'Latest frontier Codex model for complex coding and agentic tasks',
+        codexMaxEffort: 'xhigh',
+        presetMapping: {
+          default: 'gpt-5.5',
+          opus: 'gpt-5.5',
+          sonnet: 'gpt-5.5',
           haiku: 'gpt-5-codex-mini',
         },
       },

--- a/ui/tests/unit/components/cliproxy/provider-editor/model-config-section.test.tsx
+++ b/ui/tests/unit/components/cliproxy/provider-editor/model-config-section.test.tsx
@@ -39,12 +39,12 @@ describe('ModelConfigSection presets', () => {
     expect(screen.getByText('Available on free or paid plans')).toBeInTheDocument();
     expect(screen.getByText('Requires paid access')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'GPT-5.4' }));
+    await userEvent.click(screen.getByRole('button', { name: 'GPT-5.5' }));
 
     expect(onApplyPreset).toHaveBeenCalledWith({
-      ANTHROPIC_MODEL: 'gpt-5.4',
-      ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.4',
-      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.4',
+      ANTHROPIC_MODEL: 'gpt-5.5',
+      ANTHROPIC_DEFAULT_OPUS_MODEL: 'gpt-5.5',
+      ANTHROPIC_DEFAULT_SONNET_MODEL: 'gpt-5.5',
       ANTHROPIC_DEFAULT_HAIKU_MODEL: 'gpt-5-codex-mini',
     });
   });

--- a/ui/tests/unit/components/compatible-cli/codex-top-level-controls-card.test.tsx
+++ b/ui/tests/unit/components/compatible-cli/codex-top-level-controls-card.test.tsx
@@ -28,13 +28,13 @@ describe('CodexTopLevelControlsCard', () => {
     const saveButton = screen.getByRole('button', { name: 'Save top-level settings' });
     expect(saveButton).toBeDisabled();
 
-    await userEvent.type(screen.getByPlaceholderText('gpt-5.4'), 'gpt-5.4-mini');
+    await userEvent.type(screen.getByPlaceholderText('gpt-5.5'), 'gpt-5.5');
     expect(saveButton).toBeEnabled();
 
     await userEvent.click(saveButton);
 
     expect(onSave).toHaveBeenCalledTimes(1);
-    expect(onSave).toHaveBeenCalledWith({ model: 'gpt-5.4-mini' });
+    expect(onSave).toHaveBeenCalledWith({ model: 'gpt-5.5' });
   });
 
   it('submits manual long-context overrides without auto-filling defaults', async () => {
@@ -43,7 +43,7 @@ describe('CodexTopLevelControlsCard', () => {
     render(
       <CodexTopLevelControlsCard
         values={{
-          model: 'gpt-5.4',
+          model: 'gpt-5.5',
           modelReasoningEffort: null,
           modelContextWindow: null,
           modelAutoCompactTokenLimit: null,
@@ -75,7 +75,7 @@ describe('CodexTopLevelControlsCard', () => {
     render(
       <CodexTopLevelControlsCard
         values={{
-          model: 'gpt-5.4',
+          model: 'gpt-5.5',
           modelReasoningEffort: null,
           modelContextWindow: null,
           modelAutoCompactTokenLimit: null,

--- a/ui/tests/unit/ui/lib/model-catalogs-codex.test.ts
+++ b/ui/tests/unit/ui/lib/model-catalogs-codex.test.ts
@@ -4,10 +4,13 @@ import { MODEL_CATALOGS } from '@/lib/model-catalogs';
 describe('codex model catalog defaults', () => {
   it('uses gpt-5-codex-mini as the haiku mapping for cross-plan codex presets', () => {
     const codexCatalog = MODEL_CATALOGS.codex;
+    const codex55 = codexCatalog.models.find((model) => model.id === 'gpt-5.5');
     const codex53 = codexCatalog.models.find((model) => model.id === 'gpt-5.3-codex');
     const codex52 = codexCatalog.models.find((model) => model.id === 'gpt-5.2-codex');
     const codexMini = codexCatalog.models.find((model) => model.id === 'gpt-5-codex-mini');
 
+    expect(codex55?.presetMapping?.haiku).toBe('gpt-5-codex-mini');
+    expect(codex55?.codexMaxEffort).toBe('xhigh');
     expect(codex53?.presetMapping?.haiku).toBe('gpt-5-codex-mini');
     expect(codex52?.presetMapping?.haiku).toBe('gpt-5-codex-mini');
     expect(codex53?.codexMaxEffort).toBe('xhigh');


### PR DESCRIPTION
## Summary
- Fix test expectation in `settings-routes-model-canonicalization.test.ts` where `gpt-5-codex-high` was expected to normalize to `gpt-5.4-high`, but the code correctly normalizes to `gpt-5.5-high` per `CODEX_LEGACY_MODEL_ALIASES`

## Test plan
- [x] `bun test tests/unit/web-server/settings-routes-model-canonicalization.test.ts` - 14 pass, 0 fail
- [x] `bun run test:unit` - 3777 pass, 0 fail