### PR TITLE
fix(cliproxy): sanitize local port before config regeneration

### DIFF
--- a/src/web-server/routes/proxy-routes.ts
+++ b/src/web-server/routes/proxy-routes.ts
@@ -155,8 +155,9 @@ router.put('/backend', (req: Request, res: Response) => {
     // Pre-flight read: check running state before acquiring write lock
     const currentConfig = loadOrCreateUnifiedConfig();
     const currentBackend = currentConfig.cliproxy?.backend ?? DEFAULT_BACKEND;
-    const localPort =
-      currentConfig.cliproxy_server?.local?.port ?? DEFAULT_CLIPROXY_SERVER_CONFIG.local.port;
+    const localPort = validatePort(
+      currentConfig.cliproxy_server?.local?.port ?? DEFAULT_CLIPROXY_SERVER_CONFIG.local.port
+    );
     if (currentBackend !== backend && isProxyRunning() && !force) {
       res.status(409).json({
         error: 'Proxy is running. Stop proxy first or use force=true to change backend.',


### PR DESCRIPTION
### Motivation
- Prevent unvalidated `cliproxy_server.local.port` from being used to construct CLIProxy config paths which could enable path traversal and overwrite arbitrary YAML files under the CCS home directory.

### Description
- Sanitize the local port by calling `validatePort(...)` when reading `cliproxy_server.local.port` from the unified config in the backend-switch flow in `src/web-server/routes/proxy-routes.ts` before passing it to `configNeedsRegeneration(...)` and `regenerateConfig(...)`.

### Testing
- Ran `bun run test:fast`, which completed with 1968 passed, 2 skipped, and 2 failing tests (the two failures are pre-existing/unrelated), and `tsc --noEmit` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e20477fc88330b90d06ae72acf2ee)