### PR TITLE
fix: treat remote-control as a Claude subcommand

### DIFF
--- a/src/utils/claude-subcommand-detector.ts
+++ b/src/utils/claude-subcommand-detector.ts
@@ -34,6 +34,7 @@ const CLAUDE_SUBCOMMANDS = new Set<string>([
   'plugin',
   'plugins',
   'project',
+  'remote-control',
   'setup-token',
   'ultrareview',
   'update',

--- a/tests/unit/utils/claude-subcommand-detector.test.ts
+++ b/tests/unit/utils/claude-subcommand-detector.test.ts
@@ -26,6 +26,7 @@ describe('isClaudeSubcommandInvocation', () => {
       'plugin',
       'plugins',
       'project',
+      'remote-control',
       'setup-token',
       'ultrareview',
       'update',
@@ -117,6 +118,9 @@ describe('stripClaudeSubcommandSessionArgs', () => {
     expect(stripClaudeSubcommandSessionArgs(['doctor', '--permission-mode=acceptEdits'])).toEqual([
       'doctor',
     ]);
+    expect(
+      stripClaudeSubcommandSessionArgs(['remote-control', '--permission-mode', 'bypassPermissions'])
+    ).toEqual(['remote-control']);
   });
 
   it('preserves --permission-mode for the agents subcommand (after)', () => {
@@ -152,11 +156,7 @@ describe('stripClaudeSubcommandSessionArgs', () => {
         '--allow-dangerously-skip-permissions',
         'agents',
       ])
-    ).toEqual([
-      '--dangerously-skip-permissions',
-      '--allow-dangerously-skip-permissions',
-      'agents',
-    ]);
+    ).toEqual(['--dangerously-skip-permissions', '--allow-dangerously-skip-permissions', 'agents']);
   });
 
   it('still strips --teammate-mode for the agents subcommand (not accepted by upstream)', () => {
@@ -188,14 +188,17 @@ describe('subcommand passthrough — injectors short-circuit', () => {
     expect(appendThirdPartyWebSearchToolArgs(['agents'])).toEqual(['agents']);
     expect(appendThirdPartyWebSearchToolArgs(['doctor'])).toEqual(['doctor']);
     expect(appendThirdPartyWebSearchToolArgs(['mcp', 'list'])).toEqual(['mcp', 'list']);
+    expect(appendThirdPartyWebSearchToolArgs(['remote-control'])).toEqual(['remote-control']);
   });
 
   it('appendThirdPartyImageAnalysisToolArgs returns args unchanged for subcommand invocations', () => {
     expect(appendThirdPartyImageAnalysisToolArgs(['agents'])).toEqual(['agents']);
+    expect(appendThirdPartyImageAnalysisToolArgs(['remote-control'])).toEqual(['remote-control']);
   });
 
   it('appendBrowserToolArgs returns args unchanged for subcommand invocations', () => {
     expect(appendBrowserToolArgs(['agents'])).toEqual(['agents']);
+    expect(appendBrowserToolArgs(['remote-control'])).toEqual(['remote-control']);
   });
 
   it('injectors still inject for non-subcommand interactive launches', () => {


### PR DESCRIPTION
Closes #1306

## Summary
- classify Claude Code `remote-control` as a Claude subcommand
- prevent WebSearch/image-analysis/browser steering from injecting `--append-system-prompt` into `remote-control`
- keep native Codex passthrough behavior unchanged

## Validation
- `bun test tests/unit/utils/claude-subcommand-detector.test.ts`
- `bun test ./src/dispatcher/__tests__/cli-argument-parser-bootstrap.test.ts`
- pre-push fast gate: `tsc --noEmit`, `eslint src/`, `prettier --check src/`, `node scripts/run-test-bucket.js fast`

Docs impact: none
Action: no update needed — existing subcommand passthrough bugfix, no new command surface.