### PR TITLE
fix(ui): surface Claude Opus 4.7 in Claude picker

### DIFF
--- a/ui/src/lib/model-catalogs.ts
+++ b/ui/src/lib/model-catalogs.ts
@@ -629,9 +629,21 @@ export const MODEL_CATALOGS: Record<string, ProviderCatalog> = {
     defaultModel: 'claude-sonnet-4-6',
     models: [
       {
+        id: 'claude-opus-4-7',
+        name: 'Claude Opus 4.7',
+        description: 'Latest flagship model',
+        extendedContext: true,
+        presetMapping: {
+          default: 'claude-opus-4-7',
+          opus: 'claude-opus-4-7',
+          sonnet: 'claude-sonnet-4-6',
+          haiku: 'claude-haiku-4-5-20251001',
+        },
+      },
+      {
         id: 'claude-opus-4-6',
         name: 'Claude Opus 4.6',
-        description: 'Latest flagship model',
+        description: 'Previous flagship model',
         extendedContext: true,
         presetMapping: {
           default: 'claude-opus-4-6',

--- a/ui/tests/unit/components/cliproxy/provider-model-selector.test.tsx
+++ b/ui/tests/unit/components/cliproxy/provider-model-selector.test.tsx
@@ -70,6 +70,24 @@ describe('FlexibleModelSelector', () => {
     expect(screen.queryByText(/All Models \(/i)).not.toBeInTheDocument();
   });
 
+  it('surfaces Claude Opus 4.7 in the curated Claude picker', async () => {
+    render(
+      <FlexibleModelSelector
+        label="Primary model"
+        value={undefined}
+        onChange={vi.fn()}
+        catalog={MODEL_CATALOGS.claude}
+        allModels={[]}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /select model/i }));
+
+    expect(screen.getByRole('option', { name: /claude-opus-4-7/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /claude-opus-4-6/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /claude-sonnet-4-6/i })).toBeInTheDocument();
+  });
+
   it('preserves a filtered legacy value under the current-value fallback group', async () => {
     render(
       <FlexibleModelSelector

--- a/ui/tests/unit/ui/lib/preset-utils.test.ts
+++ b/ui/tests/unit/ui/lib/preset-utils.test.ts
@@ -16,10 +16,11 @@ describe('claude preset utils', () => {
     vi.restoreAllMocks();
   });
 
-  it('keeps the claude catalog default on Sonnet 4.6', () => {
+  it('keeps the claude catalog default on Sonnet 4.6 while exposing Opus 4.7', () => {
     const claudeCatalog = MODEL_CATALOGS.claude;
 
     expect(claudeCatalog.defaultModel).toBe('claude-sonnet-4-6');
+    expect(claudeCatalog.models.map((model) => model.id)).toContain('claude-opus-4-7');
     expect(claudeCatalog.models.map((model) => model.id)).toContain('claude-sonnet-4-6');
   });
 


### PR DESCRIPTION
## Summary

- add `claude-opus-4-7` to the curated Claude UI catalog used by the dashboard picker and preset resolution
- keep the default Claude preset on Sonnet 4.6 while exposing Opus 4.7 as a selectable option
- add UI regression coverage for the Claude picker and catalog path

Closes #1182

## Root Cause

The backend/shared Claude catalog already included `claude-opus-4-7`, but the UI-side static Claude catalog still stopped at 4.6. The dashboard's curated/resolved picker flow depends on that stale UI catalog, so the option never appeared.

## Validation

- [x] `cd ui && bun run test:run tests/unit/ui/lib/preset-utils.test.ts tests/unit/components/cliproxy/provider-model-selector.test.tsx`
- [x] `cd ui && bun run validate`
- [x] `bun run validate:ci-parity`
