### PR TITLE
fix(codex-quota): prevent non-string feature labels from crashing dashboard tooltip

### DIFF
--- a/src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts
+++ b/src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts
@@ -342,6 +342,26 @@ describe('Codex Quota Fetcher', () => {
       expect(windows.find((w) => w.category === 'additional')).toBeUndefined();
     });
 
+    it('should coerce non-string additional limit_name values to fallback label', () => {
+      const response = {
+        additional_rate_limits: [
+          {
+            limit_name: { unexpected: true },
+            rate_limit: {
+              primary_window: { used_percent: 10, reset_after_seconds: 3600 },
+            },
+          },
+        ],
+      };
+
+      const windows = buildCodexQuotaWindows(response as never);
+
+      expect(windows).toHaveLength(1);
+      expect(windows[0].category).toBe('additional');
+      expect(windows[0].featureLabel).toBe('Additional');
+      expect(windows[0].label).toBe('Additional (Primary)');
+    });
+
     it('should accept camelCase additionalRateLimits and rateLimit fields', () => {
       const response = {
         additionalRateLimits: [

--- a/src/cliproxy/quota/quota-fetcher-codex.ts
+++ b/src/cliproxy/quota/quota-fetcher-codex.ts
@@ -380,7 +380,11 @@ function buildCodexQuotaWindows(payload: CodexUsageResponse): CodexQuotaWindow[]
       const entryRateLimit = entry.rate_limit || entry.rateLimit;
       if (!entryRateLimit) continue;
 
-      const featureLabel = entry.limit_name || entry.limitName || 'Additional';
+      const rawFeatureLabel = entry.limit_name ?? entry.limitName;
+      const featureLabel =
+        typeof rawFeatureLabel === 'string' && rawFeatureLabel.trim().length > 0
+          ? rawFeatureLabel.trim()
+          : 'Additional';
       addWindow(
         `${featureLabel} (Primary)`,
         entryRateLimit.primary_window || entryRateLimit.primaryWindow,

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -384,8 +384,8 @@ function getCodexWindowKindFromLabel(label: string): CodexWindowKind {
  *   "OmniReview"          -> "OmniReview"
  *   ""                    -> ""
  */
-export function prettifyCodexFeatureLabel(featureLabel: string): string {
-  const trimmed = (featureLabel || '').trim();
+export function prettifyCodexFeatureLabel(featureLabel: unknown): string {
+  const trimmed = typeof featureLabel === 'string' ? featureLabel.trim() : '';
   if (!trimmed) return '';
   const stripped = trimmed.replace(/^GPT-[\d.]+-Codex-/i, '');
   if (stripped !== trimmed && stripped.length > 0) {

--- a/ui/tests/unit/ui/lib/codex-quota-breakdown.test.ts
+++ b/ui/tests/unit/ui/lib/codex-quota-breakdown.test.ts
@@ -37,6 +37,11 @@ describe('prettifyCodexFeatureLabel', () => {
     expect(prettifyCodexFeatureLabel('   ')).toBe('');
     expect(prettifyCodexFeatureLabel('  GPT-5.3-Codex-Spark  ')).toBe('Codex Spark');
   });
+
+  it('returns empty string for non-string input', () => {
+    expect(prettifyCodexFeatureLabel({ label: 'Spark' })).toBe('');
+    expect(prettifyCodexFeatureLabel(123)).toBe('');
+  });
 });
 
 describe('getCodexWindowKind', () => {


### PR DESCRIPTION
### Motivation
- Upstream Codex quota responses can include non-string `limit_name`/`limitName` values that flowed into the UI and caused `TypeError` when `prettifyCodexFeatureLabel` called `.trim()` on a non-string.
- This produced a availability bug where a malformed provider response could break the dashboard quota tooltip until data was corrected or the page refreshed.

### Description
- Harden `prettifyCodexFeatureLabel` to accept `unknown` and only call `.trim()` when the value is a string, returning an empty string for non-string inputs (`ui/src/lib/utils.ts`).
- Sanitize `additional_rate_limits` `limit_name/limitName` when parsing Codex quota responses so non-string or blank values are coerced to the safe fallback label `"Additional"` (`src/cliproxy/quota/quota-fetcher-codex.ts`).
- Add unit tests covering non-string inputs in the UI helper and parser regression to ensure malformed provider data yields the fallback label (`ui/tests/unit/ui/lib/codex-quota-breakdown.test.ts` and `src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts`).

### Testing
- Ran the UI unit tests for the modified file with `bun run test:run tests/unit/ui/lib/codex-quota-breakdown.test.ts` (from `ui/`), and the test file passed (19 tests).
- Ran the codex quota parser unit tests with `bun test ./src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts` (from repo root), and the test file passed (33 tests).
- The added tests verify that `prettifyCodexFeatureLabel` returns `''` for non-string inputs and that the quota parser coerces non-string `limit_name` values to the fallback label `"Additional"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e20430d90833083b4455305c12599)