### PR TITLE
fix(ui): keep codex toml tokens inline

### DIFF
--- a/ui/src/components/shared/code-editor.tsx
+++ b/ui/src/components/shared/code-editor.tsx
@@ -172,6 +172,11 @@ export function CodeEditor({
                     }
 
                     const tokenProps = getTokenProps({ token });
+                    // Prism TOML emits a `table` class, which collides with Tailwind's layout utility.
+                    tokenProps.style = {
+                      ...tokenProps.style,
+                      display: 'inline',
+                    };
 
                     if (isSensitive && isMasked) {
                       tokenProps.className = cn(

--- a/ui/tests/unit/components/ui/code-editor.test.tsx
+++ b/ui/tests/unit/components/ui/code-editor.test.tsx
@@ -71,6 +71,8 @@ describe('CodeEditor', () => {
   it('renders raw TOML with wrapping syntax color while copied text stays raw', () => {
     const rawToml =
       'model = "gpt-5.4"\n' +
+      '[agents.brainstormer]\n' +
+      'config_file = "agents/brainstormer.toml"\n' +
       '[mcp_servers.playwright]\n' +
       'command = "node"\n' +
       'args = ["--experimental-loader", "./very/long/path/that/should/not/soft/wrap/into/fake/toml/lines.js"]\n';
@@ -89,6 +91,9 @@ describe('CodeEditor', () => {
     const textarea = container.querySelector('[data-slot="code-editor-plain-textarea"]');
     const highlightLayer = container.querySelector('[data-slot="code-editor-highlight-layer"]');
     const highlightedToken = highlightLayer?.querySelector('span');
+    const tableToken = Array.from(highlightLayer?.querySelectorAll('span') ?? []).find(
+      (token) => token.textContent === 'agents.brainstormer'
+    );
 
     expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
     expect(textarea).toHaveValue(rawToml);
@@ -103,6 +108,8 @@ describe('CodeEditor', () => {
       wordBreak: 'break-word',
     });
     expect(highlightedToken).toBeInTheDocument();
+    expect(tableToken).toHaveClass('table');
+    expect(tableToken).toHaveStyle({ display: 'inline' });
     expect(container.querySelector('pre')).not.toBeInTheDocument();
     if (textarea instanceof HTMLTextAreaElement && highlightLayer instanceof HTMLElement) {
       textarea.scrollLeft = 96;


### PR DESCRIPTION
## Summary
- Keep Prism token spans inline so TOML table token classes do not inherit Tailwind layout utilities.
- Preserve the Codex config editor contract: wrapped visible text, syntax color, and unchanged copy/paste content.
- Add regression coverage for TOML table token inline display.

## Validation
- `bun run test:run tests/unit/components/ui/code-editor.test.tsx`
- `bun run ui:validate`
- Live browser e2e on `/codex`: before patch `[agents.brainstormer]` rendered as `[` / `agents.brainstormer` / `]`; after patch renders as one line, no horizontal overflow, syntax colors present, raw value preserved.
- `bun run ui:build`
- `bun run test:e2e`
- `bun run validate`
- Pre-commit and pre-push hooks

Docs impact: none
Action: no update needed — internal dashboard rendering fix only; no docs or CLI behavior changed.
