### PR TITLE
fix(codex): resolve ccsxp argv alias as codex

### DIFF
--- a/src/targets/target-metadata.ts
+++ b/src/targets/target-metadata.ts
@@ -21,7 +21,7 @@ export const TARGET_METADATA: Record<TargetType, TargetMetadata> = {
   },
   codex: {
     displayName: 'Codex CLI',
-    runtimeAliases: ['ccs-codex', 'ccsx'],
+    runtimeAliases: ['ccs-codex', 'ccsx', 'ccsxp'],
     legacyAliasEnvVar: 'CCS_CODEX_ALIASES',
     persistedTarget: false,
   },

--- a/tests/unit/targets/ccsd-alias-integration.test.ts
+++ b/tests/unit/targets/ccsd-alias-integration.test.ts
@@ -89,17 +89,28 @@ describe('ccsd alias integration', () => {
     expect(path.basename(argvPath)).toBe('ccsx');
   });
 
+  it('should preserve ccsxp symlink basename in argv[1] under node', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const argvPath = probeArgvPath('ccsxp');
+    expect(path.basename(argvPath)).toBe('ccsxp');
+  });
+
   it('should preserve extension-style alias basenames for wrapper compatibility', () => {
     const cmdArgvPath = probeArgvPathDirect('ccsd.cmd');
     const ps1ArgvPath = probeArgvPathDirect('ccsd.ps1');
     const explicitCmdArgvPath = probeArgvPathDirect('ccs-droid.cmd');
     const codexCmdArgvPath = probeArgvPathDirect('ccs-codex.cmd');
     const codexShortCmdArgvPath = probeArgvPathDirect('ccsx.cmd');
+    const codexProxyCmdArgvPath = probeArgvPathDirect('ccsxp.cmd');
 
     expect(path.basename(cmdArgvPath)).toBe('ccsd.cmd');
     expect(path.basename(ps1ArgvPath)).toBe('ccsd.ps1');
     expect(path.basename(explicitCmdArgvPath)).toBe('ccs-droid.cmd');
     expect(path.basename(codexCmdArgvPath)).toBe('ccs-codex.cmd');
     expect(path.basename(codexShortCmdArgvPath)).toBe('ccsx.cmd');
+    expect(path.basename(codexProxyCmdArgvPath)).toBe('ccsxp.cmd');
   });
 });

--- a/tests/unit/targets/target-resolver.test.ts
+++ b/tests/unit/targets/target-resolver.test.ts
@@ -98,6 +98,11 @@ describe('resolveTargetType', () => {
     expect(resolveTargetType([])).toBe('codex');
   });
 
+  it('should detect built-in ccsxp argv[0] alias', () => {
+    process.argv = ['node', 'ccsxp'];
+    expect(resolveTargetType([])).toBe('codex');
+  });
+
   it('should detect custom target aliases from CCS_TARGET_ALIASES', () => {
     process.env.CCS_TARGET_ALIASES = 'droid=droidx,my-droid';
     process.argv = ['node', 'my-droid'];
@@ -271,6 +276,9 @@ describe('resolveTargetType', () => {
     expect(resolveTargetType([])).toBe('codex');
 
     process.argv = ['node', 'ccsx'];
+    expect(resolveTargetType([])).toBe('codex');
+
+    process.argv = ['node', 'ccsxp'];
     expect(resolveTargetType([])).toBe('codex');
 
     process.argv = ['node', 'mydroid'];


### PR DESCRIPTION
## Summary

- register `ccsxp` as a built-in Codex argv alias
- cover the real `ccsxp` alias path in resolver tests
- cover `ccsxp` symlink basename preservation in the Node argv integration test

## Root Cause

The published `ccsxp` bin existed, but `ccsxp` was missing from the built-in Codex `argv[0]` alias map. Real bin execution could therefore fall back to the default Claude target, which then rejected the wrapper-injected Codex `--config` flag.

## Validation

- `bun test tests/unit/targets/target-resolver.test.ts tests/unit/targets/ccsd-alias-integration.test.ts`
- `bun run typecheck`
- `bun run build`
- fast pre-push gate

Closes #1107
