### PR TITLE
feat(docker): canonical compose.yaml + smoke-test (P2 of #1251)

### DIFF
--- a/.github/workflows/smoke-test-compose-url.yml
+++ b/.github/workflows/smoke-test-compose-url.yml
@@ -1,0 +1,61 @@
+name: Smoke Test – ccs.kaitran.ca/docker-compose.yaml
+
+on:
+  release:
+    types:
+      - published
+  schedule:
+    # Nightly at 07:00 UTC
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      do_up:
+        description: >
+          Also run `docker compose up -d`, wait for healthcheck, curl ports, then
+          `docker compose down -v`. Skipped by default (parse-only).
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  smoke-test:
+    name: curl + parse (+ optional up/down)
+    runs-on: [self-hosted, linux, x64, cliproxy]
+
+    steps:
+      - name: Download compose from canonical URL
+        run: |
+          curl -fsSL https://ccs.kaitran.ca/docker-compose.yaml -o /tmp/ccs-compose.yaml
+          echo "--- downloaded compose ---"
+          cat /tmp/ccs-compose.yaml
+
+      - name: Validate compose parses (docker compose config)
+        run: docker compose -f /tmp/ccs-compose.yaml config
+
+      - name: Bring stack up, verify healthcheck, tear down
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.do_up == true }}
+        run: |
+          set -euo pipefail
+
+          docker compose -f /tmp/ccs-compose.yaml up -d
+
+          echo "Waiting for healthcheck to pass (max 90s)..."
+          for i in $(seq 1 18); do
+            STATUS=$(docker compose -f /tmp/ccs-compose.yaml ps --format json \
+              | python3 -c "import sys,json; data=sys.stdin.read().strip(); rows=json.loads('['+','.join(data.splitlines())+']') if data else []; print(next((r.get('Health','') for r in rows if 'ccs' in r.get('Service','')), 'unknown'))" 2>/dev/null || echo "unknown")
+            echo "Health: $STATUS"
+            if [ "$STATUS" = "healthy" ]; then
+              break
+            fi
+            sleep 5
+          done
+
+          # Verify ports respond
+          curl -fsSL --retry 3 --retry-delay 2 http://localhost:3000 -o /dev/null || \
+            { echo "[X] Dashboard port 3000 did not respond"; docker compose -f /tmp/ccs-compose.yaml down -v; exit 1; }
+
+          curl -fsSL --retry 3 --retry-delay 2 http://localhost:8317 -o /dev/null || \
+            { echo "[X] CLIProxy port 8317 did not respond"; docker compose -f /tmp/ccs-compose.yaml down -v; exit 1; }
+
+          echo "[OK] Both ports healthy"
+          docker compose -f /tmp/ccs-compose.yaml down -v

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,39 @@
+# Canonical CCS docker-compose. Served at https://ccs.kaitran.ca/docker-compose.yaml.
+# Source of truth: kaitranntt/ccs:docker/compose.yaml
+#
+# Quick start:
+#   curl -fsSL https://ccs.kaitran.ca/docker-compose.yaml -o compose.yaml
+#   docker compose up -d
+#
+# Ports:
+#   3000 — CCS Dashboard
+#   8317 — CLIProxy API
+
+services:
+  ccs:
+    image: ghcr.io/kaitranntt/ccs:latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+      - "8317:8317"
+    volumes:
+      - ccs_home:/root/.ccs
+      - ccs_logs:/var/log/ccs
+    networks:
+      - ccs-net
+    healthcheck:
+      test:
+        - "CMD-SHELL"
+        - >
+          node -e "require('http').get('http://127.0.0.1:8317/',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  ccs_home:
+  ccs_logs:
+
+networks:
+  ccs-net:
+    name: ccs-net


### PR DESCRIPTION
Part of #1251 — Epic P2 (ccs/cli side).

Targets umbrella branch \`kai/feat/1251-docker-zero-install-ux\`.

## What changed (ccs/cli)

- \`docker/compose.yaml\` — **NEW**. Canonical compose for the zero-install flow served at https://ccs.kaitran.ca/docker-compose.yaml. References \`ghcr.io/kaitranntt/ccs:latest\` (published by P1). Named external network \`ccs-net\` (so sibling containers can \`docker network connect ccs-net <app>\`). Named volumes \`ccs_home\` + \`ccs_logs\` (eliminates the \`mkdir -p ~/.ccs\` manual step). Healthcheck uses \`node -e\` only — Node is the one guaranteed binary across variants after P4 stripped Bun from the runtime stage.
- \`.github/workflows/smoke-test-compose-url.yml\` — **NEW**. CI smoke test: curl \`https://ccs.kaitran.ca/docker-compose.yaml\` → \`docker compose config\` (always). Optional full \`up -d\` + healthcheck + port probe + \`down -v\` gated behind \`do_up\` dispatch input. Triggers on \`release: published\` and nightly cron \`0 7 * * *\`.

Existing \`docker/docker-compose.integrated.yml\` and \`docker/docker-compose.yml\` are **untouched** — \`ccs docker up\` continues to work as before.

## Validation

- \`docker compose -f docker/compose.yaml config\` — not run locally (Docker not available on dev machine). Smoke-test workflow covers this on self-hosted runner post-release.

## Companion PR (ccs-landing)

Cloudflare Worker that serves \`ccs.kaitran.ca/docker-compose.yaml\`: kaitranntt/ccs-landing#6