### PR TITLE
fix(ci): align release sync with protected dev checks

### DIFF
--- a/.github/workflows/sync-dev-after-release.yml
+++ b/.github/workflows/sync-dev-after-release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sync-dev:
     if: ${{ !github.event.release.prerelease && github.event.release.target_commitish == 'main' && startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-') }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     permissions:
       contents: write
@@ -17,8 +17,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Always use built-in workflow token so PAT rotation never breaks sync jobs.
-          token: ${{ github.token }}
+          # PAT_TOKEN is required because this pushes to protected dev and must
+          # trigger follow-up Push CI / Dev Release workflows.
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -31,7 +32,7 @@ jobs:
           git checkout dev
 
           # Attempt merge, handle version conflicts by taking main's versions
-          if ! git merge origin/main --no-edit -m "chore(sync): merge main into dev after release [skip ci]"; then
+          if ! git merge origin/main --no-edit -m "chore(sync): merge main into dev after release"; then
             echo "Merge conflicts detected, resolving version files..."
 
             # For version files, take main's version (new stable base)

--- a/tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts
+++ b/tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function resolvePath(relativePath: string) {
+  return path.resolve(import.meta.dir, relativePath);
+}
+
+describe('sync dev after release workflow', () => {
+  test('uses protected-branch runner and token settings', () => {
+    const workflowPath = resolvePath('../../../../.github/workflows/sync-dev-after-release.yml');
+
+    expect(fs.existsSync(workflowPath)).toBe(true);
+
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    const checkoutSection = workflow.slice(
+      workflow.indexOf('- name: Checkout'),
+      workflow.indexOf('- name: Configure Git')
+    );
+    const syncSection = workflow.slice(workflow.indexOf('- name: Sync dev with main'));
+
+    expect(workflow).toContain('name: Sync Dev After Main Release');
+    expect(workflow).toContain('runs-on: [self-hosted, linux, x64]');
+    expect(workflow).not.toContain('runs-on: ubuntu-latest');
+    expect(checkoutSection).toContain('token: ${{ secrets.PAT_TOKEN }}');
+    expect(checkoutSection).not.toContain('token: ${{ github.token }}');
+    expect(syncSection).toContain(
+      'git merge origin/main --no-edit -m "chore(sync): merge main into dev after release"'
+    );
+    expect(syncSection).not.toContain('[skip ci]');
+    expect(syncSection).toContain('git push origin dev');
+  });
+});


### PR DESCRIPTION
## Summary
- move sync-after-release job to the self-hosted Linux runner
- use PAT_TOKEN for the protected dev sync push so follow-up workflows can run
- remove `[skip ci]` from the sync merge commit
- add workflow regression coverage

## Validation
- `bun test tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts tests/unit/scripts/github/dev-release-workflow.test.ts`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/sync-dev-after-release.yml .github/workflows/dev-release.yml`
- `bun run validate:ci-parity`
