### PR TITLE
chore(ci): clarify Docker curl retry intent

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -376,6 +376,8 @@ jobs:
 
       - name: Probe dashboard port 3000
         run: |
+          # Single-shot probe by design: healthcheck and network-contract already
+          # handle readiness waits, and curl --retry would not retry HTTP errors.
           HTTP_CODE=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 http://127.0.0.1:13000/ || echo "000")
           if [[ "${HTTP_CODE}" == "000" ]]; then
             echo "[X] Could not reach dashboard on :3000 (connection failed)"
@@ -385,6 +387,8 @@ jobs:
 
       - name: Probe CLIProxy port 8317
         run: |
+          # Single-shot probe by design: healthcheck and network-contract already
+          # handle readiness waits, and curl --retry would not retry HTTP errors.
           HTTP_CODE=$(curl -o /dev/null -s -w "%{http_code}" --max-time 10 http://127.0.0.1:18317/ || echo "000")
           if [[ "${HTTP_CODE}" == "000" ]]; then
             echo "[X] Could not reach CLIProxy on :8317 (connection failed)"

--- a/.github/workflows/smoke-test-compose-url.yml
+++ b/.github/workflows/smoke-test-compose-url.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Download compose from canonical URL
         run: |
+          # Keep this as a plain fetch. curl --retry only covers transport-like
+          # failures by default and can overstate HTTP 5xx resilience.
           curl -fsSL https://ccs.kaitran.ca/docker-compose.yaml -o /tmp/ccs-compose.yaml
           echo "--- downloaded compose ---"
           cat /tmp/ccs-compose.yaml


### PR DESCRIPTION
## Summary
- document why the Docker smoke-test curl probes stay single-shot
- document why the canonical compose download avoids cosmetic `curl --retry`
- keep Docker workflow behavior unchanged while preventing misleading retry semantics from returning

Closes #1265

## Validation
- `bun -e "const yaml=require('js-yaml'); for (const f of ['.github/workflows/docker-release.yml','.github/workflows/smoke-test-compose-url.yml']) { yaml.load(require('fs').readFileSync(f,'utf8')); console.log('[OK] YAML parsed '+f); }"`
- `rg -n -- "^[[:space:]]*[^#[:space:]].*curl .*--retry|^[[:space:]]*[^#[:space:]].*--retry .*curl" .github/workflows/docker-release.yml .github/workflows/smoke-test-compose-url.yml || true`
- `bun run format`
- `bun run lint:fix`
- `bun run validate`
- `bun run validate:ci-parity`