### PR TITLE
fix(ci): isolate dev release runner

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   guard:
     if: ${{ github.ref == 'refs/heads/dev' }}
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.release-guard.outputs.should_release }}
 
@@ -36,7 +36,7 @@ jobs:
   release:
     needs: guard
     if: ${{ needs.guard.outputs.should_release == 'true' }}
-    runs-on: [self-hosted, linux, x64]
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,9 +524,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/tests/unit/scripts/github/dev-release-workflow.test.ts
+++ b/tests/unit/scripts/github/dev-release-workflow.test.ts
@@ -24,8 +24,8 @@ describe('dev release workflow', () => {
 
     expect(workflow).toContain('name: Dev Release');
     expect(workflow).toContain('branches: [dev]');
-    expect(workflow.match(/runs-on: \[self-hosted, linux, x64\]/g)).toHaveLength(2);
-    expect(workflow).not.toContain('runs-on: ubuntu-latest');
+    expect(workflow.match(/runs-on: ubuntu-latest/g)).toHaveLength(2);
+    expect(workflow).not.toContain('runs-on: [self-hosted, linux, x64]');
     expect(checkoutSection).toContain("token: ${{ secrets.PAT_TOKEN }}");
     expect(checkoutSection).not.toContain('token: ${{ github.token }}');
     expect(releaseSection).toContain('GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}');


### PR DESCRIPTION
### Motivation
- Prevent privileged dev release secrets (`PAT_TOKEN`/`NPM_TOKEN`) from being exposed to a shared self-hosted PR runner pool by restoring the release job to ephemeral GitHub-hosted runners.
- Keep the dev-release workflow guard logic intact while eliminating the cross-workflow persistence risk introduced by shared runner labels.
- Ensure repository formatting/lint gates remain satisfied after the small TypeScript formatting edits required by the toolchain.

### Description
- Change `runs-on` for the `guard` and `release` jobs in `.github/workflows/dev-release.yml` from `[self-hosted, linux, x64]` to `ubuntu-latest` so the secret-bearing release job runs on ephemeral GitHub-hosted runners.
- Update `tests/unit/scripts/github/dev-release-workflow.test.ts` to assert two `ubuntu-latest` occurrences and reject the shared self-hosted label for this workflow.
- Apply formatter-driven wrapping changes to imports in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts` to satisfy the repo formatting checks.

### Testing
- Ran `bun run format` and `bun run lint:fix` successfully to apply and fix formatting and lint issues.
- Ran `bun test tests/unit/scripts/github/dev-release-workflow.test.ts` and the updated dev-release workflow unit tests passed.
- Ran `bun run validate` and `bun run validate:ci-parity`, which exposed unrelated pre-existing test failures (not introduced by these changes): `web-server account-routes context normalization > rolls back inferred shared resource metadata when instance reconciliation fails` and `browser status > bootstraps the managed default browser profile dir before reporting attach readiness`, and broader settings-profile launch failures during the full parity suite, so the full CI parity gate is currently failing due to those unrelated test regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01597d1df08330a3c8d66911188c1e)