### PR TITLE
fix(codex): require local dashboard access

### DIFF
--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,9 +524,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/src/web-server/routes/codex-routes.ts
+++ b/src/web-server/routes/codex-routes.ts
@@ -1,4 +1,4 @@
-import type { Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { Router } from 'express';
 import {
   CodexRawConfigConflictError,
@@ -8,8 +8,17 @@ import {
   patchCodexConfig,
   saveCodexRawConfig,
 } from '../services/codex-dashboard-service';
+import { requireLocalAccessWhenAuthDisabled } from '../middleware/auth-middleware';
 
 const router = Router();
+const CODEX_LOCAL_ACCESS_ERROR =
+  'Codex dashboard endpoints require localhost access when dashboard auth is disabled.';
+
+router.use((req: Request, res: Response, next: NextFunction): void => {
+  if (requireLocalAccessWhenAuthDisabled(req, res, CODEX_LOCAL_ACCESS_ERROR)) {
+    next();
+  }
+});
 
 router.get('/diagnostics', async (_req: Request, res: Response): Promise<void> => {
   try {

--- a/tests/unit/web-server/api-routes-remote-write-guard.test.ts
+++ b/tests/unit/web-server/api-routes-remote-write-guard.test.ts
@@ -20,6 +20,7 @@ describe('api-routes remote write guard', () => {
   let tempHome = '';
   let originalDashboardAuthEnabled: string | undefined;
   let originalCcsHome: string | undefined;
+  let originalCodexHome: string | undefined;
 
   beforeAll(async () => {
     const app = express();
@@ -53,8 +54,10 @@ describe('api-routes remote write guard', () => {
   beforeEach(() => {
     originalDashboardAuthEnabled = process.env.CCS_DASHBOARD_AUTH_ENABLED;
     originalCcsHome = process.env.CCS_HOME;
+    originalCodexHome = process.env.CODEX_HOME;
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-api-routes-remote-write-guard-'));
     process.env.CCS_HOME = tempHome;
+    process.env.CODEX_HOME = path.join(tempHome, '.codex');
     process.env.CCS_DASHBOARD_AUTH_ENABLED = 'false';
     forcedRemoteAddress = '10.10.0.24';
   });
@@ -70,6 +73,12 @@ describe('api-routes remote write guard', () => {
       process.env.CCS_HOME = originalCcsHome;
     } else {
       delete process.env.CCS_HOME;
+    }
+
+    if (originalCodexHome !== undefined) {
+      process.env.CODEX_HOME = originalCodexHome;
+    } else {
+      delete process.env.CODEX_HOME;
     }
 
     if (tempHome && fs.existsSync(tempHome)) {
@@ -173,6 +182,25 @@ describe('api-routes remote write guard', () => {
     } finally {
       deleteSessionLockForPort(8317);
     }
+  });
+
+  it('blocks remote Codex raw config reads when dashboard auth is disabled', async () => {
+    const codexHome = process.env.CODEX_HOME;
+    if (!codexHome) {
+      throw new Error('CODEX_HOME was not initialized for the test');
+    }
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, 'config.toml'),
+      'model_provider = "sensitive"\n[model_providers.sensitive]\nexperimental_bearer_token = "secret-token"\n'
+    );
+
+    const response = await fetch(`${baseUrl}/api/codex/config/raw`);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'Codex dashboard endpoints require localhost access when dashboard auth is disabled.',
+    });
   });
 
   it('blocks remote PATCH requests when dashboard auth is disabled', async () => {


### PR DESCRIPTION
### Motivation

- Codex dashboard routes were mounted under `/api/codex` without the local-access guard used by other sensitive endpoints, allowing unauthenticated remote reads/writes when `dashboard_auth` is disabled. 
- Exposed endpoints returned unredacted raw config and allowed persistent TOML writes/patches (including `stdio` MCP server commands), creating a remote disclosure and persistent configuration-tampering/command-execution risk.

### Description

- Enforce localhost-only access for Codex dashboard endpoints by importing `requireLocalAccessWhenAuthDisabled` and adding a route-local middleware guard that rejects non-loopback requests when dashboard auth is disabled. 
- Add a regression unit test that verifies non-loopback requests to `GET /api/codex/config/raw` are blocked when `CCS_DASHBOARD_AUTH_ENABLED=false` and `CODEX_HOME` is isolated to a temp directory. 
- Apply minor formatting adjustments to a couple dynamic-import lines touched by the formatting/lint gates to satisfy repo style checks.

### Testing

- Ran `bun test tests/unit/web-server/api-routes-remote-write-guard.test.ts tests/unit/web-server/codex-routes.test.ts` and both suites passed (codex/guard coverage exercised and confirmed `403` for remote raw reads). 
- Ran formatting and lint/type checks: `bun run format`, `bun run lint:fix`, `bun run format:check`, `bun run lint`, and `bun run typecheck` all completed successfully. 
- Ran `bun run validate` and `bun run validate:ci-parity` (CI-parity/full test buckets); these encountered pre-existing unrelated test failures in broader suites (not caused by the Codex guard changes), specifically failures in `web-server account-routes context normalization` and `browser status` and some settings-profile launch tests, so the full-suite parity target remains red for unrelated baseline issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017897eda88330932c5418b840e837)