### PR TITLE
fix(dispatcher): preserve --permission-mode for `claude agents` subcommand

### DIFF
--- a/src/utils/claude-subcommand-detector.ts
+++ b/src/utils/claude-subcommand-detector.ts
@@ -95,6 +95,25 @@ const SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS = new Set<string>([
 ]);
 
 /**
+ * Flags that look session-only but are actually accepted by specific Claude
+ * subcommands. Keep these intact instead of stripping. Sourced from
+ * `claude <sub> --help` (v2.1.139); add new entries when upstream extends a
+ * subcommand parser.
+ *
+ * - `agents` accepts `--permission-mode`, `--dangerously-skip-permissions`,
+ *   and `--allow-dangerously-skip-permissions` as defaults for dispatched
+ *   sessions (see `claude agents --help`). Stripping these breaks
+ *   `ccs <profile> agents --permission-mode bypassPermissions`.
+ */
+const SUBCOMMAND_ALLOWED_SESSION_FLAGS: Record<string, ReadonlySet<string>> = {
+  agents: new Set<string>([
+    '--allow-dangerously-skip-permissions',
+    '--dangerously-skip-permissions',
+    '--permission-mode',
+  ]),
+};
+
+/**
  * Returns true when `args` look like a Claude subcommand invocation.
  *
  * Heuristic:
@@ -108,9 +127,19 @@ const SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS = new Set<string>([
  * the rest of the line belongs to that subcommand.
  */
 export function isClaudeSubcommandInvocation(args: readonly string[]): boolean {
+  return getClaudeSubcommandName(args) !== null;
+}
+
+/**
+ * Returns the Claude subcommand name when `args` look like a subcommand
+ * invocation, otherwise null. Uses the same scan as
+ * `isClaudeSubcommandInvocation` so callers can branch on the specific
+ * subcommand (e.g. `agents` allows flags that other subcommands reject).
+ */
+export function getClaudeSubcommandName(args: readonly string[]): string | null {
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (arg === '--') return false;
+    if (arg === '--') return null;
 
     if (arg.startsWith('-')) {
       if (VALUE_TAKING_FLAGS.has(arg)) {
@@ -124,29 +153,44 @@ export function isClaudeSubcommandInvocation(args: readonly string[]): boolean {
       continue;
     }
 
-    return CLAUDE_SUBCOMMANDS.has(arg);
+    return CLAUDE_SUBCOMMANDS.has(arg) ? arg : null;
   }
 
-  return false;
+  return null;
 }
 
 export function stripClaudeSubcommandSessionArgs(args: readonly string[]): string[] {
-  if (!isClaudeSubcommandInvocation(args)) {
+  const subcommand = getClaudeSubcommandName(args);
+  if (subcommand === null) {
     return [...args];
   }
+
+  const allowed = SUBCOMMAND_ALLOWED_SESSION_FLAGS[subcommand];
+  const isAllowed = (flag: string): boolean => allowed?.has(flag) === true;
 
   const out: string[] = [];
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
-    if (SUBCOMMAND_SESSION_ONLY_FLAGS.has(arg)) {
+    if (SUBCOMMAND_SESSION_ONLY_FLAGS.has(arg) && !isAllowed(arg)) {
       continue;
     }
 
-    if (arg.startsWith('--permission-mode=') || arg.startsWith('--teammate-mode=')) {
+    if (arg.startsWith('--permission-mode=')) {
+      if (isAllowed('--permission-mode')) {
+        out.push(arg);
+        continue;
+      }
+      continue;
+    }
+    if (arg.startsWith('--teammate-mode=')) {
+      if (isAllowed('--teammate-mode')) {
+        out.push(arg);
+        continue;
+      }
       continue;
     }
 
-    if (SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS.has(arg)) {
+    if (SUBCOMMAND_SESSION_ONLY_VALUE_FLAGS.has(arg) && !isAllowed(arg)) {
       const next = args[i + 1];
       if (next !== undefined && !next.startsWith('-')) {
         i += 1;

--- a/tests/unit/utils/claude-subcommand-detector.test.ts
+++ b/tests/unit/utils/claude-subcommand-detector.test.ts
@@ -86,28 +86,74 @@ describe('stripClaudeCodeFeatureBlockingEnv', () => {
 });
 
 describe('stripClaudeSubcommandSessionArgs', () => {
-  it('removes session-only flags before a Claude subcommand', () => {
+  it('removes session-only flags before a non-agents Claude subcommand', () => {
     expect(
       stripClaudeSubcommandSessionArgs([
         '--dangerously-skip-permissions',
         '--teammate-mode',
         'in-process',
-        'agents',
+        'doctor',
       ])
-    ).toEqual(['agents']);
+    ).toEqual(['doctor']);
   });
 
-  it('removes session-only flags after a Claude subcommand while preserving subcommand flags', () => {
+  it('removes session-only flags after a non-agents subcommand while preserving subcommand flags', () => {
     expect(
       stripClaudeSubcommandSessionArgs([
-        'agents',
+        'mcp',
         '--dangerously-skip-permissions',
         '--teammate-mode',
         'in-process',
         '--setting-sources',
         'user',
       ])
-    ).toEqual(['agents', '--setting-sources', 'user']);
+    ).toEqual(['mcp', '--setting-sources', 'user']);
+  });
+
+  it('preserves --permission-mode for the agents subcommand (after)', () => {
+    // `claude agents` accepts `--permission-mode <mode>` as the default
+    // permission mode for dispatched sessions; CCS must not strip it.
+    expect(
+      stripClaudeSubcommandSessionArgs([
+        'agents',
+        '--permission-mode',
+        'bypassPermissions',
+        '--teammate-mode',
+        'in-process',
+      ])
+    ).toEqual(['agents', '--permission-mode', 'bypassPermissions']);
+  });
+
+  it('preserves --permission-mode for the agents subcommand (before, --flag=value form)', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs(['--permission-mode=bypassPermissions', 'agents'])
+    ).toEqual(['--permission-mode=bypassPermissions', 'agents']);
+  });
+
+  it('preserves --dangerously-skip-permissions and --allow-dangerously-skip-permissions for agents', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs([
+        '--dangerously-skip-permissions',
+        '--allow-dangerously-skip-permissions',
+        'agents',
+      ])
+    ).toEqual([
+      '--dangerously-skip-permissions',
+      '--allow-dangerously-skip-permissions',
+      'agents',
+    ]);
+  });
+
+  it('still strips --teammate-mode for the agents subcommand (not accepted by upstream)', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs([
+        'agents',
+        '--teammate-mode',
+        'in-process',
+        '--permission-mode',
+        'bypassPermissions',
+      ])
+    ).toEqual(['agents', '--permission-mode', 'bypassPermissions']);
   });
 
   it('leaves non-subcommand interactive launches unchanged', () => {

--- a/tests/unit/utils/claude-subcommand-detector.test.ts
+++ b/tests/unit/utils/claude-subcommand-detector.test.ts
@@ -110,6 +110,15 @@ describe('stripClaudeSubcommandSessionArgs', () => {
     ).toEqual(['mcp', '--setting-sources', 'user']);
   });
 
+  it('removes --permission-mode for non-agents subcommands', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs(['--permission-mode', 'bypassPermissions', 'doctor'])
+    ).toEqual(['doctor']);
+    expect(stripClaudeSubcommandSessionArgs(['doctor', '--permission-mode=acceptEdits'])).toEqual([
+      'doctor',
+    ]);
+  });
+
   it('preserves --permission-mode for the agents subcommand (after)', () => {
     // `claude agents` accepts `--permission-mode <mode>` as the default
     // permission mode for dispatched sessions; CCS must not strip it.
@@ -122,6 +131,12 @@ describe('stripClaudeSubcommandSessionArgs', () => {
         'in-process',
       ])
     ).toEqual(['agents', '--permission-mode', 'bypassPermissions']);
+  });
+
+  it('preserves --permission-mode for the agents subcommand (before, separate value form)', () => {
+    expect(
+      stripClaudeSubcommandSessionArgs(['--permission-mode', 'bypassPermissions', 'agents'])
+    ).toEqual(['--permission-mode', 'bypassPermissions', 'agents']);
   });
 
   it('preserves --permission-mode for the agents subcommand (before, --flag=value form)', () => {


### PR DESCRIPTION
Hi maintainers,

First of all, thanks for CCS — I use it daily and it's been a real quality-of-life upgrade.

I ran into a small bug while trying to open the agent view with bypass permissions:

```bash
ccs <profile> agents --permission-mode bypassPermissions
```

The agent view opens, but the `--permission-mode bypassPermissions` part doesn't actually make it through to Claude — CCS strips it before launching `claude agents`, so dispatched sessions still come up with the previous default. The same happens for `--dangerously-skip-permissions` and `--allow-dangerously-skip-permissions`.

After digging a bit, I found that the strip is there for a good reason — most Claude subcommands (`auth`, `doctor`, `mcp`, …) reject those flags with `unknown option`, so CCS pre-emptively removes them. The one exception is `claude agents`, which actually accepts and uses all three to set the default permission mode for sessions dispatched from the agent view. So the fix is just to teach the strip about that one subcommand and leave everything else alone.

This PR does exactly that, with a small per-subcommand allowlist and a helper that reports which subcommand is being invoked. The earlier `--settings` / TTY-fallback fixes from #1218 / #1240 are untouched.

Filed the matching report at #1311. Happy to adjust the shape, naming, or scope however you'd prefer — just let me know. Thanks again for the review!
