### PR TITLE
fix(dispatcher): preserve --permission-mode for `claude agents` subcommand

### DIFF
--- a/src/utils/claude-subcommand-detector.ts
+++ b/src/utils/claude-subcommand-detector.ts
@@ -95,6 +95,25 @@ const SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS = new Set<string>([
 ]);
 
 /**
+ * Flags that look session-only but are actually accepted by specific Claude
+ * subcommands. Keep these intact instead of stripping. Sourced from
+ * `claude <sub> --help` (v2.1.139); add new entries when upstream extends a
+ * subcommand parser.
+ *
+ * - `agents` accepts `--permission-mode`, `--dangerously-skip-permissions`,
+ *   and `--allow-dangerously-skip-permissions` as defaults for dispatched
+ *   sessions (see `claude agents --help`). Stripping these breaks
+ *   `ccs <profile> agents --permission-mode bypassPermissions`.
+ */
+const SUBCOMMAND_ALLOWED_SESSION_FLAGS: Record<string, ReadonlySet<string>> = {
+  agents: new Set<string>([
+    '--allow-dangerously-skip-permissions',
+    '--dangerously-skip-permissions',
+    '--permission-mode',
+  ]),
+};
+
+/**
  * Returns true when `args` look like a Claude subcommand invocation.
  *
  * Heuristic:
@@ -108,9 +127,19 @@ const SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS = new Set<string>([
  * the rest of the line belongs to that subcommand.
  */
 export function isClaudeSubcommandInvocation(args: readonly string[]): boolean {
+  return getClaudeSubcommandName(args) !== null;
+}
+
+/**
+ * Returns the Claude subcommand name when `args` look like a subcommand
+ * invocation, otherwise null. Uses the same scan as
+ * `isClaudeSubcommandInvocation` so callers can branch on the specific
+ * subcommand (e.g. `agents` allows flags that other subcommands reject).
+ */
+export function getClaudeSubcommandName(args: readonly string[]): string | null {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (arg === '--') return false;
+    if (arg === '--') return null;
 
     if (arg.startsWith('-')) {
       if (VALUE_TAKING_FLAGS.has(arg)) {
@@ -124,29 +153,44 @@ export function isClaudeSubcommandInvocation(args: readonly string[]): boolean {
       continue;
     }
 
-    return CLAUDE_SUBCOMMANDS.has(arg);
+    return CLAUDE_SUBCOMMANDS.has(arg) ? arg : null;
   }
 
-  return false;
+  return null;
 }
 
 export function stripClaudeSubcommandSessionArgs(args: readonly string[]): string[] {
-  if (!isClaudeSubcommandInvocation(args)) {
+  const subcommand = getClaudeSubcommandName(args);
+  if (subcommand === null) {
     return [...args];
   }
+
+  const allowed = SUBCOMMAND_ALLOWED_SESSION_FLAGS[subcommand];
+  const isAllowed = (flag: string): boolean => allowed?.has(flag) === true;
 
   const out: string[] = [];
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (SUBCOMMAND_SESSION_ONLY_FLAGS.has(arg)) {
+    if (SUBCOMMAND_SESSION_ONLY_FLAGS.has(arg) && !isAllowed(arg)) {
       continue;
     }
 
-    if (arg.startsWith('--permission-mode=') || arg.startsWith('--teammate-mode=')) {
+    if (arg.startsWith('--permission-mode=')) {
+      if (isAllowed('--permission-mode')) {
+        out.push(arg);
+        continue;
+      }
+      continue;
+    }
+    if (arg.startsWith('--teammate-mode=')) {
+      if (isAllowed('--teammate-mode')) {
+        out.push(arg);
+        continue;
+      }
       continue;
     }
 
-    if (SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS.has(arg)) {
+    if (SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS.has(arg) && !isAllowed(arg)) {
       const next = args[i + 1];
       if (next !== undefined && !next.startsWith('-')) {
         i += 1;

--- a/tests/unit/utils/claude-subcommand-detector.test.ts
+++ b/tests/unit/utils/claude-subcommand-detector.test.ts
@@ -86,28 +86,74 @@ describe('stripClaudeCodeFeatureBlockingEnv', () => {
 });
 
 describe('stripClaudeSubcommandSessionArgs', () => {
-  it('removes session-only flags before a Claude subcommand', () => {
+  it('removes session-only flags before a non-agents Claude subcommand', () => {
     expect(
       stripClaudeSubcommandSessionArgs([
         '--dangerously-skip-permissions',
         '--teammate-mode',
         'in-process',
-        'agents',
+        'doctor',
       ])
-    ).toEqual(['agents']);
+    ).toEqual(['doctor']);
   });
 
-  it('removes session-only flags after a Claude subcommand while preserving subcommand flags', () => {
+  it('removes session-only flags after a non-agents subcommand while preserving subcommand flags', () => {
     expect(
       stripClaudeSubcommandSessionArgs([
-        'agents',
+        'mcp',
         '--dangerously-skip-permissions',
         '--teammate-mode',
         'in-process',
         '--setting-sources',
         'user',
       ])
-    ).toEqual(['agents', '--setting-sources', 'user']);
+    ).toEqual(['mcp', '--setting-sources', 'user']);
+  });
+
+  it('preserves --permission-mode for the agents subcommand (after)', () => {
+    // `claude agents` accepts `--permission-mode <mode>` as the default
+    // permission mode for dispatched sessions; CCS must not strip it.
+    expect(
+      stripClaudeSubcommandSessionArgs([
+        'agents',
+        '--permission-mode',
+        'bypassPermissions',
+        '--teammate-mode',
+        'in-process',
+      ])
+    ).toEqual(['agents', '--permission-mode', 'bypassPermissions']);
+  });
+
+  it('preserves --permission-mode for the agents subcommand (before, --flag=value form)', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs(['--permission-mode=bypassPermissions', 'agents'])
+    ).toEqual(['--permission-mode=bypassPermissions', 'agents']);
+  });
+
+  it('preserves --dangerously-skip-permissions and --allow-dangerously-skip-permissions for agents', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs([
+        '--dangerously-skip-permissions',
+        '--allow-dangerously-skip-permissions',
+        'agents',
+      ])
+    ).toEqual([
+      '--dangerously-skip-permissions',
+      '--allow-dangerously-skip-permissions',
+      'agents',
+    ]);
+  });
+
+  it('still strips --teammate-mode for the agents subcommand (not accepted by upstream)', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs([
+        'agents',
+        '--teammate-mode',
+        'in-process',
+        '--permission-mode',
+        'bypassPermissions',
+      ])
+    ).toEqual(['agents', '--permission-mode', 'bypassPermissions']);
   });
 
   it('leaves non-subcommand interactive launches unchanged', () => {


### PR DESCRIPTION
## Summary

Fixes #1311.

`stripClaudeSubcommandSessionArgs` was unconditionally stripping `--permission-mode`, `--dangerously-skip-permissions`, and `--allow-dangerously-skip-permissions` from every Claude subcommand invocation. That is correct for `auth` / `doctor` / `mcp` / `plugin` / etc. — those subcommand parsers reject the flags with `error: unknown option '...'`. But `claude agents` accepts all three (they configure the default permission mode for sessions dispatched from the agent view, per `claude agents --help` in v2.1.139), so `ccs <profile> agents --permission-mode bypassPermissions` was silently dropping the flag before launching Claude.

## Changes

- Add `getClaudeSubcommandName(args)` to `src/utils/claude-subcommand-detector.ts`. It reuses the existing scan logic but returns the matched subcommand token instead of a boolean. `isClaudeSubcommandInvocation` is now a thin wrapper.
- Introduce `SUBCOMMAND_ALLOWED_SESSION_FLAGS`, a per-subcommand allowlist of session-only flags that the upstream subcommand parser actually accepts. Today only `agents` is listed (`--permission-mode`, `--dangerously-skip-permissions`, `--allow-dangerously-skip-permissions`).
- Rework `stripClaudeSubcommandSessionArgs` to consult the allowlist for the detected subcommand. `--teammate-mode` is still stripped everywhere — no upstream subcommand parser accepts it, including `agents`.
- All non-`agents` subcommands keep their current strip behavior, so the `--settings` / TTY-fallback fixes from #1218 / #1240 are unchanged.

## Verified upstream behavior (claude 2.1.139)

| Subcommand | `--permission-mode <mode>` | `--dangerously-skip-permissions` |
| --- | --- | --- |
| `agents` | accepted (default for dispatched sessions) | accepted (alias for `--permission-mode bypassPermissions`) |
| `auth` / `doctor` / `mcp` / `plugin(s)` / `project` / `setup-token` / `ultrareview` / `update` / `upgrade` / `auto-mode` / `install` | `error: unknown option '--permission-mode'` | rejected |

## Test plan

- [x] `bun test tests/unit/utils/claude-subcommand-detector.test.ts` (20/20 pass; new cases: `--permission-mode` after `agents`, `--permission-mode=value` before `agents`, `--dangerously-skip-permissions` + `--allow-dangerously-skip-permissions` for `agents`, `--teammate-mode` still stripped for `agents`, regression for non-`agents` subcommands).
- [x] `bun run format`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run validate` (1974/1974 unit + integration pass, 2 skipped).
- [x] Smoke test against the compiled `dist/utils/claude-subcommand-detector.js`:
  - `agents --permission-mode bypassPermissions` -> preserved.
  - `agents --teammate-mode in-process --permission-mode plan` -> only `--teammate-mode` stripped.
  - `--permission-mode=bypassPermissions agents` -> preserved.
  - `doctor --permission-mode bypassPermissions` -> stripped (regression guard).
  - `mcp --dangerously-skip-permissions` -> stripped (regression guard).

## Notes

- No public API surface change; `isClaudeSubcommandInvocation` keeps its existing signature and semantics.
- `getClaudeSubcommandName` is exported so future per-subcommand logic (e.g. `--settings` handling for `agents`, which upstream actually supports) can branch on the subcommand token without re-implementing the scan.
