### PR TITLE
fix: address upstream reviewer findings + failing CI checks (#1261 loop 1)

### DIFF
--- a/.github/workflows/breaking-change-guard.yml
+++ b/.github/workflows/breaking-change-guard.yml
@@ -41,7 +41,14 @@ jobs:
           set -euo pipefail
 
           BASE="origin/${{ github.base_ref }}"
-          DIFF=$(git diff "${BASE}"...HEAD -- docker/compose.yaml)
+
+          # Guard: if docker/compose.yaml does not exist in the base branch, this
+          # is a new file — no contract existed before, so no regression is possible.
+          if ! git cat-file -e "${BASE}:docker/compose.yaml" 2>/dev/null; then
+            echo "[i] docker/compose.yaml is new in this PR (not present on ${BASE}) — skipping contract check"
+            echo "breaking=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           BREAKING=0
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -288,7 +288,11 @@ jobs:
   # ---------------------------------------------------------------------------
   smoke-test:
     name: Smoke test integrated image
-    needs: [publish-integrated, publish-dashboard]
+    # Depends only on publish-integrated, NOT publish-dashboard.
+    # publish-dashboard is skipped on prerelease (rc.N) events — if it were
+    # listed here, GitHub Actions would also skip smoke-test and
+    # promote-mutable-tags on every rc publish, breaking the rc soak flow.
+    needs: [publish-integrated]
     # Run on both rc and stable releases; skip if integrated publish was skipped
     if: ${{ needs.publish-integrated.outputs.publish == 'true' }}
     runs-on: [self-hosted, linux, x64, cliproxy]
@@ -355,7 +359,11 @@ jobs:
 
       - name: Run network-contract test
         run: |
-          bash tests/docker/network-contract.sh "${{ steps.image.outputs.ref }}"
+          # network-contract.sh signature: <compose-file> [image-ref]
+          # Pass compose.yaml as $1 and the pinned image ref as $2 so the
+          # smoke test exercises the canonical compose file with the exact
+          # image that was just published, not whatever tag is in the file.
+          bash tests/docker/network-contract.sh docker/compose.yaml "${{ steps.image.outputs.ref }}"
 
       - name: Probe dashboard port 3000
         run: |

--- a/.github/workflows/docs-parity.yml
+++ b/.github/workflows/docs-parity.yml
@@ -19,6 +19,9 @@ on:
 jobs:
   quickstart-parity:
     name: Assert quickstart snippet matches in README.md and docker/README.md
+    if: >-
+      contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)
+      || github.event_name == 'push'
     runs-on: [self-hosted, linux, x64, cliproxy]
 
     steps:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -20,6 +20,11 @@ services:
       - "3000:3000"
       - "8317:8317"
     volumes:
+      # /root/.ccs matches the HOME used inside the integrated image.
+      # entrypoint-integrated.sh runs as root (supervisord user=root) and
+      # explicitly mkdir -p /root/.ccs, so state always lands here.
+      # Note: docker/entrypoint.sh (legacy dashboard image) uses a different
+      # default — it does NOT apply to this integrated image.
       - ccs_home:/root/.ccs
       - ccs_logs:/var/log/ccs
     networks:

--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,8 +524,9 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
-    await import('../accounts/account-safety');
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
+    '../accounts/account-safety'
+  );
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,8 +112,9 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } =
-    await import('../../config/config-loader-facade');
+  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
+    '../../config/config-loader-facade'
+  );
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/tests/unit/scripts/github/ci-workflow.test.ts
+++ b/tests/unit/scripts/github/ci-workflow.test.ts
@@ -19,7 +19,8 @@ describe('pr ci workflow', () => {
     expect(workflow).toContain('name: CI');
     expect(workflow).toContain('pull_request:');
     expect(workflow).toContain('branches: [main, dev]');
-    expect(workflow.split(trustedAuthorGate).length - 1).toBe(3);
+    // 4 jobs: validate (matrix), build, test, compose-parity — each gated
+    expect(workflow.split(trustedAuthorGate).length - 1).toBe(4);
     expect(workflow).toContain('group: ci-${{ github.ref }}');
     expect(workflow).toContain('cancel-in-progress: true');
     expect(workflow).toContain('fail-fast: false');


### PR DESCRIPTION
## Summary

Addresses all 3 failing CI checks and all 3 upstream reviewer findings on umbrella PR #1261.

### CI Fixes

**CI-1 — `breaking-change-guard` crash on new file**
Guard each `git show "${BASE}:docker/compose.yaml"` call with a `git cat-file -e` existence check. When `docker/compose.yaml` doesn't exist on the base branch (new file in the PR), skip contract checking — a new file can't regress a contract that didn't exist.

**CI-2 — `format` drift**
Ran `bun run format` on two files with pre-existing prettier drift:
- `src/cliproxy/quota/quota-manager.ts`
- `src/management/checks/image-analysis-check.ts`

No logic changes.

**CI-3 — `test` count mismatch in ci-workflow.test.ts**
The `compose-parity` job added in #1260 legitimately needs the trusted-author gate (self-hosted runner + PR checkout). Updated expected gate count from 3 → 4.

**CI-4 (discovered) — `self-hosted-runner-policy` test failure**
`docs-parity.yml` (added in the umbrella PR) runs on a self-hosted runner with PR checkout but lacked the trusted-author guard. Added the guard while preserving push-event behavior (push doesn't require author check).

### Reviewer Findings

**REV-1 — `network-contract.sh` called with wrong argument order**
`network-contract.sh` signature is `<compose-file> [image-ref]`. The smoke-test job was passing the image ref as `$1` (compose-file position). Fixed to `bash tests/docker/network-contract.sh docker/compose.yaml "${{ steps.image.outputs.ref }}"`.

**REV-2 — `smoke-test` skipped on rc.N due to `publish-dashboard` in needs**
`publish-dashboard` is conditionally skipped on prereleases. GitHub Actions propagates skips to downstream jobs unless overridden. Removed `publish-dashboard` from `smoke-test.needs` — smoke-test only verifies the integrated image and has no dependency on the legacy dashboard job.

**REV-3 — Volume path concern (`/root/.ccs` vs `/home/node/.ccs`)**
Verified: `entrypoint-integrated.sh` explicitly `mkdir -p /root/.ccs` and supervisord runs as `user=root` with `HOME="/root"`. The compose volume mount at `/root/.ccs` is correct. The reviewer was looking at `entrypoint.sh` (legacy image), not `entrypoint-integrated.sh`. Added inline comment to compose.yaml documenting the path and why.

## Files Changed

- `.github/workflows/breaking-change-guard.yml` — CI-1
- `src/cliproxy/quota/quota-manager.ts` — CI-2 (format)
- `src/management/checks/image-analysis-check.ts` — CI-2 (format)
- `tests/unit/scripts/github/ci-workflow.test.ts` — CI-3
- `.github/workflows/docs-parity.yml` — CI-4 (discovered)
- `.github/workflows/docker-release.yml` — REV-1 + REV-2
- `docker/compose.yaml` — REV-3 (comment only)

Closes no issues. Does not merge. Targets umbrella PR #1261.