### PR TITLE
fix(ci): restore stable release semantic-release invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set +e
-          OUTPUT=$(bunx semantic-release 2>&1)
+          OUTPUT=$(bun x semantic-release 2>&1)
           STATUS=$?
           set -e
           echo "$OUTPUT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaitranntt/ccs",
-  "version": "7.75.0-dev.11",
+  "version": "7.75.0-dev.12",
   "description": "Claude Code Switch - Instant profile switching between Claude, GLM, Kimi, and more",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary
- replace the stable release workflow's `bunx semantic-release` call with `bun x semantic-release`
- fixes the post-merge stable release failure from run `25202782450`
- carries the normal `7.75.0-dev.12` dev-release commit generated after the fix landed on `dev`

## Validation
- local protected-branch parity gate passed before push
- `Push CI` and `Dev Release` both completed successfully on `dev`
