### PR TITLE
feat: support ollama cloud anthropic compatible api

### DIFF
--- a/src/targets/droid-provider.ts
+++ b/src/targets/droid-provider.ts
@@ -77,6 +77,14 @@ export function inferDroidProviderFromBaseUrl(
   }
 
   if (
+    pathname.includes('/compatible-mode') ||
+    pathname.includes('/openai') ||
+    pathname.includes('/chat/completions')
+  ) {
+    return 'generic-chat-completion-api';
+  }
+
+  if (
     host.includes('anthropic.com') ||
     pathname.includes('/anthropic') ||
     host.includes('ollama.com')
@@ -91,10 +99,7 @@ export function inferDroidProviderFromBaseUrl(
     host.includes('api.fireworks.ai') ||
     host.includes('inference.baseten.co') ||
     host.includes('dashscope') ||
-    host.includes('huggingface.co') ||
-    pathname.includes('/compatible-mode') ||
-    pathname.includes('/openai') ||
-    pathname.includes('/chat/completions')
+    host.includes('huggingface.co')
   ) {
     return 'generic-chat-completion-api';
   }

--- a/src/targets/droid-provider.ts
+++ b/src/targets/droid-provider.ts
@@ -88,7 +88,6 @@ export function inferDroidProviderFromBaseUrl(
     host.includes('inference.baseten.co') ||
     host.includes('dashscope') ||
     host.includes('huggingface.co') ||
-    host.includes('ollama.com') ||
     pathname.includes('/compatible-mode') ||
     pathname.includes('/openai') ||
     pathname.includes('/chat/completions')

--- a/src/targets/droid-provider.ts
+++ b/src/targets/droid-provider.ts
@@ -76,7 +76,11 @@ export function inferDroidProviderFromBaseUrl(
     return 'openai';
   }
 
-  if (host.includes('anthropic.com') || pathname.includes('/anthropic')) {
+  if (
+    host.includes('anthropic.com') ||
+    pathname.includes('/anthropic') ||
+    host.includes('ollama.com')
+  ) {
     return 'anthropic';
   }
 

--- a/tests/unit/proxy/profile-router.test.ts
+++ b/tests/unit/proxy/profile-router.test.ts
@@ -50,4 +50,33 @@ describe('resolveOpenAICompatProfileConfig', () => {
     expect(result?.provider).toBe('generic-chat-completion-api');
     expect(result?.model).toBe('qwen3.6-plus');
   });
+
+  it('does not proxy bare ollama.com profiles that are anthropic-native', () => {
+    const result = resolveOpenAICompatProfileConfig(
+      'ollama-cloud',
+      '/tmp/ollama-cloud.settings.json',
+      {
+        ANTHROPIC_BASE_URL: 'https://ollama.com',
+        ANTHROPIC_AUTH_TOKEN: 'ollama-token',
+        ANTHROPIC_MODEL: 'qwen3-coder-plus',
+      }
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('still proxies explicit ollama.com chat-completions endpoints', () => {
+    const result = resolveOpenAICompatProfileConfig(
+      'ollama-cloud-chat-completions',
+      '/tmp/ollama-cloud-chat-completions.settings.json',
+      {
+        ANTHROPIC_BASE_URL: 'https://ollama.com/v1/chat/completions',
+        ANTHROPIC_AUTH_TOKEN: 'ollama-token',
+        ANTHROPIC_MODEL: 'qwen3-coder-plus',
+      }
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.provider).toBe('generic-chat-completion-api');
+  });
 });

--- a/tests/unit/targets/droid-provider.test.ts
+++ b/tests/unit/targets/droid-provider.test.ts
@@ -99,11 +99,5 @@ describe('droid-provider', () => {
       expect(resolveDroidProvider({ baseUrl: 'https://ollama.com' })).toBe('anthropic');
       expect(resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/messages' })).toBe('anthropic');
     });
-
-    it('routes ollama.com /chat/completions to generic openai-compatible', () => {
-      expect(
-        resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/chat/completions' })
-      ).toBe('generic-chat-completion-api');
-    });
   });
 });

--- a/tests/unit/targets/droid-provider.test.ts
+++ b/tests/unit/targets/droid-provider.test.ts
@@ -94,5 +94,16 @@ describe('droid-provider', () => {
       expect(resolveDroidProvider({ baseUrl: 'http://127.0.0.1:8317' })).toBe('anthropic');
       expect(resolveDroidProvider({})).toBe('anthropic');
     });
+
+    it('defaults ollama.com to anthropic', () => {
+      expect(resolveDroidProvider({ baseUrl: 'https://ollama.com' })).toBe('anthropic');
+      expect(resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/messages' })).toBe('anthropic');
+    });
+
+    it('routes ollama.com /chat/completions to generic openai-compatible', () => {
+      expect(
+        resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/chat/completions' })
+      ).toBe('generic-chat-completion-api');
+    });
   });
 });

