### PR TITLE
fix: tighten parity check + catch service-key rename (#1261 loop 3)

### DIFF
--- a/.github/workflows/breaking-change-guard.yml
+++ b/.github/workflows/breaking-change-guard.yml
@@ -7,6 +7,7 @@ name: Breaking Change Guard – Docker Compose Contract
 #   services.ccs.image (the image *name*, not the tag)
 #   networks.ccs-net.name
 #   services.ccs.container_name (if set)
+#   services keys (Docker DNS uses the service key; renaming "ccs:" changes http://ccs:8317)
 #
 # If any of these fields change in a PR, the workflow fails unless at least
 # one commit in the PR includes a breaking-change marker (feat!: or fix!:).
@@ -77,6 +78,30 @@ jobs:
           NEW_CN=$(grep 'container_name:' docker/compose.yaml | tr -d ' ' || echo "")
           if [[ "${OLD_CN}" != "${NEW_CN}" ]]; then
             echo "[!] BREAKING: container_name changed: '${OLD_CN}' -> '${NEW_CN}'"
+            BREAKING=1
+          fi
+
+          # 4. Service key rename — public DNS contract on ccs-net depends on the
+          #    service key being "ccs". Docker's service-name DNS resolves sibling
+          #    containers via the compose service KEY (e.g. http://ccs:8317). A
+          #    rename from "ccs:" to anything else silently breaks every sibling
+          #    container in the wild even when image/network/container_name match.
+          #
+          #    Extraction logic: find lines that look like top-level service keys
+          #    (two-space indent + identifier + colon, NOT sub-keys like "image:").
+          #    This matches YAML service keys without requiring an external YAML parser.
+          OLD_KEYS=$(git show "${BASE}:docker/compose.yaml" 2>/dev/null \
+            | awk '/^services:/{s=1;next} s && /^  [a-zA-Z0-9_-]+:/{print $1} /^[^ ]/{s=0}' \
+            | tr -d ':' | sort | tr '\n' ' ' | sed 's/ $//')
+          NEW_KEYS=$(awk '/^services:/{s=1;next} s && /^  [a-zA-Z0-9_-]+:/{print $1} /^[^ ]/{s=0}' \
+            docker/compose.yaml \
+            | tr -d ':' | sort | tr '\n' ' ' | sed 's/ $//')
+          if ! echo " ${NEW_KEYS} " | grep -q " ccs "; then
+            echo "[!] BREAKING: services.ccs key missing from docker/compose.yaml — sibling containers on ccs-net rely on DNS hostname 'ccs'"
+            BREAKING=1
+          fi
+          if [[ "${OLD_KEYS}" != "${NEW_KEYS}" ]]; then
+            echo "[!] BREAKING: services keys changed: '${OLD_KEYS}' -> '${NEW_KEYS}'"
             BREAKING=1
           fi
 

--- a/tests/docker/compose-parity.sh
+++ b/tests/docker/compose-parity.sh
@@ -65,19 +65,37 @@ volume_targets() {
 }
 
 # ---------------------------------------------------------------------------
-# 1. Image name (repo without tag) — both should reference kaitranntt/ccs
+# Expected image names (without tag) — source of truth for this assertion.
+#
+# canonical (docker/compose.yaml):
+#   Pulls from the public registry. Default image is ghcr.io/kaitranntt/ccs.
+#
+# integrated (docker/docker-compose.integrated.yml):
+#   Built locally from Dockerfile.integrated; the resulting image is tagged
+#   ccs-cliproxy (no registry prefix) so it stays separate from the public
+#   image but is still clearly a CCS-family image.
+# ---------------------------------------------------------------------------
+EXPECTED_CANONICAL_IMAGE="ghcr.io/kaitranntt/ccs"
+EXPECTED_INTEGRATED_IMAGE="ccs-cliproxy"
+
+# ---------------------------------------------------------------------------
+# 1. Image name (repo without tag) — assert exact match against expected names
 # ---------------------------------------------------------------------------
 log "Checking image name parity..."
 
 CANONICAL_IMAGE=$(image_name "$CANONICAL" "ccs")
 INTEGRATED_IMAGE=$(image_name "$INTEGRATED" "ccs-cliproxy")
 
-# Both must contain kaitranntt/ccs (integrated builds locally but from the same Dockerfile)
-if echo "$CANONICAL_IMAGE" | grep -q "kaitranntt/ccs" && \
-   echo "$INTEGRATED_IMAGE" | grep -q "ccs"; then
-  ok "Image names reference expected repo (canonical: ${CANONICAL_IMAGE}, integrated: ${INTEGRATED_IMAGE})"
+if [[ "${CANONICAL_IMAGE}" != "${EXPECTED_CANONICAL_IMAGE}" ]]; then
+  fail "Canonical image name mismatch — expected='${EXPECTED_CANONICAL_IMAGE}' got='${CANONICAL_IMAGE}'"
 else
-  fail "Image name mismatch — canonical='${CANONICAL_IMAGE}' integrated='${INTEGRATED_IMAGE}'"
+  ok "Canonical image name matches expected (${CANONICAL_IMAGE})"
+fi
+
+if [[ "${INTEGRATED_IMAGE}" != "${EXPECTED_INTEGRATED_IMAGE}" ]]; then
+  fail "Integrated image name mismatch — expected='${EXPECTED_INTEGRATED_IMAGE}' got='${INTEGRATED_IMAGE}'"
+else
+  ok "Integrated image name matches expected (${INTEGRATED_IMAGE})"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses two reviewer findings from umbrella PR #1261 (loop 3):

- **REV7 (compose-parity image check):** Replace loose `grep -q "ccs"` substring check with exact equality against declared `EXPECTED_CANONICAL_IMAGE` and `EXPECTED_INTEGRATED_IMAGE` constants. The integrated compose builds locally as `ccs-cliproxy:latest` (intentionally separate from `ghcr.io/kaitranntt/ccs`), so each side's expected name is explicitly documented.
- **REV8 (breaking-change-guard misses service-key rename):** Add a 4th check that extracts top-level service keys via `awk` and fails if (a) `ccs` key is absent or (b) the key set changes. Docker's service-name DNS uses the compose service KEY as the hostname; `http://ccs:8317` breaks silently if `services.ccs:` is renamed.

## Test plan

- [x] `bash tests/docker/compose-parity.sh` passes with exact-match checks
- [x] Manually verified awk extraction returns `ccs` for current `docker/compose.yaml`
- [x] Guard logic: renamed key (e.g. `app`) correctly triggers `[X] ccs key missing` failure
- [x] `bun run validate` — 1975 tests pass, 0 fail