### PR TITLE
fix(ci): align stable release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
 
     permissions:
       contents: write

--- a/tests/unit/scripts/github/release-workflow.test.ts
+++ b/tests/unit/scripts/github/release-workflow.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+function resolvePath(relativePath: string) {
+  return path.resolve(import.meta.dir, relativePath);
+}
+
+describe('stable release workflow', () => {
+  test('uses the protected-branch runner and release token path', () => {
+    const workflowPath = resolvePath('../../../../.github/workflows/release.yml');
+
+    expect(fs.existsSync(workflowPath)).toBe(true);
+
+    const workflow = fs.readFileSync(workflowPath, 'utf8');
+    const checkoutSection = workflow.slice(
+      workflow.indexOf('- name: Checkout code'),
+      workflow.indexOf('- name: Setup Node.js')
+    );
+    const releaseSection = workflow.slice(
+      workflow.indexOf('- name: Release'),
+      workflow.indexOf('- name: Notify Discord')
+    );
+
+    expect(workflow).toContain('name: Release');
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain('runs-on: [self-hosted, linux, x64]');
+    expect(workflow).not.toContain('runs-on: ubuntu-latest');
+    expect(checkoutSection).toContain('token: ${{ secrets.PAT_TOKEN }}');
+    expect(releaseSection).toContain('GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}');
+    expect(releaseSection).toContain('GH_TOKEN: ${{ secrets.PAT_TOKEN }}');
+    expect(releaseSection).toContain('NPM_TOKEN: ${{ secrets.NPM_TOKEN }}');
+  });
+});


### PR DESCRIPTION
## Summary
- move the stable release workflow to the self-hosted Linux runner
- add regression coverage for the protected main release token path

## Validation
- `bun test tests/unit/scripts/github/release-workflow.test.ts tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts tests/unit/scripts/github/dev-release-workflow.test.ts`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml .github/workflows/sync-dev-after-release.yml .github/workflows/dev-release.yml`
- fast pre-push gate
