### PR TITLE
fix(proxy): stringify tool_result images for OpenAI upstreams

### DIFF
--- a/src/proxy/transformers/request-transformer.ts
+++ b/src/proxy/transformers/request-transformer.ts
@@ -224,8 +224,8 @@ function convertToolResultContent(content: unknown, isError: boolean, label: str
           ? (parsed.source as Record<string, unknown>)
           : undefined;
       const description =
-        source?.type === 'url' && typeof source.url === 'string'
-          ? source.url
+        source?.type === 'url'
+          ? 'url image payload'
           : source?.type === 'base64' && typeof source.media_type === 'string'
             ? `${source.media_type} base64 payload`
             : 'unsupported image payload';

--- a/src/proxy/transformers/request-transformer.ts
+++ b/src/proxy/transformers/request-transformer.ts
@@ -219,7 +219,18 @@ function convertToolResultContent(content: unknown, isError: boolean, label: str
     }
 
     if (parsed.type === 'image') {
-      throw new Error(`${label}[${index}].type "image" is not supported in tool_result content`);
+      const source =
+        typeof parsed.source === 'object' && parsed.source !== null
+          ? (parsed.source as Record<string, unknown>)
+          : undefined;
+      const description =
+        source?.type === 'url' && typeof source.url === 'string'
+          ? source.url
+          : source?.type === 'base64' && typeof source.media_type === 'string'
+            ? `${source.media_type} base64 payload`
+            : 'unsupported image payload';
+      parts.push(`[tool_result image omitted: ${description}]`);
+      continue;
     }
 
     if (typeof parsed.text === 'string') {

--- a/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
@@ -204,7 +204,10 @@ describe('ProxyRequestTransformer regressions', () => {
               tool_use_id: 'toolu_1',
               content: [
                 { type: 'text', text: 'screenshot captured' },
-                { type: 'image', source: { type: 'url', url: 'https://example.com/error.png' } },
+                {
+                  type: 'image',
+                  source: { type: 'url', url: 'https://storage.example.com/error.png?X-Amz-Signature=secret' },
+                },
                 {
                   type: 'image',
                   source: { type: 'base64', media_type: 'image/png', data: 'ZmFrZQ==' },
@@ -222,6 +225,9 @@ describe('ProxyRequestTransformer regressions', () => {
       content:
         'screenshot captured\n[tool_result image omitted: url image payload]\n[tool_result image omitted: image/png base64 payload]',
     });
+    expect(result.messages[1]?.content).not.toContain('https://storage.example.com');
+    expect(result.messages[1]?.content).not.toContain('X-Amz-Signature');
+    expect(result.messages[1]?.content).not.toContain('secret');
   });
 
   it('rejects unsupported assistant blocks instead of silently dropping them', () => {

--- a/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
@@ -220,7 +220,7 @@ describe('ProxyRequestTransformer regressions', () => {
       role: 'tool',
       tool_call_id: 'toolu_1',
       content:
-        'screenshot captured\n[tool_result image omitted: https://example.com/error.png]\n[tool_result image omitted: image/png base64 payload]',
+        'screenshot captured\n[tool_result image omitted: url image payload]\n[tool_result image omitted: image/png base64 payload]',
     });
   });
 

--- a/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
@@ -189,27 +189,39 @@ describe('ProxyRequestTransformer regressions', () => {
     ).toThrow('must start with tool_result blocks for pending tool_use ids');
   });
 
-  it('rejects tool_result content that cannot be represented as OpenAI tool text', () => {
-    expect(() =>
-      new ProxyRequestTransformer().transform({
-        messages: [
-          {
-            role: 'assistant',
-            content: [{ type: 'tool_use', id: 'toolu_1', name: 'vision', input: { detail: 'high' } }],
-          },
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'tool_result',
-                tool_use_id: 'toolu_1',
-                content: [{ type: 'image', source: { type: 'url', url: 'https://example.com/error.png' } }],
-              },
-            ],
-          },
-        ],
-      })
-    ).toThrow('type "image" is not supported in tool_result content');
+  it('converts tool_result image blocks to text placeholders for OpenAI-compatible tool messages', () => {
+    const result = new ProxyRequestTransformer().transform({
+      messages: [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'toolu_1', name: 'vision', input: { detail: 'high' } }],
+        },
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'toolu_1',
+              content: [
+                { type: 'text', text: 'screenshot captured' },
+                { type: 'image', source: { type: 'url', url: 'https://example.com/error.png' } },
+                {
+                  type: 'image',
+                  source: { type: 'base64', media_type: 'image/png', data: 'ZmFrZQ==' },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(result.messages[1]).toEqual({
+      role: 'tool',
+      tool_call_id: 'toolu_1',
+      content:
+        'screenshot captured\n[tool_result image omitted: https://example.com/error.png]\n[tool_result image omitted: image/png base64 payload]',
+    });
   });
 
   it('rejects unsupported assistant blocks instead of silently dropping them', () => {


### PR DESCRIPTION
## Summary
- Convert `image` blocks inside Anthropic `tool_result.content` arrays into textual placeholders for OpenAI-compatible upstream tool messages.
- Keep normal user image blocks translated to OpenAI `image_url` parts.
- Add a regression test covering URL and base64 image blocks inside tool results.

## Motivation
OpenAI-compatible tool messages are text-only. When Claude Code includes an Anthropic image block inside a tool result, forwarding or rejecting that shape can surface provider errors such as:

```text
messages[N].content[0].content[0].type "image" is not supported in tool_result content
```

Stringifying the image as an explicit omitted-image placeholder preserves the transcript flow and avoids sending unsupported nested image content upstream.

## Test Plan
- `bun test tests/unit/proxy/transformers/request-transformer.test.ts tests/unit/proxy/transformers/request-transformer-regressions.test.ts`
- `bun run build`
- pre-push fast gate: `tsc --noEmit`, `eslint src/`, `prettier --check src/`, `node scripts/run-test-bucket.js fast`