### PR TITLE
fix(cliproxy): redact generic token query params in oauth trace

### DIFF
--- a/src/cliproxy/auth/__tests__/oauth-trace-redactor.test.ts
+++ b/src/cliproxy/auth/__tests__/oauth-trace-redactor.test.ts
@@ -85,6 +85,13 @@ describe('redactString', () => {
     expect(out).not.toContain('AT_SECRET');
     expect(out).toBe(`access_token=${REDACTED_PLACEHOLDER}&keep=1`);
   });
+
+  test('redacts ampersand-delimited generic token query params', () => {
+    const out = redactString('access_token=AT_SECRET&token=TOKEN_SECRET');
+    expect(out).not.toContain('AT_SECRET');
+    expect(out).not.toContain('TOKEN_SECRET');
+    expect(out).toBe(`access_token=${REDACTED_PLACEHOLDER}&token=${REDACTED_PLACEHOLDER}`);
+  });
 });
 
 describe('redactUrl', () => {

--- a/src/cliproxy/auth/oauth-trace/redactor.ts
+++ b/src/cliproxy/auth/oauth-trace/redactor.ts
@@ -10,6 +10,7 @@
 const SENSITIVE_QUERY_KEYS = [
   'code',
   'state',
+  'token',
   'access_token',
   'refresh_token',
   'id_token',


### PR DESCRIPTION
### Motivation
- A redaction regression allowed URL-style input like `access_token=AT_SECRET&token=TOKEN_SECRET` to expose the `token` value because `QUERY_PARAM_REGEX` omitted the generic `token` key while the line-leading regex stopped at `&`, leaving `&token=...` preserved for later processing in `redactString`.
- This is a security-sensitive information-leak risk for OAuth stdout/stderr snippets and trace files, so a minimal, targeted fix was needed to restore full redaction coverage for ampersand-delimited query params.

### Description
- Add `token` to `SENSITIVE_QUERY_KEYS` in `src/cliproxy/auth/oauth-trace/redactor.ts` so `QUERY_PARAM_REGEX` also matches and redacts `&token=...` patterns.
- Add a focused regression test `redacts ampersand-delimited generic token query params` to `src/cliproxy/auth/__tests__/oauth-trace-redactor.test.ts` that asserts both `access_token` and `token` are redacted in `redactString`.
- The change is minimal and preserves existing behavior for other sensitive keys and URL-style suffix handling.

### Testing
- Ran the redactor unit tests with `bun test ./src/cliproxy/auth/__tests__/oauth-trace-redactor.test.ts`, and the test file completed with all tests passing (38 pass, 0 fail).
- The newly added regression test specifically passed and verifies `redactString('access_token=AT_SECRET&token=TOKEN_SECRET')` returns both values redacted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1243d8065c83308d56d4e3f93a233a)