### PR TITLE
fix: smoke-test failure check + relax service-key guard (#1261 loop 4)

### DIFF
--- a/.github/workflows/breaking-change-guard.yml
+++ b/.github/workflows/breaking-change-guard.yml
@@ -81,27 +81,20 @@ jobs:
             BREAKING=1
           fi
 
-          # 4. Service key rename — public DNS contract on ccs-net depends on the
-          #    service key being "ccs". Docker's service-name DNS resolves sibling
-          #    containers via the compose service KEY (e.g. http://ccs:8317). A
-          #    rename from "ccs:" to anything else silently breaks every sibling
-          #    container in the wild even when image/network/container_name match.
+          # 4. Service key contract — Docker DNS on ccs-net uses the compose service
+          #    KEY as the hostname (e.g. http://ccs:8317). Renaming or removing
+          #    "ccs:" breaks every sibling container in the wild. Adding new service
+          #    keys (e.g. a sidecar) does NOT affect the "ccs" DNS contract and is
+          #    therefore allowed without a breaking-change marker.
           #
           #    Extraction logic: find lines that look like top-level service keys
           #    (two-space indent + identifier + colon, NOT sub-keys like "image:").
           #    This matches YAML service keys without requiring an external YAML parser.
-          OLD_KEYS=$(git show "${BASE}:docker/compose.yaml" 2>/dev/null \
-            | awk '/^services:/{s=1;next} s && /^  [a-zA-Z0-9_-]+:/{print $1} /^[^ ]/{s=0}' \
-            | tr -d ':' | sort | tr '\n' ' ' | sed 's/ $//')
           NEW_KEYS=$(awk '/^services:/{s=1;next} s && /^  [a-zA-Z0-9_-]+:/{print $1} /^[^ ]/{s=0}' \
             docker/compose.yaml \
             | tr -d ':' | sort | tr '\n' ' ' | sed 's/ $//')
           if ! echo " ${NEW_KEYS} " | grep -q " ccs "; then
             echo "[!] BREAKING: services.ccs key missing from docker/compose.yaml — sibling containers on ccs-net rely on DNS hostname 'ccs'"
-            BREAKING=1
-          fi
-          if [[ "${OLD_KEYS}" != "${NEW_KEYS}" ]]; then
-            echo "[!] BREAKING: services keys changed: '${OLD_KEYS}' -> '${NEW_KEYS}'"
             BREAKING=1
           fi
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -342,10 +342,12 @@ jobs:
             "${{ steps.image.outputs.ref }}"
 
           echo "[i] Waiting for container healthcheck (up to 60s)..."
+          HEALTHY=0
           for i in $(seq 1 12); do
             STATUS=$(docker inspect "${CONTAINER_NAME}" --format='{{.State.Health.Status}}' 2>/dev/null || echo "missing")
             if [[ "${STATUS}" == "healthy" ]]; then
               echo "[OK] Container is healthy after $((i * 5))s"
+              HEALTHY=1
               break
             fi
             if [[ "${STATUS}" == "unhealthy" ]]; then
@@ -356,6 +358,12 @@ jobs:
             echo "    [${i}/12] status=${STATUS}, waiting 5s..."
             sleep 5
           done
+          if [[ "${HEALTHY}" -ne 1 ]]; then
+            echo "[X] Container did not become healthy within 60s (last status: ${STATUS})" >&2
+            docker logs "${CONTAINER_NAME}" --tail 100 >&2
+            docker inspect "${CONTAINER_NAME}" --format='{{json .State}}' >&2 || true
+            exit 1
+          fi
 
       - name: Run network-contract test
         run: |


### PR DESCRIPTION
## Summary

Addresses 2 reviewer findings on umbrella PR #1261.

### REV9 — Smoke-test silent pass on healthcheck timeout

**File:** `.github/workflows/docker-release.yml`

Added `HEALTHY` flag to the boot-and-wait loop. Previously if the container never
reached `healthy` within 60 s (status stuck at `starting` or `missing`), the loop
exited normally and the job continued to port probes. Now the step fails explicitly
with container logs + state dump if `HEALTHY` is not set at loop exit.

`network-contract.sh` already uses the same pattern (`HEALTHY` flag + failure guard
after the loop) — no change needed there.

### REV10 — Overbroad service-key breaking-change check

**File:** `.github/workflows/breaking-change-guard.yml`

Dropped the `OLD_KEYS != NEW_KEYS` comparison from check 4. That condition
treated _any_ change to the set of service keys as breaking, including adding
a harmless sidecar like `services.cache`. The actual contract only requires that
`services.ccs` exists (Docker DNS on `ccs-net` uses the compose service key as
hostname). Removed the unused `OLD_KEYS` extraction; kept only the
`services.ccs` presence check.

## Checklist

- [x] `bun run format && bun run lint:fix && bun run validate` — 1973 pass, 0 fail
- [x] No functional changes to production code — CI workflow YAML only
- [x] `network-contract.sh` already correct — not touched