### PR TITLE
chore(docker): skip ccs postinstall in legacy image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -81,7 +81,7 @@ COPY --from=build /app/LICENSE ./LICENSE
 # Install AI CLI tools (using latest - pin versions in production if needed)
 # These are optional tools for docker exec usage
 RUN npm install -g @google/gemini-cli @vibe-kit/grok-cli @anthropic-ai/claude-code \
-  && npm install -g @kaitranntt/ccs --force \
+  && npm install -g @kaitranntt/ccs --force --ignore-scripts \
   && npm cache clean --force \
   && su -s /bin/bash node -c 'curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path' \
   && ln -sf /app/dist/ccs.js /usr/local/bin/ccs

--- a/tests/unit/docker/dockerfile-lifecycle-scripts.test.ts
+++ b/tests/unit/docker/dockerfile-lifecycle-scripts.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'bun:test';
+
+const dockerfile = readFileSync('docker/Dockerfile', 'utf8');
+const entrypoint = readFileSync('docker/entrypoint.sh', 'utf8');
+
+describe('legacy Dockerfile lifecycle scripts', () => {
+  it('skips package lifecycle scripts for every CCS install during image build', () => {
+    const ccsInstallCommands = dockerfile
+      .split('\n')
+      .filter((line) => line.includes('npm install') && line.includes('@kaitranntt/ccs'));
+
+    expect(ccsInstallCommands.length).toBeGreaterThan(0);
+    for (const command of ccsInstallCommands) {
+      expect(command).toContain('--ignore-scripts');
+    }
+  });
+
+  it('creates the runtime CCS home directory from the entrypoint instead', () => {
+    expect(entrypoint).toContain('ccs_home_dir="${CCS_HOME_DIR:-/home/node/.ccs}"');
+    expect(entrypoint).toContain('mkdir -p "$ccs_home_dir"');
+  });
+});


### PR DESCRIPTION
## Summary
- add `--ignore-scripts` to the legacy Dockerfile global `@kaitranntt/ccs` install
- add a focused static Dockerfile lifecycle-script regression test
- verify runtime state is handled by the Docker entrypoint and RecoveryManager rather than build-time postinstall

Closes #1264

## Validation
- `bun test tests/unit/docker/dockerfile-lifecycle-scripts.test.ts`
- `bun run format`
- `bun run validate`
- pre-push fast gate: `tsc --noEmit`, `eslint src/`, `prettier --check src/`, `node scripts/run-test-bucket.js fast`

## Docs impact
Docs impact: none
Action: no update needed - internal Docker image build hygiene only; no user-facing command, config, runtime workflow, or documented install behavior changes.