### PR TITLE
fix(codex): enforce local cliproxy base URL for ccsxp repair

### DIFF
--- a/src/targets/codex-cliproxy-provider-config.ts
+++ b/src/targets/codex-cliproxy-provider-config.ts
@@ -56,7 +56,10 @@ function isValidCodexCliproxyBaseUrl(value: unknown): value is string {
   if (!trimmed) return false;
   try {
     const url = new URL(trimmed);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    const hostname = url.hostname.toLowerCase();
+    const isLoopbackHost =
+      hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+    return isLoopbackHost && url.protocol === 'http:' && url.pathname === '/api/provider/codex';
   } catch {
     return false;
   }

--- a/tests/unit/targets/codex-cliproxy-provider-config.test.ts
+++ b/tests/unit/targets/codex-cliproxy-provider-config.test.ts
@@ -84,7 +84,7 @@ wire_api = "responses"
     expect(rawText).toContain('supports_websockets = false');
   });
 
-  it('preserves custom cliproxy provider values while repairing other fields', async () => {
+  it('repairs non-loopback cliproxy provider base_url while preserving custom env_key', async () => {
     fs.mkdirSync(codexHome, { recursive: true });
     fs.writeFileSync(
       configPath,
@@ -102,9 +102,7 @@ wire_api = "chat"
     expect(result.changed).toBe(true);
     expect(result.envKey).toBe('CCS_CUSTOM_CLIPROXY_TOKEN');
     const rawText = fs.readFileSync(configPath, 'utf8');
-    expect(rawText).toContain(
-      'base_url = "https://cliproxy.example.com/api/provider/codex/responses"'
-    );
+    expect(rawText).toContain(`base_url = \"${buildCodexCliproxyProviderBaseUrl(9321)}\"`);
     expect(rawText).toContain('env_key = "CCS_CUSTOM_CLIPROXY_TOKEN"');
     expect(rawText).toContain('wire_api = "responses"');
   });
@@ -161,7 +159,7 @@ supports_websockets = false
     expect(fs.readFileSync(configPath, 'utf8')).toBe(rawText);
   });
 
-  it('leaves a ready remote provider unchanged', async () => {
+  it('repairs a remote provider base_url back to the managed local default', async () => {
     fs.mkdirSync(codexHome, { recursive: true });
     const rawText = `[model_providers.cliproxy]
 name = "CLIProxy Codex"
@@ -175,9 +173,10 @@ supports_websockets = false
 
     const result = await ensureCodexCliproxyProviderConfig(8317, env);
 
-    expect(result.changed).toBe(false);
+    expect(result.changed).toBe(true);
     expect(result.envKey).toBe('CCS_REMOTE_CLIPROXY_TOKEN');
-    expect(fs.readFileSync(configPath, 'utf8')).toBe(rawText);
+    const repairedText = fs.readFileSync(configPath, 'utf8');
+    expect(repairedText).toContain(`base_url = "${buildCodexCliproxyProviderBaseUrl(8317)}"`);
   });
 
   it('normalizes a ready native Codex tuning alias before requests reach cliproxy', async () => {


### PR DESCRIPTION
### Motivation
- Restore the previous local-endpoint safety invariant so ccsxp does not preserve arbitrary remote `model_providers.cliproxy.base_url` values that could exfiltrate an injected CLIProxy API key and request data.
- Prevent attacker-controlled or remote endpoints from being treated as "ready" and left in place by the Codex provider repair logic.

### Description
- Tighten `isValidCodexCliproxyBaseUrl` in `src/targets/codex-cliproxy-provider-config.ts` to only accept loopback hosts (`localhost`, `127.0.0.1`, `::1`) with `http:` and the exact `/api/provider/codex` path.
- Keep provider-repair behavior but force fallback to the managed local base URL whenever the configured `base_url` is remote or otherwise unsafe by using the stricter validation in `resolveProviderBaseUrl`/`isProviderReady`.
- Update unit tests in `tests/unit/targets/codex-cliproxy-provider-config.test.ts` to assert that non-loopback/remote URLs are repaired back to the managed local cliproxy URL while preserving a custom `env_key`.

### Testing
- Ran `bun test tests/unit/targets/codex-cliproxy-provider-config.test.ts`, and the test suite for the modified code passed (all tests in that file passed).
- `tsc --noEmit` was executed as part of validation and succeeded for the changed files.
- The repository `format:check`/Prettier pre-commit step flagged unrelated formatting issues in other files, so the formatting hook prevented a normal commit for unrelated files; the security fix and its tests were verified independently and included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11fa79d0bc8330b91db52e3d8df0b5)