### PR TITLE
refactor(cliproxy): remove orphaned bg keepalive wiring

### DIFF
--- a/src/cliproxy/executor/claude-launcher.ts
+++ b/src/cliproxy/executor/claude-launcher.ts
@@ -163,9 +163,6 @@ export async function launchClaude(context: ClaudeLaunchContext): Promise<ChildP
     }
   }
 
-  const hasSessionProxy = Boolean(codexReasoningProxy || toolSanitizationProxy || httpsTunnel);
-  const backgroundKeepAliveBaseUrl = hasSessionProxy ? tracedEnv.ANTHROPIC_BASE_URL : undefined;
-
   // Wire cleanup handlers (process exit, SIGINT, SIGTERM, proxy teardown)
   setupCleanupHandlers(
     claude,
@@ -174,8 +171,7 @@ export async function launchClaude(context: ClaudeLaunchContext): Promise<ChildP
     codexReasoningProxy,
     toolSanitizationProxy,
     httpsTunnel,
-    verbose,
-    { backgroundKeepAliveBaseUrl }
+    verbose
   );
 
   return claude;

--- a/src/cliproxy/executor/session-bridge.ts
+++ b/src/cliproxy/executor/session-bridge.ts
@@ -8,7 +8,7 @@
  * - Startup lock coordination
  */
 
-import { ChildProcess, execFileSync } from 'child_process';
+import { ChildProcess } from 'child_process';
 import { info, warn } from '../../utils/ui';
 import { getInstalledCliproxyVersion } from '../binary-manager';
 import { CLIProxyBackend } from '../types';
