### PR TITLE
fix(ci): isolate stable release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,9 +524,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/tests/unit/scripts/github/release-workflow.test.ts
+++ b/tests/unit/scripts/github/release-workflow.test.ts
@@ -7,7 +7,7 @@ function resolvePath(relativePath: string) {
 }
 
 describe('stable release workflow', () => {
-  test('uses the protected-branch runner and release token path', () => {
+  test('uses an ephemeral hosted runner and release token path', () => {
     const workflowPath = resolvePath('../../../../.github/workflows/release.yml');
 
     expect(fs.existsSync(workflowPath)).toBe(true);
@@ -24,8 +24,8 @@ describe('stable release workflow', () => {
 
     expect(workflow).toContain('name: Release');
     expect(workflow).toContain('branches: [main]');
-    expect(workflow).toContain('runs-on: [self-hosted, linux, x64]');
-    expect(workflow).not.toContain('runs-on: ubuntu-latest');
+    expect(workflow).toContain('runs-on: ubuntu-latest');
+    expect(workflow).not.toContain('runs-on: [self-hosted, linux, x64]');
     expect(checkoutSection).toContain('token: ${{ secrets.PAT_TOKEN }}');
     expect(releaseSection).toContain('GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}');
     expect(releaseSection).toContain('GH_TOKEN: ${{ secrets.PAT_TOKEN }}');


### PR DESCRIPTION
### Motivation
- Prevent exposure of high-value release credentials by ensuring the stable `Release` job runs on an ephemeral hosted runner rather than a generic self-hosted pool shared with PR jobs.

### Description
- Change `runs-on` for the release job in `.github/workflows/release.yml` from `[self-hosted, linux, x64]` to `ubuntu-latest` to restore ephemeral runner isolation.
- Update `tests/unit/scripts/github/release-workflow.test.ts` to assert `runs-on: ubuntu-latest` and to reject the shared self-hosted label while retaining checks for checkout/release token usage.
- Apply Prettier formatting adjustments to `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts` (minor import-line reflow) to satisfy the repo formatting gate.
- Preserve existing release credential handling (checkout uses `secrets.PAT_TOKEN`, release step still exports `PAT`/`NPM` tokens); only runner selection was changed.

### Testing
- `bun test tests/unit/scripts/github/release-workflow.test.ts` — passed (1 pass, 0 fail).
- `bun run format` and `bun run lint:fix` — completed successfully.
- `bun run validate` — static checks passed, but the fast test bucket failed in unrelated tests (`web-server account-routes context normalization` and `browser status`) causing the local `validate` run to exit non-zero.
- `bun run validate:ci-parity` — build and static gates completed, but the full test suite failed in unrelated settings-profile launch tests on the local environment, so the parity gate returned non-zero.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0151fd0d5883309f4c5ab2bb54fd33)