### PR TITLE
fix(web-server): skip failed requests in dashboard request logging

### DIFF
--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -524,9 +524,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/src/web-server/middleware/request-logging-middleware.ts
+++ b/src/web-server/middleware/request-logging-middleware.ts
@@ -10,9 +10,10 @@ export function requestLoggingMiddleware(req: Request, res: Response, next: Next
   res.locals.ccsRequestId = requestId;
   res.setHeader('x-ccs-request-id', requestId);
   const shouldSkipLogging = req.originalUrl.startsWith('/api/logs');
+  const shouldLogResponse = () => res.statusCode < 400;
 
   res.on('finish', () => {
-    if (shouldSkipLogging) {
+    if (shouldSkipLogging || !shouldLogResponse()) {
       return;
     }
     logger.info('request.completed', 'Dashboard request completed', {

--- a/tests/unit/web-server/request-logging-middleware.test.ts
+++ b/tests/unit/web-server/request-logging-middleware.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { EventEmitter } from 'events';
+
+const infoSpy = mock(() => {});
+
+mock.module('../../../src/services/logging', () => ({
+  createLogger: () => ({
+    info: infoSpy,
+  }),
+}));
+
+describe('requestLoggingMiddleware', () => {
+  it('skips logging failed unauthenticated responses', async () => {
+    const { requestLoggingMiddleware } = await import(
+      '../../../src/web-server/middleware/request-logging-middleware'
+    );
+
+    const req = {
+      originalUrl: '/api/profiles',
+      method: 'GET',
+      headers: { 'user-agent': 'test-agent' },
+      socket: { remoteAddress: '10.0.0.10' },
+    } as never;
+
+    const res = new EventEmitter() as EventEmitter & {
+      locals: Record<string, unknown>;
+      statusCode: number;
+      setHeader: (name: string, value: string) => void;
+    };
+    res.locals = {};
+    res.statusCode = 401;
+    res.setHeader = () => {};
+
+    let nextCalled = false;
+    requestLoggingMiddleware(req, res as never, () => {
+      nextCalled = true;
+    });
+
+    expect(nextCalled).toBe(true);
+    res.emit('finish');
+    expect(infoSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it('logs successful responses', async () => {
+    const { requestLoggingMiddleware } = await import(
+      '../../../src/web-server/middleware/request-logging-middleware'
+    );
+
+    const req = {
+      originalUrl: '/api/profiles',
+      method: 'GET',
+      headers: { 'user-agent': 'test-agent' },
+      socket: { remoteAddress: '127.0.0.1' },
+    } as never;
+
+    const res = new EventEmitter() as EventEmitter & {
+      locals: Record<string, unknown>;
+      statusCode: number;
+      setHeader: (name: string, value: string) => void;
+    };
+    res.locals = {};
+    res.statusCode = 200;
+    res.setHeader = () => {};
+
+    requestLoggingMiddleware(req, res as never, () => {});
+    res.emit('finish');
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- The request logger previously emitted structured entries for every finished request before auth, which lets unauthenticated attackers amplify logs and drive archive rotation and disk growth.
- The change aims to reduce availability risk by avoiding persistence of failed auth probes while preserving successful request telemetry.

### Description
- Update `requestLoggingMiddleware` to only emit logs for responses with status `< 400` (skip 4xx/5xx failed responses) in `src/web-server/middleware/request-logging-middleware.ts`.
- Add a focused unit test `tests/unit/web-server/request-logging-middleware.test.ts` to assert failed (401) responses are not logged and successful (200) responses are logged.
- Apply repository formatter fixes to two unrelated files (`src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`) produced by hooks during commit.

### Testing
- Ran `bun test tests/unit/web-server/request-logging-middleware.test.ts` and it passed (skips failed unauthenticated responses and logs successful responses).
- Ran `bun test tests/unit/services/logging/logger-stages.test.ts tests/unit/services/logging/log-storage.test.ts` and both tests passed.
- Pre-commit checks (`tsc --noEmit`, `eslint`, and `prettier --check`) were executed and passed after formatting fixes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e204280a88330a0acacb335b841e6)