### PR TITLE
fix(web-server): stop startup local prefix sync secret leak

### DIFF
--- a/src/web-server/index.ts
+++ b/src/web-server/index.ts
@@ -19,8 +19,6 @@ import {
   isDashboardWebSocketUpgradeAllowed,
 } from './middleware/auth-middleware';
 import { requestLoggingMiddleware } from './middleware/request-logging-middleware';
-import { ensureManagedModelPrefixes } from '../cliproxy/ai-providers/managed-model-prefixes';
-import { getProxyTarget } from '../cliproxy/proxy/proxy-target-resolver';
 import { startAutoSyncWatcher, stopAutoSyncWatcher } from '../cliproxy/sync';
 import { shutdownUsageAggregator } from './usage/aggregator';
 import { createLogger } from '../services/logging';
@@ -171,14 +169,6 @@ export async function startServer(options: ServerOptions): Promise<ServerInstanc
 
   // Start auto-sync watcher (if enabled in config)
   startAutoSyncWatcher();
-
-  if (!getProxyTarget().isRemote) {
-    void ensureManagedModelPrefixes().catch((error) => {
-      logger.warn('cliproxy.prefix_sync_failed', 'Managed model prefix repair failed', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
-  }
 
   // Combined cleanup function
   const cleanup = () => {


### PR DESCRIPTION
### Motivation
- Remove an unauthenticated dashboard-startup path that automatically called `ensureManagedModelPrefixes()` against a local CLIProxy target and could disclose the effective CLIProxy management secret to a local process listening on the configured port.

### Description
- Stop invoking `ensureManagedModelPrefixes()` during `startServer()` bootstrap in `src/web-server/index.ts` so no management API requests are sent at dashboard startup. 
- Remove the import/usage tied to the startup call while keeping the existing explicit sync flows (CLI/API routes) intact. 
- Keep `startAutoSyncWatcher()` in the server startup path so on-demand/watcher sync behavior remains unchanged.

### Testing
- Ran the targeted test invocation `bun run test src/cliproxy/ai-providers/__tests__/managed-model-prefixes.test.ts`, which executed the repository test harness; the managed-prefix tests passed while the run surfaced an unrelated, pre-existing failure in `tests/unit/targets/settings-profile-websearch-launch.test.ts` in this environment. 
- Ran `bun run format` to apply/precheck formatting. 
- Pre-commit checks during the change passed (`tsc --noEmit`, `eslint src/ --fix`, `prettier --check src/`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e20437dec8330a2ef0dbb76b78507)