### PR TITLE
fix(config): bind dashboard default to IPv4 wildcard

### DIFF
--- a/docs/dashboard-auth-cli.md
+++ b/docs/dashboard-auth-cli.md
@@ -6,7 +6,7 @@ CLI commands for managing CCS dashboard authentication.
 
 ## Overview
 
-The CCS dashboard (`ccs config`) can be protected with username/password authentication. This is useful whenever the dashboard is reachable from another device, including when the runtime's default bind is network-accessible or when you explicitly bind it beyond loopback with `ccs config --host 0.0.0.0`.
+The CCS dashboard (`ccs config`) can be protected with username/password authentication. This is useful whenever the dashboard is reachable from another device, including when the runtime's default IPv4 wildcard bind is network-accessible or when you explicitly bind it beyond loopback with `ccs config --host 0.0.0.0` or another non-loopback host.
 
 Authentication is **disabled by default** for backward compatibility. Use the CLI to configure and enable it.
 

--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,9 +524,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/commands/config-command-options.ts
+++ b/src/commands/config-command-options.ts
@@ -1,5 +1,6 @@
 import { extractOption, hasAnyFlag, scanCommandArgs } from './arg-extractor';
 import { getOfficialChannelsSupportMessage } from '../channels/official-channels-runtime';
+import { DEFAULT_DASHBOARD_HOST } from './config-dashboard-host';
 
 const CONFIG_COMMAND_FLAGS = ['--help', '-h', '--port', '-p', '--host', '-H', '--dev'] as const;
 