@@ -31,70 +31,6 @@ export interface ProxySessionResult {
   sessionId?: string;
   proxy?: ChildProcess;
   shouldSpawn: boolean;
-}
-
-export interface SessionProxyKeepAliveOptions {
-  backgroundKeepAliveBaseUrl?: string;
-  keepAlivePollIntervalMs?: number;
-  hasBackgroundWorkerUsingBaseUrl?: (baseUrl: string) => boolean;
-}
-
-export interface ShouldKeepSessionProxiesAliveOptions {
-  code: number | null;
-  signal: NodeJS.Signals | null;
-  backgroundKeepAliveBaseUrl?: string;
-  hasBackgroundWorkerUsingBaseUrl: (baseUrl: string) => boolean;
-}
-
-const CLAUDE_BG_WORKER_ARGS = ['--bg-spare', '--bg-pty-host'] as const;
-
-export function hasClaudeBackgroundWorkerUsingBaseUrlInProcessList(
-  processList: string,
-  baseUrl: string
-): boolean {
-  const envNeedle = `ANTHROPIC_BASE_URL=${baseUrl}`;
-  return processList
-    .split(/\r?\n/)
-    .some(
-      (line) => line.includes(envNeedle) && CLAUDE_BG_WORKER_ARGS.some((arg) => line.includes(arg))
-    );
-}
-
-export function hasClaudeBackgroundWorkerUsingBaseUrl(baseUrl: string): boolean {
-  if (process.platform === 'win32') {
-    return false;
-  }
-
-  for (const args of [['auxEww'], ['auxeww'], ['eww', '-axo', 'pid=,command=']]) {
-    try {
-      const processList = execFileSync('ps', args, {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-      });
-      if (hasClaudeBackgroundWorkerUsingBaseUrlInProcessList(processList, baseUrl)) {
-        return true;
-      }
-    } catch {
-      continue;
-    }
-  }
-
-  return false;
-}
-
-export function shouldKeepSessionProxiesAlive(
-  options: ShouldKeepSessionProxiesAliveOptions
-): boolean {
-  if (options.code !== 0 || options.signal) {
-    return false;
-  }
-
-  const baseUrl = options.backgroundKeepAliveBaseUrl;
-  if (!baseUrl) {
-    return false;
-  }
-
-  return options.hasBackgroundWorkerUsingBaseUrl(baseUrl);
 }
 
 /**
@@ -244,8 +180,7 @@ export function setupCleanupHandlers(
   codexReasoningProxy: unknown,
   toolSanitizationProxy: unknown,
   httpsTunnel: unknown,
-  verbose: boolean,
-  keepAliveOptions: SessionProxyKeepAliveOptions = {}
+  verbose: boolean
 ): void {
   const log = (msg: string) => {
     if (verbose) {
@@ -275,20 +210,6 @@ export function setupCleanupHandlers(
     }
   };
 
-  // Security hardening: only allow keepalive when caller provides an explicit,
-  // trusted detector. Falling back to global process-list probing is spoofable.
-  const backgroundProbe = keepAliveOptions.hasBackgroundWorkerUsingBaseUrl;
-
-  const startKeepAliveWatcher = (baseUrl: string) => {
-    const timer = setInterval(() => {
-      if (backgroundProbe?.(baseUrl)) return;
-      log('No Claude bg worker is using the session proxy; cleaning up');
-      stopSessionResources();
-      process.exit(0);
-    }, keepAliveOptions.keepAlivePollIntervalMs ?? 30000);
-    timer.unref();
-  };
-
   const cleanup = () => {
     log('Parent signal received, cleaning up');
     stopSessionResources();
@@ -297,24 +218,6 @@ export function setupCleanupHandlers(
 
   claude.on('exit', (code, signal) => {
     log(`Claude exited: code=${code}, signal=${signal}`);
-    const backgroundKeepAliveBaseUrl = keepAliveOptions.backgroundKeepAliveBaseUrl;
-
-    if (
-      backgroundProbe &&
-      shouldKeepSessionProxiesAlive({
-        code,
-        signal,
-        backgroundKeepAliveBaseUrl,
-        hasBackgroundWorkerUsingBaseUrl: backgroundProbe,
-      }) &&
-      backgroundKeepAliveBaseUrl
-    ) {
-      stopQuotaMonitor();
-      log(`Keeping session proxy alive for Claude bg worker: ${backgroundKeepAliveBaseUrl}`);
-      startKeepAliveWatcher(backgroundKeepAliveBaseUrl);
-      return;
-    }
-
     stopSessionResources();
 
     if (signal) {

--- a/tests/unit/cliproxy/session-bridge-bg-keepalive.test.ts
+++ b/tests/unit/cliproxy/session-bridge-bg-keepalive.test.ts
@@ -1,57 +1,17 @@
-import { describe, it, expect } from 'bun:test';
-import {
-  hasClaudeBackgroundWorkerUsingBaseUrlInProcessList,
-  shouldKeepSessionProxiesAlive,
-} from '../../../src/cliproxy/executor/session-bridge';
+/**
+ * The bg-keepalive feature (shouldKeepSessionProxiesAlive, hasClaudeBackgroundWorker*,
+ * backgroundProbe) was removed as dead code: the sole caller (claude-launcher.ts) never
+ * provided a trusted hasBackgroundWorkerUsingBaseUrl detector, so the keepalive path was
+ * unreachable. The ps-based detector was also spoofable (fixed in #1340). This test file
+ * is kept as a placeholder to prevent the test suite from failing on missing imports.
+ *
+ * If a trusted bg-worker detector is implemented in the future, new tests belong here.
+ */
+
+import { describe, it } from 'bun:test';
 
 describe('session bridge background proxy keepalive', () => {
-  it('keeps per-session proxies alive after a clean Claude exit when a bg worker inherited the base URL', () => {
-    expect(
-      shouldKeepSessionProxiesAlive({
-        code: 0,
-        signal: null,
-        backgroundKeepAliveBaseUrl: 'http://127.0.0.1:64314/api/provider/codex',
-        hasBackgroundWorkerUsingBaseUrl: () => true,
-      })
-    ).toBe(true);
-  });
-
-  it('cleans up per-session proxies when no bg worker inherited the base URL', () => {
-    expect(
-      shouldKeepSessionProxiesAlive({
-        code: 0,
-        signal: null,
-        backgroundKeepAliveBaseUrl: 'http://127.0.0.1:64314/api/provider/codex',
-        hasBackgroundWorkerUsingBaseUrl: () => false,
-      })
-    ).toBe(false);
-  });
-
-  it('cleans up per-session proxies for signaled Claude exits', () => {
-    expect(
-      shouldKeepSessionProxiesAlive({
-        code: null,
-        signal: 'SIGTERM',
-        backgroundKeepAliveBaseUrl: 'http://127.0.0.1:64314/api/provider/codex',
-        hasBackgroundWorkerUsingBaseUrl: () => true,
-      })
-    ).toBe(false);
-  });
-
-  it('detects Claude bg workers that inherited the exact base URL', () => {
-    const baseUrl = 'http://127.0.0.1:64314/api/provider/codex';
-    const processList = `
-123 /opt/claude/claude.exe --bg-spare /tmp/claim.sock ANTHROPIC_BASE_URL=${baseUrl} ANTHROPIC_AUTH_TOKEN=ccs-internal-managed
-456 /opt/claude/claude.exe --bg-spare /tmp/claim.sock ANTHROPIC_BASE_URL=http://127.0.0.1:62075/api/provider/codex
-789 /opt/claude/claude.exe --print ANTHROPIC_BASE_URL=${baseUrl}
-`;
-
-    expect(hasClaudeBackgroundWorkerUsingBaseUrlInProcessList(processList, baseUrl)).toBe(true);
-    expect(
-      hasClaudeBackgroundWorkerUsingBaseUrlInProcessList(
-        processList,
-        'http://127.0.0.1:65535/api/provider/codex'
-      )
-    ).toBe(false);
+  it('bg keepalive wiring removed — no dead code to test', () => {
+    // No-op: feature scaffold removed per red-team finding on #1340.
   });
 });


### PR DESCRIPTION
## Red-team finding (post-#1340)

PR #1340 correctly removed the spoofable `ps`-based fallback from `backgroundProbe`. However, the keepalive scaffold (`backgroundProbe`, `shouldKeepSessionProxiesAlive`, `startKeepAliveWatcher`, related types) became permanently unreachable:

- `claude-launcher.ts` passes `{ backgroundKeepAliveBaseUrl }` to `setupCleanupHandlers` but **never** passes `hasBackgroundWorkerUsingBaseUrl`
- With no detector, `backgroundProbe` is always `undefined`
- The `backgroundProbe &&` guard added in #1340 prevents the keepalive branch from ever firing
- `shouldKeepSessionProxiesAlive` and related helpers have no other callers in `src/`

## Decision: Option A — remove dead code

No trusted detector exists and no caller wires one up. YAGNI: the scaffold is speculative. A future PR can re-add it with an actual trusted implementation if the feature is needed.

## Changes

- `session-bridge.ts`: delete `CLAUDE_BG_WORKER_ARGS`, `hasClaudeBackgroundWorkerUsingBaseUrl{,InProcessList}`, `shouldKeepSessionProxiesAlive`, `ShouldKeepSessionProxiesAliveOptions`, `SessionProxyKeepAliveOptions`, `backgroundProbe`, `startKeepAliveWatcher`, and the keepalive exit branch; `setupCleanupHandlers` now always calls `stopSessionResources` on Claude exit
- `claude-launcher.ts`: remove `backgroundKeepAliveBaseUrl` wiring (unused after above)
- Remove `execFileSync` import (was only used by the deleted `ps` detector)
- Update test file: tests for deleted exports replaced with no-op placeholder

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `bun run format` — clean
- [x] `bun test` fast bucket — 2265 pass, 0 fail