--- a/tests/unit/targets/droid-provider.test.ts
+++ b/tests/unit/targets/droid-provider.test.ts
@@ -99,5 +99,11 @@ describe('droid-provider', () => {
       expect(resolveDroidProvider({ baseUrl: 'https://ollama.com' })).toBe('anthropic');
       expect(resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/messages' })).toBe('anthropic');
     });
+
+    it('routes ollama.com /chat/completions to generic', () => {
+      expect(
+        resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/chat/completions' })
+      ).toBe('generic-chat-completion-api');
+    });
   });
 });

--- a/tests/unit/targets/droid-provider.test.ts
+++ b/tests/unit/targets/droid-provider.test.ts
@@ -100,10 +100,25 @@ describe('droid-provider', () => {
       expect(resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/messages' })).toBe('anthropic');
     });
 
-    it('routes ollama.com /chat/completions to generic', () => {
+    it('keeps ollama.com anthropic even for generic model families', () => {
       expect(
-        resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/chat/completions' })
-      ).toBe('generic-chat-completion-api');
+        resolveDroidProvider({
+          baseUrl: 'https://ollama.com',
+          model: 'qwen3-coder-plus',
+        })
+      ).toBe('anthropic');
+      expect(
+        resolveDroidProvider({
+          baseUrl: 'https://ollama.com/v1/messages',
+          model: 'deepseek-v3.1',
+        })
+      ).toBe('anthropic');
+    });
+
+    it('routes ollama.com /chat/completions to generic', () => {
+      expect(resolveDroidProvider({ baseUrl: 'https://ollama.com/v1/chat/completions' })).toBe(
+        'generic-chat-completion-api'
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

CCS hardcodes Olama Cloud's `ollama.com` as a `generic-chat-completion-api` (OpenAI-compatible) provider in its URL detection logic. 

This means any API profile using `ANTHROPIC_BASE_URL: https://ollama.com` will always be routed through a local OpenAI→Anthropic translation proxy, even though Ollama Cloud fully supports the Anthropic Messages API natively.

This change adds first-class routing support so CCS treats Ollama Cloud profiles as Anthropic-native by default, instead of forcing them through an unnecessary OpenAI-compatible translation proxy.

## Evidence

Ollama Cloud supports the Anthropic Messages API (`/v1/messages`) natively. Reference:
- https://docs.ollama.com/api/anthropic-compatibility

All models tested return valid Anthropic-format responses directly:

```bash
curl -X POST https://ollama.com/v1/messages \
  -H "Authorization: Bearer <token>" \
  -H "anthropic-version: 2023-06-01" \
  -H "content-type: application/json" \
  -d '{"model":"gemma4:31b-cloud","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}'
# → HTTP 200, valid Anthropic response
```

## Behavior

| URL | Before | After |
|---|---|---|
| `https://ollama.com` | `generic-chat-completion-api` | `anthropic` (natural fallback default) |
| `https://ollama.com/v1/messages` | `generic-chat-completion-api` | `anthropic` |
| `https://ollama.com/v1/chat/completions` | `generic-chat-completion-api` | `generic-chat-completion-api` (pathname match still works) |

Pathname-based generic checks (`/chat/completions`, `/openai`, `/compatible-mode`) now run before host-based anthropic detection, so explicit pathname overrides always win regardless of host.

---

## Testing

Use what applies. If you skipped something, add a short note instead of forcing it.

- [x] `bun run format && bun run lint:fix && bun run validate`
- [x] `bun run validate:ci-parity` before requesting review
- [x] `bun run test:e2e` if this PR touches command routing, proxy flows, or workflow/release logic
- [ ] `cd ui && bun run validate` if UI changed
- [ ] Not run

<details>

<summary>The only test that failed was prettier (pre-existing, unrelated to this PR):</summary>

```diff
diff --git a/src/cliproxy/quota/quota-manager.ts b/src/cliproxy/quota/quota-manager.ts
index f715ee47..5290db92 100644
--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -523,9 +523,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();
diff --git a/src/management/checks/image-analysis-check.ts b/src/management/checks/image-analysis-check.ts
index 85fe7e3a..18fd06a3 100644
--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateUnifiedConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/unified-config-loader'
-  );
+  const { updateUnifiedConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/unified-config-loader');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;
```

</details>


## Checklist

Check what applies. Not every item is relevant for every PR.

- [x] Base branch is `dev` unless this is an approved hotfix
- [x] Branch name follows `feat/*`, `fix/*`, `docs/*`, or approved hotfix naming
- [ ] Relevant `--help` output updated if CLI behavior changed
- [x] Tests added or updated if behavior changed
- [ ] README or local docs updated if user-facing behavior changed
  - [Ollama Cloud Docs page](https://docs.ccs.kaitran.ca/providers/api/ollama) is still accurate, does not need an update.
- [ ] If a check failed, the PR body explains what failed and what changed to fix it
- [ ] No secrets, tokens, or private config data are included

## Docs Impact

Docs impact: none

Action: [Ollama Cloud Docs page](https://docs.ccs.kaitran.ca/providers/api/ollama) is still accurate, does not need an update.