### PR TITLE
fix(ci): isolate release sync token from self-hosted runners

### DIFF
--- a/.github/workflows/sync-dev-after-release.yml
+++ b/.github/workflows/sync-dev-after-release.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   sync-dev:
     if: ${{ !github.event.release.prerelease && github.event.release.target_commitish == 'main' && startsWith(github.event.release.tag_name, 'v') && !contains(github.event.release.tag_name, '-') }}
-    runs-on: [self-hosted, linux, x64]
+    # Keep the privileged PAT-backed sync isolated from the self-hosted runner
+    # pool used by pull-request CI. GitHub-hosted runners are ephemeral.
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write
@@ -17,9 +19,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # PAT_TOKEN is required because this pushes to protected dev and must
-          # trigger follow-up Push CI / Dev Release workflows.
-          token: ${{ secrets.PAT_TOKEN }}
+          persist-credentials: false
+
+      - name: Harden Git workspace
+        run: |
+          rm -rf .git/hooks
+          mkdir -p .git/hooks
+          git config --local core.hooksPath /dev/null
 
       - name: Configure Git
         run: |
@@ -47,4 +53,12 @@ jobs:
             git commit --no-edit
           fi
 
-          git push origin dev
+          # PAT_TOKEN is required because this pushes to protected dev and must
+          # trigger follow-up Push CI / Dev Release workflows. Keep it scoped to
+          # the final push rather than persisting it in the checkout config.
+          auth_header=$(printf 'x-access-token:%s' "$PAT_TOKEN" | base64 | tr -d '\n')
+          git -c core.hooksPath=/dev/null \
+            -c "http.https://github.com/kaitranntt/ccs/.extraheader=AUTHORIZATION: basic ${auth_header}" \
+            push origin dev
+        env:
+          PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,9 +524,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts
+++ b/tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts
@@ -7,7 +7,7 @@ function resolvePath(relativePath: string) {
 }
 
 describe('sync dev after release workflow', () => {
-  test('uses protected-branch runner and token settings', () => {
+  test('isolates the protected-branch token from pull-request runners', () => {
     const workflowPath = resolvePath('../../../../.github/workflows/sync-dev-after-release.yml');
 
     expect(fs.existsSync(workflowPath)).toBe(true);
@@ -20,14 +20,18 @@ describe('sync dev after release workflow', () => {
     const syncSection = workflow.slice(workflow.indexOf('- name: Sync dev with main'));
 
     expect(workflow).toContain('name: Sync Dev After Main Release');
-    expect(workflow).toContain('runs-on: [self-hosted, linux, x64]');
-    expect(workflow).not.toContain('runs-on: ubuntu-latest');
-    expect(checkoutSection).toContain('token: ${{ secrets.PAT_TOKEN }}');
-    expect(checkoutSection).not.toContain('token: ${{ github.token }}');
+    expect(workflow).toContain('runs-on: ubuntu-latest');
+    expect(workflow).not.toContain('runs-on: [self-hosted, linux, x64]');
+    expect(checkoutSection).toContain('persist-credentials: false');
+    expect(checkoutSection).not.toContain('token: ${{ secrets.PAT_TOKEN }}');
     expect(syncSection).toContain(
       'git merge origin/main --no-edit -m "chore(sync): merge main into dev after release"'
     );
     expect(syncSection).not.toContain('[skip ci]');
-    expect(syncSection).toContain('git push origin dev');
+    expect(workflow).toContain('git config --local core.hooksPath /dev/null');
+    expect(syncSection).toContain('PAT_TOKEN: ${{ secrets.PAT_TOKEN }}');
+    expect(syncSection).toContain('http.https://github.com/kaitranntt/ccs/.extraheader');
+    expect(syncSection).toContain('git -c core.hooksPath=/dev/null');
+    expect(syncSection).toContain('push origin dev');
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent a high-severity GitHub Actions vulnerability where a privileged release-sync job used a self-hosted runner and persisted a repository PAT, allowing a PR-runner to persist hooks or files that could later be used to exfiltrate or misuse the PAT.
- Keep privileged push credentials isolated and ephemeral while preserving the existing sync behavior that merges main into dev after a release.

### Description

- Move the privileged `sync-dev` job to a GitHub-hosted ephemeral runner by changing `runs-on` to `ubuntu-latest` and add comments explaining the isolation rationale in `.github/workflows/sync-dev-after-release.yml`.
- Harden checkout and push steps by setting `persist-credentials: false`, clearing/disabling local Git hooks (`rm -rf .git/hooks` + `git config --local core.hooksPath /dev/null`), and scoping `PAT_TOKEN` to a single final push via an extraheader (`http.*.extraheader`) instead of passing the PAT to `actions/checkout`.
- Update the workflow regression test `tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts` to assert the secure settings (ephemeral runner, `persist-credentials: false`, disabled hooks, scoped PAT push header and `git -c core.hooksPath=/dev/null` usage).
- Apply small Prettier formatting adjustments to two source files (`src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`) so the repo format checks remain green.

### Testing

- Ran `bun run format` and `bun run lint:fix` and both completed successfully.
- Executed the updated unit test `bun test tests/unit/scripts/github/sync-dev-after-release-workflow.test.ts` and it passed.
- Ran `bun run validate` (typecheck + lint + format:check + `test:fast`); typecheck/lint/format steps completed, but `validate` failed because unrelated pre-existing tests in the local full fast test bucket failed in this environment rather than due to the workflow change.
- Ran `bun run validate:ci-parity` (build + full tests + e2e); the build/typecheck/format stages completed but the full test suite failed in this container due to unrelated existing test failures in slow/integration buckets, so CI-parity did not fully pass here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0151e1e97c83308bb734e31ea22ef2)