### PR TITLE
fix(proxy): strip stale content encoding from error responses

### DIFF
--- a/src/proxy/transformers/sse-stream-transformer.ts
+++ b/src/proxy/transformers/sse-stream-transformer.ts
@@ -50,6 +50,7 @@ export function createAnthropicErrorResponse(
 ): Response {
   const responseHeaders = new Headers(headers);
   responseHeaders.set('Content-Type', 'application/json');
+  responseHeaders.delete('Content-Encoding');
   responseHeaders.delete('Content-Length');
 
   return new Response(JSON.stringify(createAnthropicErrorPayload(type, message)), {

--- a/tests/integration/proxy/messages-edge-cases.test.ts
+++ b/tests/integration/proxy/messages-edge-cases.test.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
+import * as zlib from 'zlib';
 import { startOpenAICompatProxyServer } from '../../../src/proxy/server/proxy-server';
 import type { OpenAICompatProfileConfig } from '../../../src/proxy/profile-router';
 
@@ -140,6 +141,36 @@ describe('openai proxy message edge cases', () => {
       error: {
         type: 'rate_limit_error',
         message: 'rate limited',
+      },
+    });
+  });
+
+  it('does not leak upstream content-encoding onto synthesized error responses', async () => {
+    const compressed = zlib.gzipSync(
+      JSON.stringify({ error: { message: 'invalid upstream request' } })
+    );
+
+    await startProxyWithHandler((_req, res) => {
+      res.writeHead(400, {
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
+        'Content-Length': String(compressed.length),
+      });
+      res.end(compressed);
+    });
+
+    const response = await requestProxy({
+      model: 'hf-model',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get('content-encoding')).toBeNull();
+    await expect(response.json()).resolves.toMatchObject({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'invalid upstream request',
       },
     });
   });


### PR DESCRIPTION
## Summary
- strip upstream `Content-Encoding` from synthesized Anthropic error responses
- add regression coverage for gzipped OpenAI-compatible upstream errors

## Root Cause
When an OpenAI-compatible upstream returns a non-OK gzipped JSON response, `fetch` already decodes the body before CCS synthesizes a new Anthropic JSON error envelope. CCS copied the upstream headers onto that new plain JSON response, so stale `Content-Encoding: gzip` made downstream clients attempt to decompress uncompressed JSON.

## Validation
- `bun test tests/integration/proxy/messages-edge-cases.test.ts`
- `bun run format`
- `bun run lint:fix`
- `bun run validate`
- `bun run validate:ci-parity`
- pre-commit hook: `tsc --noEmit`, `eslint src/ --fix`, `prettier --check src/`
- pre-push hook: fast gate passed

Closes #1238
