### PR TITLE
fix: address final-review criticals — healthcheck/digest/contract guards (#1261 loop 8)

### DIFF
--- a/.github/workflows/breaking-change-guard.yml
+++ b/.github/workflows/breaking-change-guard.yml
@@ -87,12 +87,22 @@ jobs:
             BREAKING=1
           fi
 
-          # 2. ccs-net network name change
-          OLD_NET=$(git show "${BASE}:docker/compose.yaml" \
-            | grep 'name: ccs-net' | tr -d ' ' || echo "")
-          NEW_NET=$(grep 'name: ccs-net' docker/compose.yaml | tr -d ' ' || echo "")
-          if [[ "${OLD_NET}" != "${NEW_NET}" ]]; then
-            echo "[!] BREAKING: ccs-net network name changed"
+          # 2. ccs-net network name — positive assertion: the canonical name MUST
+          #    still be present in the NEW file. Comparing old vs new string only
+          #    catches modifications; if BOTH files lack it (rename to something
+          #    else) both vars are empty and the diff is zero — breaking change
+          #    goes undetected. The positive assertion catches renames AND removals.
+          if ! grep -qE '^\s+name:\s+ccs-net\s*$' docker/compose.yaml; then
+            echo "[!] BREAKING: networks.ccs-net is missing or renamed — public DNS contract relies on this name"
+            BREAKING=1
+          fi
+
+          # 2b. hostname override guard (covers M2): if a service sets
+          #     'hostname:', Docker uses that instead of the service key as the
+          #     DNS name on ccs-net, silently breaking http://ccs:8317 for
+          #     sibling containers even if the service key stays "ccs".
+          if grep -qE '^\s+hostname:' docker/compose.yaml; then
+            echo "[!] BREAKING: services.ccs.hostname override changes DNS name — public contract requires 'ccs'"
             BREAKING=1
           fi
 

--- a/docker/Dockerfile.integrated
+++ b/docker/Dockerfile.integrated
@@ -1,4 +1,9 @@
-FROM eceasy/cli-proxy-api:latest
+# Base image pinned by digest for reproducible builds.
+# To refresh: docker pull eceasy/cli-proxy-api:latest && docker inspect --format='{{index .RepoDigests 0}}' eceasy/cli-proxy-api:latest
+# Refresh cadence: quarterly OR on security advisory from upstream.
+# TODO: pin apk packages once apk-digest pinning workflow exists in CI (apk add nodejs npm are currently unpinned;
+#       alpine package versions can be pinned but require per-package version discovery and maintenance).
+FROM eceasy/cli-proxy-api:latest@sha256:4fa722b9ff83adfbe6e350d433b7dcb754756aa63df95a7a6349767dc13b2cb7
 
 ARG CCS_NPM_VERSION=latest
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -14,6 +14,11 @@
 
 services:
   ccs:
+    # image uses Docker Compose env-var-with-default syntax so CI smoke tests can
+    # override via CCS_IMAGE=ghcr.io/.../ccs:<rc-tag> docker compose up -d while
+    # end users get the documented :latest by default. The Cloudflare Worker that
+    # serves this file at ccs.kaitran.ca validates that the default part starts
+    # with the canonical ghcr.io/kaitranntt/ccs prefix.
     image: ${CCS_IMAGE:-ghcr.io/kaitranntt/ccs:latest}
     restart: unless-stopped
     ports:
@@ -41,7 +46,7 @@ services:
             const http = require('http');
             let pending = 2; let ok = true;
             const check = (port) => http.get('http://127.0.0.1:'+port+'/', r => {
-              if (r.statusCode >= 500) ok = false;
+              if (r.statusCode >= 400) ok = false;
               if (--pending === 0) process.exit(ok ? 0 : 1);
             }).on('error', () => { ok = false; if (--pending === 0) process.exit(1); });
             check(3000); check(8317);

--- a/tests/docker/compose-parity.sh
+++ b/tests/docker/compose-parity.sh
@@ -34,12 +34,22 @@ image_name() {
   # Match lines like:
   #   image: ghcr.io/owner/repo:tag
   #   image: ${CCS_IMAGE:-ghcr.io/owner/repo:tag}
+  #   image: registry.local:5000/owner/repo:tag   (registry with port — must NOT truncate at first colon)
+  #
+  # Pipeline:
+  #   1. Extract raw image value (strip "image:" prefix and whitespace)
+  #   2. Strip ${VAR:-default} wrapper if present — must happen AFTER whitespace
+  #      removal so the anchor ^ matches at position 0
+  #   3. Strip only the trailing :tag suffix, preserving internal colons
+  #      (e.g. registry:5000/owner/repo keeps its port colon intact)
+  #
+  # Mirrors the extract_image_name() logic in .github/workflows/breaking-change-guard.yml.
   grep -A 50 "^  ${service}:" "$file" \
     | grep -m1 '^\s*image:' \
     | sed 's/.*image:\s*//' \
-    | sed 's/\${[^:-]*:-\([^}]*\)}/\1/' \
-    | sed 's/:.*//' \
-    | tr -d ' '
+    | tr -d ' ' \
+    | sed -E 's/^\$\{[A-Za-z_][A-Za-z0-9_]*:-//; s/\}$//' \
+    | sed 's|:[^:/]*$||'
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/docker/image-size-logic.test.sh
+++ b/tests/docker/image-size-logic.test.sh
@@ -202,6 +202,58 @@ make_mock_docker_platform ""
 run_platform_test "--platform: fail loudly when size output is empty (REV5 guard)" 1 "209715200"
 
 # ------------------------------------------------------------------
+# compose-parity image_name() regression — M5 guard
+#
+# Verifies the sed pipeline in tests/docker/compose-parity.sh correctly
+# strips only the trailing :tag and does NOT truncate at the first colon
+# (which would break registry:port/owner/repo references).
+# ------------------------------------------------------------------
+echo ""
+echo "Running compose-parity image_name() regex tests..."
+echo ""
+
+# Inline the updated image_name() logic from compose-parity.sh so these tests
+# run without depending on a compose file on disk.
+_image_name_from_raw() {
+  local raw="$1"
+  printf '%s' "$raw" \
+    | sed -E 's/^\$\{[A-Za-z_][A-Za-z0-9_]*:-//; s/\}$//' \
+    | sed 's|:[^:/]*$||' \
+    | tr -d ' '
+}
+
+run_image_name_test() {
+  local name="$1" input="$2" expected="$3"
+  local got
+  got=$(_image_name_from_raw "$input")
+  if [[ "$got" == "$expected" ]]; then
+    echo "[OK] ${name}"
+    (( PASS++ )) || true
+  else
+    echo "[X] ${name}: expected='${expected}' got='${got}'"
+    (( FAIL++ )) || true
+  fi
+}
+
+# Plain image reference — tag stripped
+run_image_name_test \
+  "plain image: strip :tag" \
+  "ghcr.io/kaitranntt/ccs:latest" \
+  "ghcr.io/kaitranntt/ccs"
+
+# Env-var-with-default syntax — wrapper stripped, then tag stripped
+run_image_name_test \
+  "env-var default: strip wrapper and :tag" \
+  '${CCS_IMAGE:-ghcr.io/kaitranntt/ccs:latest}' \
+  "ghcr.io/kaitranntt/ccs"
+
+# Registry with port — internal colon preserved, only :tag stripped
+run_image_name_test \
+  "registry:port/owner/repo:tag — preserve internal colon" \
+  "registry.local:5000/owner/repo:tag" \
+  "registry.local:5000/owner/repo"
+
+# ------------------------------------------------------------------
 # Summary
 # ------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Final-review critical and high fixes for umbrella PR #1261 (loop 8).

- **H1** — Healthcheck threshold tightened from `>= 500` to `>= 400`: a 404 on `/` is not healthy
- **H2** — `eceasy/cli-proxy-api` base image pinned by manifest-list digest for reproducible builds; apk package pinning noted as known limitation
- **M1/M2** — `breaking-change-guard.yml`: replace diff-based ccs-net check with positive assertion (catches rename+removal); add `hostname:` override guard (hostname override silently changes Docker DNS name even when service key stays `ccs`)
- **M5** — `compose-parity.sh` `image_name()`: fix `sed 's/:.*//'` → `sed 's|:[^:/]*$||'` so `registry:port/owner/repo:tag` is parsed correctly; move `tr -d ' '` before wrapper-strip sed so `^` anchor matches; mirrors `extract_image_name()` in breaking-change-guard.yml
- **C1** — Document `${CCS_IMAGE:-...}` env-var-with-default contract above the image line in compose.yaml (no compose.yaml logic change)

## Tests

- `bash tests/docker/compose-parity.sh` — all checks pass
- `bash tests/docker/image-size-logic.test.sh` — 14/14 pass (includes 3 new `image_name()` regression cases)
- `bun run validate` — 1974 pass, 0 fail

## Notes

- C1 (Worker validation) is handled by a parallel agent in ccs-landing; this PR adds the compose.yaml comment documenting the contract
- Do NOT merge — targets umbrella `kai/feat/1251-docker-zero-install-ux`