### PR TITLE
fix(cliproxy): probe routing via management endpoint

### DIFF
--- a/src/cliproxy/management-api-client.ts
+++ b/src/cliproxy/management-api-client.ts
@@ -20,6 +20,7 @@ import type { CliproxyRoutingStrategy } from './types';
 
 /** Default timeout for management operations (longer than health check) */
 const DEFAULT_TIMEOUT_MS = 5000;
+const ROUTING_STRATEGY_PATH = '/v0/management/routing/strategy';
 
 /** Default port for HTTPS protocol */
 const DEFAULT_HTTPS_PORT = 443;
@@ -232,7 +233,7 @@ export class ManagementApiClient {
    * Get the global credential routing strategy from CLIProxy.
    */
   async getRoutingStrategy(): Promise<CliproxyRoutingStrategy> {
-    const response = await this.request<{ strategy?: string }>('GET', '/routing/strategy');
+    const response = await this.request<{ strategy?: string }>('GET', ROUTING_STRATEGY_PATH);
     return response.data?.strategy === 'fill-first' ? 'fill-first' : 'round-robin';
   }
 
@@ -240,7 +241,7 @@ export class ManagementApiClient {
    * Update the global credential routing strategy on CLIProxy.
    */
   async putRoutingStrategy(strategy: CliproxyRoutingStrategy): Promise<CliproxyRoutingStrategy> {
-    await this.request('PUT', '/routing/strategy', { value: strategy });
+    await this.request('PUT', ROUTING_STRATEGY_PATH, { value: strategy });
     return strategy;
   }
 

--- a/src/cliproxy/routing-strategy-http.ts
+++ b/src/cliproxy/routing-strategy-http.ts
@@ -9,12 +9,16 @@ import {
 const ROUTING_TIMEOUT_MS = 5000;
 const CLIPROXY_ROUTING_MANAGEMENT_PATH = '/v0/management/routing/strategy';
 
+export function getCliproxyRoutingManagementUrl(target: ProxyTarget): string {
+  return buildProxyUrl(target, CLIPROXY_ROUTING_MANAGEMENT_PATH);
+}
+
 export async function fetchCliproxyRoutingResponse(
   target: ProxyTarget,
   method: 'GET' | 'PUT',
   body?: Record<string, string>
 ): Promise<Response> {
-  const url = buildProxyUrl(target, CLIPROXY_ROUTING_MANAGEMENT_PATH);
+  const url = getCliproxyRoutingManagementUrl(target);
   const headers = buildManagementHeaders(
     target,
     body ? { 'Content-Type': 'application/json' } : {}

--- a/src/cliproxy/routing-strategy-http.ts
+++ b/src/cliproxy/routing-strategy-http.ts
@@ -7,13 +7,14 @@ import {
 } from './proxy-target-resolver';
 
 const ROUTING_TIMEOUT_MS = 5000;
+const CLIPROXY_ROUTING_MANAGEMENT_PATH = '/v0/management/routing/strategy';
 
 export async function fetchCliproxyRoutingResponse(
   target: ProxyTarget,
   method: 'GET' | 'PUT',
   body?: Record<string, string>
 ): Promise<Response> {
-  const url = buildProxyUrl(target, '/routing/strategy');
+  const url = buildProxyUrl(target, CLIPROXY_ROUTING_MANAGEMENT_PATH);
   const headers = buildManagementHeaders(
     target,
     body ? { 'Content-Type': 'application/json' } : {}

--- a/tests/unit/cliproxy/management-api-client.test.ts
+++ b/tests/unit/cliproxy/management-api-client.test.ts
@@ -128,7 +128,7 @@ describe('management-api-client', () => {
 
         expect(strategy).toBe('round-robin');
         expect(fetchMock).toHaveBeenCalledWith(
-          'http://localhost:8317/routing/strategy',
+          'http://localhost:8317/v0/management/routing/strategy',
           expect.objectContaining({
             method: 'PUT',
             body: JSON.stringify({ value: 'round-robin' }),

--- a/tests/unit/cliproxy/routing-strategy-http.test.ts
+++ b/tests/unit/cliproxy/routing-strategy-http.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { fetchCliproxyRoutingResponse } from '../../../src/cliproxy/routing-strategy-http';
+import type { ProxyTarget } from '../../../src/cliproxy/proxy-target-resolver';
+
+describe('routing-strategy-http', () => {
+  const target: ProxyTarget = {
+    host: '127.0.0.1',
+    port: 8317,
+    protocol: 'http',
+    isRemote: false,
+  };
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it('reads the routing strategy from the management endpoint', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ strategy: 'round-robin' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await fetchCliproxyRoutingResponse(target, 'GET');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:8317/v0/management/routing/strategy',
+      expect.objectContaining({
+        method: 'GET',
+      })
+    );
+
+    global.fetch = originalFetch;
+  });
+
+  it('writes the routing strategy to the management endpoint', async () => {
+    const originalFetch = global.fetch;
+    const fetchMock = mock(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    global.fetch = fetchMock as typeof global.fetch;
+
+    await fetchCliproxyRoutingResponse(target, 'PUT', { value: 'fill-first' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:8317/v0/management/routing/strategy',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ value: 'fill-first' }),
+      })
+    );
+
+    global.fetch = originalFetch;
+  });
+});

--- a/tests/unit/cliproxy/routing-strategy-http.test.ts
+++ b/tests/unit/cliproxy/routing-strategy-http.test.ts
@@ -1,65 +1,32 @@
-import { afterEach, describe, expect, it, mock } from 'bun:test';
-import { fetchCliproxyRoutingResponse } from '../../../src/cliproxy/routing-strategy-http';
+import { describe, expect, it } from 'bun:test';
+import { getCliproxyRoutingManagementUrl } from '../../../src/cliproxy/routing-strategy-http';
 import type { ProxyTarget } from '../../../src/cliproxy/proxy-target-resolver';
 
 describe('routing-strategy-http', () => {
-  const target: ProxyTarget = {
-    host: '127.0.0.1',
-    port: 8317,
-    protocol: 'http',
-    isRemote: false,
-  };
+  it('builds the local management URL for routing strategy reads', () => {
+    const target: ProxyTarget = {
+      host: '127.0.0.1',
+      port: 8317,
+      protocol: 'http',
+      isRemote: false,
+    };
 
-  afterEach(() => {
-    mock.restore();
+    expect(getCliproxyRoutingManagementUrl(target)).toBe(
+      'http://127.0.0.1:8317/v0/management/routing/strategy'
+    );
   });
 
-  it('reads the routing strategy from the management endpoint', async () => {
-    const originalFetch = global.fetch;
-    const fetchMock = mock(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ strategy: 'round-robin' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
+  it('builds the remote management URL for routing strategy writes', () => {
+    const target: ProxyTarget = {
+      host: 'proxy.example.com',
+      port: 443,
+      protocol: 'https',
+      allowSelfSigned: true,
+      isRemote: true,
+    };
+
+    expect(getCliproxyRoutingManagementUrl(target)).toBe(
+      'https://proxy.example.com:443/v0/management/routing/strategy'
     );
-    global.fetch = fetchMock as typeof global.fetch;
-
-    await fetchCliproxyRoutingResponse(target, 'GET');
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://127.0.0.1:8317/v0/management/routing/strategy',
-      expect.objectContaining({
-        method: 'GET',
-      })
-    );
-
-    global.fetch = originalFetch;
-  });
-
-  it('writes the routing strategy to the management endpoint', async () => {
-    const originalFetch = global.fetch;
-    const fetchMock = mock(() =>
-      Promise.resolve(
-        new Response(JSON.stringify({ ok: true }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-    );
-    global.fetch = fetchMock as typeof global.fetch;
-
-    await fetchCliproxyRoutingResponse(target, 'PUT', { value: 'fill-first' });
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://127.0.0.1:8317/v0/management/routing/strategy',
-      expect.objectContaining({
-        method: 'PUT',
-        body: JSON.stringify({ value: 'fill-first' }),
-      })
-    );
-
-    global.fetch = originalFetch;
   });
 });


### PR DESCRIPTION
## Summary
- fix local CLIProxy routing reachability probes to use the real management endpoint
- keep the management API client aligned with the same routing strategy path
- add regression coverage for the management routing URL and payload path

## Root Cause
`ccs cliproxy status` showed the local proxy was healthy on `127.0.0.1:8317`, but the routing/session-affinity probe was calling `/routing/strategy`.

CLIProxy exposes this setting on `/v0/management/routing/strategy`, so CCS incorrectly treated a healthy local proxy as unreachable and fell back to the saved startup default.

## Validation
- `bun test tests/unit/cliproxy/routing-strategy-http.test.ts tests/unit/cliproxy/management-api-client.test.ts tests/unit/cliproxy/routing-strategy.test.ts`
- `node scripts/run-test-bucket.js fast`
- `bun run build`
- `node dist/ccs.js cliproxy routing`
- `node dist/ccs.js cliproxy routing affinity`
