### PR TITLE
fix(cliproxy): disable spoofable default bg keepalive probe

### DIFF
--- a/src/cliproxy/executor/session-bridge.ts
+++ b/src/cliproxy/executor/session-bridge.ts
@@ -275,12 +275,13 @@ export function setupCleanupHandlers(
     }
   };
 
-  const backgroundProbe =
-    keepAliveOptions.hasBackgroundWorkerUsingBaseUrl ?? hasClaudeBackgroundWorkerUsingBaseUrl;
+  // Security hardening: only allow keepalive when caller provides an explicit,
+  // trusted detector. Falling back to global process-list probing is spoofable.
+  const backgroundProbe = keepAliveOptions.hasBackgroundWorkerUsingBaseUrl;
 
   const startKeepAliveWatcher = (baseUrl: string) => {
     const timer = setInterval(() => {
-      if (backgroundProbe(baseUrl)) return;
+      if (backgroundProbe?.(baseUrl)) return;
       log('No Claude bg worker is using the session proxy; cleaning up');
       stopSessionResources();
       process.exit(0);
@@ -299,6 +300,7 @@ export function setupCleanupHandlers(
     const backgroundKeepAliveBaseUrl = keepAliveOptions.backgroundKeepAliveBaseUrl;
 
     if (
+      backgroundProbe &&
       shouldKeepSessionProxiesAlive({
         code,
         signal,


### PR DESCRIPTION
### Motivation
- Prevent a local attacker from spoofing Claude background-worker presence via global `ps` substring matches and thereby keeping per-session proxies (including HTTPS tunnel that can inject auth) alive after Claude exits.

### Description
- Harden `setupCleanupHandlers` in `src/cliproxy/executor/session-bridge.ts` by removing the implicit fallback to the global `ps`-based detector and only permitting keepalive behavior when a trusted `hasBackgroundWorkerUsingBaseUrl` detector is explicitly provided by the caller, with a runtime guard so default behavior always cleans up on Claude exit.

### Testing
- Ran `bun test tests/unit/cliproxy/session-bridge-bg-keepalive.test.ts` which passed all 4 tests. 
- Ran type checking via `bun run typecheck` / `tsc --noEmit` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e1d89f2b48330bba3e78cf01361b4)