### PR TITLE
docs(ci): clarify intentional design choices (#1261 loop 7)

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -400,10 +400,19 @@ jobs:
   # ---------------------------------------------------------------------------
   # Job 4: Promote mutable tags — runs ONLY after smoke tests pass
   # Adds :latest, :<major>, :<minor> aliases pointing to the immutable digest.
-  # Never triggered automatically by release events — requires an explicit
-  # workflow_dispatch with promote_to_latest=true (via promote-release.yml or
-  # direct gh CLI call) after the operator confirms the immutable :<ver> image
-  # is stable. This is the sole rc.1 soak gate for Docker mutable tags.
+  #
+  # INTENTIONAL DESIGN (issue #1251 rc.1 soak — see docs/release-process.md):
+  # GitHub release events publish ONLY the immutable :<ver> tag. The mutable
+  # :latest / :<major> / :<minor> aliases STAY POINTED AT THE PRIOR STABLE
+  # RELEASE until an operator manually promotes after a soak window (~24h).
+  # Trade-off: zero-install users (curl ccs.kaitran.ca/docker-compose.yaml &&
+  # docker compose up -d) keep receiving last-known-good :latest during the
+  # soak; operators wanting the new version pull :<ver> directly.
+  #
+  # Operator promotion:
+  #   gh workflow run promote-release.yml -f tag=v<X.Y.Z>
+  # (or equivalently: gh workflow run "Publish Docker Image" -f tag=v<X.Y.Z>
+  # -f promote_to_latest=true)
   # ---------------------------------------------------------------------------
   promote-mutable-tags:
     name: Promote mutable tags (:latest / major / minor)

--- a/docker/Dockerfile.integrated
+++ b/docker/Dockerfile.integrated
@@ -3,9 +3,13 @@ FROM eceasy/cli-proxy-api:latest
 ARG CCS_NPM_VERSION=latest
 
 # CCS integrated image: CCS CLI + CLIProxy + supervisord.
-# No AI CLIs (claude-code, gemini-cli, etc.) are bundled.
-# To use AI CLIs alongside CLIProxy, run them in sibling containers
-# attached to ccs-net — see docker/README.md#connect-your-app-to-cliproxy.
+# Design choice (issue #1251 final scope): single-image strategy. The originally-
+# proposed `:full` variant bundling claude-code/gemini-cli/grok-cli/opencode was
+# DROPPED on maintainer review. Rationale: smaller surface area, fewer supply-
+# chain dependencies, simpler tag taxonomy. Users needing AI CLIs run them in
+# sibling containers attached to ccs-net — the public DNS contract guarantees
+# http://ccs:8317 reachability. See docker/README.md#connect-your-app-to-
+# cliproxy. Historical record: CHANGELOG.md "### Removed" entry.
 
 RUN apk add --no-cache \
     curl \


### PR DESCRIPTION
Final reviewer loop pass — addresses 2 reviewer findings as intentional-design clarifications.

Part of #1261 — umbrella PR review loop iteration 7.

## What changed (doc-only)

- `docker/Dockerfile.integrated` — strengthen the "no :full image" comment to explicitly cite issue #1251 final scope and the Q3 maintainer decision rationale.
- `.github/workflows/docker-release.yml` — strengthen the `promote-mutable-tags` job comment to call out the rc.1 soak trade-off explicitly: zero-install users keep getting last-known-good `:latest` during the soak; operators wanting the new version pull `:<ver>` directly.

## Reviewer findings addressed (both intentional)

1. **Missing Full Image** — Q3 user decision dropped `:full` entirely. Inline comment now references the historical CHANGELOG entry and the sibling-container migration path on `ccs-net`.
2. **Release Promotion** — The rc.1 soak (from loop-5) is the documented design: mutable Docker tags require manual `gh workflow run promote-release.yml`. Inline comment now spells out the trade-off and operator promotion command.

Neither finding is a bug; both are documented design choices. This commit makes that unmistakable to future maintainers and AI reviewers.

## Test plan

- Doc-only — no CI behavior change. PR-Agent Review will run on this PR.