@@ -22,6 +23,7 @@ function formatUnexpectedArgsError(tokens: string[]): string {
 
 export function parseConfigCommandArgs(args: string[]): ConfigCommandParseResult {
   const options: ConfigCommandOptions = {
+    host: DEFAULT_DASHBOARD_HOST,
     hostProvided: false,
     dev: false,
   };
@@ -121,14 +123,14 @@ export function showConfigCommandHelp(): void {
   console.log('');
   console.log('Options:');
   console.log('  --port, -p PORT    Specify server port (default: auto-detect)');
-  console.log('  --host, -H HOST    Bind dashboard server host (default: system default)');
+  console.log('  --host, -H HOST    Bind dashboard server host (default: 0.0.0.0)');
   console.log('  --dev              Development mode with Vite HMR');
   console.log('  --help, -h         Show this help message');
   console.log('');
   console.log('Examples:');
   console.log('  ccs config                       Auto-detect available port');
   console.log('  ccs config --port 3000           Use specific port');
-  console.log('  ccs config --host 0.0.0.0        Force all-interface binding for remote devices');
+  console.log('  ccs config --host 0.0.0.0        Bind all IPv4 interfaces for remote devices');
   console.log('  ccs config --host 127.0.0.1      Restrict dashboard to this machine');
   console.log('  ccs config --dev                 Development mode with hot reload');
   console.log('  ccs config auth setup            Configure dashboard login');

--- a/src/commands/config-command.ts
+++ b/src/commands/config-command.ts
@@ -176,7 +176,7 @@ export async function handleConfigCommand(
       port,
       dev: options.dev,
     };
-    if (options.hostProvided && options.host) {
+    if (options.host) {
       serverOptions.host = normalizeDashboardHost(options.host);
     }
 

--- a/src/commands/config-dashboard-host.ts
+++ b/src/commands/config-dashboard-host.ts
@@ -1,7 +1,9 @@
 import * as os from 'os';
 
+export const DEFAULT_DASHBOARD_HOST = '0.0.0.0';
+
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
-const WILDCARD_HOSTS = new Set(['0.0.0.0', '::']);
+const WILDCARD_HOSTS = new Set([DEFAULT_DASHBOARD_HOST, '::']);
 
 interface NetworkInterfaceCandidate {
   address: string;

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/src/web-server/index.ts
+++ b/src/web-server/index.ts
@@ -18,6 +18,7 @@ import { getProxyTarget } from '../cliproxy/proxy/proxy-target-resolver';
 import { startAutoSyncWatcher, stopAutoSyncWatcher } from '../cliproxy/sync';
 import { shutdownUsageAggregator } from './usage/aggregator';
 import { createLogger } from '../services/logging';
+import { DEFAULT_DASHBOARD_HOST } from '../commands/config-dashboard-host';
 
 export interface ServerOptions {
   port: number;
@@ -38,6 +39,7 @@ const logger = createLogger('web-server');
  * Start Express server with WebSocket support
  */
 export async function startServer(options: ServerOptions): Promise<ServerInstance> {
+  const bindHost = options.host || DEFAULT_DASHBOARD_HOST;
   const app = express();
   const server = http.createServer(app);
   const wss = new WebSocketServer({
@@ -142,7 +144,7 @@ export async function startServer(options: ServerOptions): Promise<ServerInstanc
       logger.error('server.listen_failed', 'Dashboard server failed to start', {
         code: error.code || 'unknown',
         message: error.message,
-        host: options.host || null,
+        host: bindHost,
         port: options.port,
       });
       cleanup();
@@ -154,7 +156,7 @@ export async function startServer(options: ServerOptions): Promise<ServerInstanc
     const onListening = () => {
       server.off('error', onError);
       logger.info('server.listening', 'Dashboard server listening', {
-        host: options.host || '0.0.0.0',
+        host: bindHost,
         port: options.port,
         dev: Boolean(options.dev),
       });
@@ -164,12 +166,7 @@ export async function startServer(options: ServerOptions): Promise<ServerInstanc
     };
 
     try {
-      if (options.host) {
-        server.listen(options.port, options.host, onListening);
-        return;
-      }
-
-      server.listen(options.port, onListening);
+      server.listen(options.port, bindHost, onListening);
     } catch (error) {
       server.off('error', onError);
       cleanup();

--- a/tests/unit/commands/config-command-options.test.ts
+++ b/tests/unit/commands/config-command-options.test.ts
@@ -3,12 +3,12 @@ import { describe, expect, it } from 'bun:test';
 import { parseConfigCommandArgs } from '../../../src/commands/config-command-options';
 
 describe('config command options parser', () => {
-  it('defaults to system bind behavior without explicit host', () => {
+  it('defaults to explicit IPv4 wildcard binding without treating it as user-provided', () => {
     const result = parseConfigCommandArgs([]);
 
     expect(result.help).toBe(false);
     expect(result.error).toBeUndefined();
-    expect(result.options.host).toBeUndefined();
+    expect(result.options.host).toBe('0.0.0.0');
     expect(result.options.hostProvided).toBe(false);
   });
 

--- a/tests/unit/commands/config-command.test.ts
+++ b/tests/unit/commands/config-command.test.ts
@@ -79,7 +79,7 @@ beforeEach(() => {
   errorLines = [];
   dashboardAuthEnabled = false;
   startServerError = null;
-  mockServerBindHost = '::';
+  mockServerBindHost = '0.0.0.0';
 
   originalConsoleLog = console.log;
   originalConsoleError = console.error;
@@ -140,15 +140,15 @@ describe('config command dashboard startup', () => {
     expect(errorLines.join('\n')).toContain('Unexpected arguments: bogus');
   });
 
-  it('keeps the default startup path free of an explicit host override', async () => {
+  it('uses an explicit IPv4 wildcard host for the default startup path', async () => {
     await handleConfigCommand([], createTestDeps());
 
     expect(startServerCalls).toHaveLength(1);
-    expect(startServerCalls[0]).toEqual({ port: 3000, dev: false });
+    expect(startServerCalls[0]).toEqual({ port: 3000, dev: false, host: '0.0.0.0' });
 
     const rendered = logLines.join('\n');
     expect(rendered).toContain('Dashboard: http://localhost:3000');
-    expect(rendered).toContain('Bind host: ::');
+    expect(rendered).toContain('Bind host: 0.0.0.0');
     expect(rendered).toContain(
       'Dashboard may be reachable from other devices that can connect to this machine.'
     );
@@ -206,7 +206,7 @@ describe('config command dashboard startup', () => {
 
       const rendered = logLines.join('\n');
       expect(rendered).toContain('Dashboard: http://localhost:3000');
-      expect(rendered).toContain('Bind host: ::');
+      expect(rendered).toContain('Bind host: 0.0.0.0');
       expect(errorLines).toHaveLength(0);
     } finally {
       networkInterfacesSpy.mockRestore();

--- a/tests/unit/web-server/start-server-host.test.ts
+++ b/tests/unit/web-server/start-server-host.test.ts
@@ -20,11 +20,13 @@ afterEach(async () => {
 });
 
 describe('startServer host binding', () => {
-  it('binds with system-default host when no host is provided', async () => {
+  it('binds to the IPv4 wildcard host when no host is provided', async () => {
     const instance = await startServer({ port: 0 });
     instances.push(instance);
 
     const address = instance.server.address() as AddressInfo;
+    expect(address.address).toBe('0.0.0.0');
+    expect(address.family).toBe('IPv4');
     expect(address.port).toBeGreaterThan(0);
   });
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -18,7 +18,7 @@ From project root:
 bun run dev
 ```
 
-This starts the CCS server, opens a local browser URL, and prints bind/network details for the dashboard.
+This starts the CCS server, opens a local browser URL, and binds the dashboard to the default IPv4 wildcard host (`0.0.0.0`).
 If the runtime bind is reachable beyond loopback, CCS also prints an auth reminder.
 
 For remote device access during development, run:


### PR DESCRIPTION
### Motivation

- Prevent Node from using a system-default IPv6 wildcard (e.g. `::`) when no host is supplied, which could expose the unauthenticated dashboard on IPv6 interfaces.

### Description

- Add a single `DEFAULT_DASHBOARD_HOST = '0.0.0.0'` and treat it as the implicit default bind host for the dashboard. (`src/commands/config-dashboard-host.ts`)
- Make the `ccs config` parser populate `options.host` with the IPv4 wildcard by default and preserve `hostProvided` for explicit user intent. (`src/commands/config-command-options.ts`)
- Ensure `ccs config` passes the effective host through to `startServer`, and make `startServer` itself default to the same IPv4 wildcard before calling `server.listen`. (`src/commands/config-command.ts`, `src/web-server/index.ts`)
- Update CLI help and docs to document the `0.0.0.0` default and adjust tests to assert the IPv4 wildcard behavior. (help text, `docs/dashboard-auth-cli.md`, `ui/README.md`, and updated unit tests)

### Testing

- Ran formatting and lint autofixes with `bun run format` and `bun run lint:fix`, which completed successfully. 
- Ran focused unit tests: `bun test tests/unit/commands/config-command-options.test.ts tests/unit/commands/config-command.test.ts tests/unit/web-server/start-server-host.test.ts tests/unit/commands/config-dashboard-host.test.ts`, and these passed. 
- Ran `bun run validate`, where typecheck/lint/format checks passed but `test:fast` surfaced unrelated existing failures in broader suites (two failing unit tests in `web-server account-routes` and `browser status`), so `validate` returned non-zero. 
- Ran `bun run validate:ci-parity` (full CI-parity build + tests) and observed unrelated failures in other test groups (several settings/profile/browser/image-analysis Web/target tests); the changes in this PR are small and limited to dashboard host binding and docs, and the targeted unit tests for this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0184fce0588330b7a3cf3043445b1a)