### PR TITLE
Add Tuning Engines provider

### DIFF
--- a/docs/openai-compatible-providers.md
+++ b/docs/openai-compatible-providers.md
@@ -6,6 +6,7 @@ your API profile points at an OpenAI-compatible chat completions endpoint.
 This is useful for providers such as:
 
 - Hugging Face Inference Providers
+- Tuning Engines
 - OpenRouter
 - Ollama
 - llama.cpp servers
@@ -48,10 +49,18 @@ Create or reuse an API profile that points at an OpenAI-compatible endpoint:
 ccs api create --preset hf
 ```
 
+For Tuning Engines:
+
+```bash
+ccs api create --preset te
+```
+
 Then you can use the profile directly:
 
 ```bash
 ccs hf
+# or
+ccs te
 ```
 
 CCS detects that the profile is OpenAI-compatible and auto-routes Claude Code

--- a/src/shared/provider-preset-catalog.ts
+++ b/src/shared/provider-preset-catalog.ts
@@ -12,6 +12,7 @@ export const PROVIDER_PRESET_IDS = [
   'openrouter',
   'alibaba-coding-plan',
   'huggingface',
+  'tuningengines',
   'ollama',
   'llamacpp',
   'anthropic',
@@ -61,6 +62,8 @@ export const PROVIDER_PRESET_ALIASES: Readonly<Record<string, ProviderPresetId>>
   alibaba: 'alibaba-coding-plan',
   acp: 'alibaba-coding-plan',
   hf: 'huggingface',
+  te: 'tuningengines',
+  tuning: 'tuningengines',
 });
 
 const RAW_PROVIDER_PRESET_DEFINITIONS: readonly ProviderPresetDefinition[] = [
@@ -152,6 +155,20 @@ const RAW_PROVIDER_PRESET_DEFINITIONS: readonly ProviderPresetDefinition[] = [
     requiresApiKey: true,
     defaultTarget: 'droid',
     badge: 'Router',
+  },
+  {
+    id: 'tuningengines',
+    name: 'Tuning Engines',
+    description: 'Governed OpenAI-compatible gateway for routed intelligence',
+    baseUrl: 'https://api.tuningengines.com/v1',
+    defaultProfileName: 'te',
+    defaultModel: 'llama-3.3-70b-fp8',
+    apiKeyPlaceholder: 'sk-te-...',
+    apiKeyHint: 'Create an inference key at app.tuningengines.com/inference/keys',
+    category: 'alternative',
+    requiresApiKey: true,
+    defaultTarget: 'droid',
+    badge: 'Governed gateway',
   },
   {
     id: 'glm',

--- a/tests/unit/api/provider-presets.test.ts
+++ b/tests/unit/api/provider-presets.test.ts
@@ -92,6 +92,19 @@ describe('provider-presets', () => {
     expect(isValidPresetId('hf')).toBe(true);
   });
 
+  it('resolves Tuning Engines preset metadata and aliases', () => {
+    const preset = getPresetById('tuningengines');
+    expect(preset?.id).toBe('tuningengines');
+    expect(preset?.baseUrl).toBe('https://api.tuningengines.com/v1');
+    expect(preset?.defaultProfileName).toBe('te');
+    expect(preset?.defaultModel).toBe('llama-3.3-70b-fp8');
+    expect(preset?.defaultTarget).toBe('droid');
+    expect(preset?.apiKeyPlaceholder).toBe('sk-te-...');
+    expect(getPresetById('te')?.id).toBe('tuningengines');
+    expect(getPresetById('tuning')?.id).toBe('tuningengines');
+    expect(isValidPresetId('te')).toBe(true);
+  });
+
   it('uses OpenRouter v1 as the OpenAI-compatible API root', () => {
     const preset = getPresetById('openrouter');
     expect(preset?.baseUrl).toBe('https://openrouter.ai/api/v1');


### PR DESCRIPTION
Adds Tuning Engines as an OpenAI-compatible provider or documented upstream option.\n\nThis includes the Tuning Engines API base URL, key placeholder, and starter model IDs where the project exposes provider presets, examples, or configuration docs.\n\nValidation:\n- git diff --check\n- bun test tests/unit/api/provider-presets.test.ts