### PR TITLE
fix(dispatcher): also treat -p as non-subcommand short for --print

### DIFF
--- a/src/utils/claude-subcommand-detector.ts
+++ b/src/utils/claude-subcommand-detector.ts
@@ -144,7 +144,7 @@ export function getClaudeSubcommandName(args: readonly string[]): string | null 
     const arg = args[i];
     if (arg === '--') return null;
 
-    if (arg === '--print') return null;
+    if (arg === '--print' || arg === '-p') return null;
 
     if (arg.startsWith('-')) {
       if (VALUE_TAKING_FLAGS.has(arg)) {

--- a/tests/unit/utils/claude-subcommand-detector.test.ts
+++ b/tests/unit/utils/claude-subcommand-detector.test.ts
@@ -62,6 +62,14 @@ describe('isClaudeSubcommandInvocation', () => {
     expect(isClaudeSubcommandInvocation(['--print', 'doctor'])).toBe(false);
   });
 
+  it('treats -p (short form of --print) as non-subcommand — regression for #1341', () => {
+    // CCS uses -p in headless-executor; without this check the security bypass
+    // survived via the short flag form.
+    expect(isClaudeSubcommandInvocation(['-p', 'agents'])).toBe(false);
+    expect(isClaudeSubcommandInvocation(['-p', 'doctor'])).toBe(false);
+    expect(isClaudeSubcommandInvocation(['-p'])).toBe(false);
+  });
+
   it('handles --flag=value forms', () => {
     expect(isClaudeSubcommandInvocation(['--model=sonnet', 'agents'])).toBe(true);
   });
@@ -210,6 +218,12 @@ describe('subcommand passthrough — injectors short-circuit', () => {
 
   it('injectors still inject in --print prompt mode with subcommand-like prompt text', () => {
     const out = appendThirdPartyWebSearchToolArgs(['--print', 'agents']);
+    expect(out).toContain('--append-system-prompt');
+    expect(out).toContain('--disallowedTools');
+  });
+
+  it('injectors still inject in -p prompt mode — regression for #1341', () => {
+    const out = appendThirdPartyWebSearchToolArgs(['-p', 'agents']);
     expect(out).toContain('--append-system-prompt');
     expect(out).toContain('--disallowedTools');
   });


### PR DESCRIPTION
## Summary

Red-team follow-up to #1341. The original fix only guarded `--print` but Claude accepts `-p` as the short form of the same flag. CCS itself passes `-p` in `src/delegation/headless-executor.ts:265`, so the security bypass survived via the short flag form.

**Change:** `claude-subcommand-detector.ts` now returns `null` (non-subcommand) for both `--print` and `-p`.

## Regression tests added

- `['-p', 'agents']` → non-subcommand
- `['-p', 'doctor']` → non-subcommand
- `['-p']` alone → non-subcommand
- Injector short-circuit verification: `appendThirdPartyWebSearchToolArgs(['-p', 'agents'])` still injects args (not treated as passthrough)

All 26 subcommand detector tests pass locally; pre-push fast gate 2270/2270.