### PR TITLE
ci(pr-agent): disable ticket analysis to prevent sub-issue crash

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -16,7 +16,13 @@ require_estimate_effort_to_review = true
 require_can_be_split_review = true
 require_security_review = true
 require_todo_scan = true
-require_ticket_analysis_review = true
+# Ticket analysis disabled: PR-Agent's fetch_sub_issues crashes with an
+# unguarded `.get()` on a null GraphQL response when the PR body references
+# numeric PR shortcodes (e.g. "see #1257") — GraphQL `repository.issue(number)`
+# returns null when the number is a PR, not an issue, and pr-agent
+# (github_provider.py:1048) does not handle that. Re-enable once upstream
+# adds the None guard.
+require_ticket_analysis_review = false
 publish_output_no_suggestions = true
 persistent_comment = true
 num_max_findings = 10


### PR DESCRIPTION
Fixes the failing PR-Agent Review on umbrella #1261.

## Root cause
PR-Agent's `fetch_sub_issues` (github_provider.py:1048) calls `.get()` on a null GraphQL response. The crash triggers when the PR body cites a PR number as a shortcode (e.g. `#1257`) — GraphQL `repository.issue(number: 1257)` returns `null` because #1257 is a PR not an issue, and pr-agent doesn't handle the null.

The umbrella PR body references many merged loop-fix PR numbers, which guarantees the crash.

## Fix
Set `require_ticket_analysis_review = false` in `.pr_agent.toml`. Other review sections (security, score, tests, todo scan, can-be-split) stay enabled.

## Test plan
- [x] One-line config change, no code touched
- [ ] PR-Agent re-runs on this PR with ticket analysis off; should not crash