### PR TITLE
fix(codex-auth): restrict symlink fallback and harden config copy fallback

### DIFF
--- a/src/codex-auth/codex-config-symlink.ts
+++ b/src/codex-auth/codex-config-symlink.ts
@@ -94,7 +94,7 @@ export function ensureSharedConfigSymlink(
       target: targetPath,
     });
   } catch (err) {
-    copySharedConfigFallback(targetPath, linkPath, err);
+    handleSymlinkFailure(targetPath, linkPath, err);
   }
 }
 
@@ -106,9 +106,30 @@ function isRegularConfigCopyUnmodified(linkPath: string, targetPath: string): bo
   }
 }
 
-function copySharedConfigFallback(targetPath: string, linkPath: string, err: unknown): void {
-  fs.copyFileSync(targetPath, linkPath);
-  fs.chmodSync(linkPath, 0o600);
+function handleSymlinkFailure(targetPath: string, linkPath: string, err: unknown): void {
+  const code = (err as NodeJS.ErrnoException | null)?.code;
+  if (code !== 'EPERM' && code !== 'EACCES' && code !== 'ENOSYS') {
+    throw err;
+  }
+
+  const tmpPath = path.join(
+    path.dirname(linkPath),
+    `.config.toml.tmp-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  );
+
+  try {
+    fs.copyFileSync(targetPath, tmpPath, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(tmpPath, 0o600);
+    fs.renameSync(tmpPath, linkPath);
+  } catch (copyErr) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // best effort cleanup
+    }
+    throw copyErr;
+  }
+
   process.stderr.write(
     `[!] codex-auth: symlink unavailable; copied shared config.toml to ${linkPath}. ` +
       `Config edits won't propagate automatically.\n`

--- a/tests/unit/codex-auth/codex-config-symlink.test.ts
+++ b/tests/unit/codex-auth/codex-config-symlink.test.ts
@@ -143,6 +143,19 @@ describe('ensureSharedConfigSymlink', () => {
     expect(stderrChunks.join('')).toContain('symlink unavailable');
   });
 
+
+  it('rethrows symlink errors that are not fallback-safe', () => {
+    fs.writeFileSync(sharedConfigPath, 'model = "gpt-5.5"\n', { mode: 0o600 });
+    const symlinkSpy = spyOn(fs, 'symlinkSync').mockImplementation(() => {
+      throw Object.assign(new Error('simulated race'), { code: 'EEXIST' });
+    });
+
+    try {
+      expect(() => ensureSharedConfigSymlink(profileDir, sharedConfigPath)).toThrow(/simulated race/);
+    } finally {
+      symlinkSpy.mockRestore();
+    }
+  });
   it('preserves edited fallback copies on later repair attempts', () => {
     fs.writeFileSync(sharedConfigPath, 'model = "gpt-5.5"\n', { mode: 0o600 });
     const linkPath = path.join(profileDir, 'config.toml');


### PR DESCRIPTION
### Motivation
- Prevent a TOCTOU vulnerability where any `symlinkSync` error caused a direct `copyFileSync(target, linkPath)` that could follow a raced destination symlink and disclose shared Codex config contents.
- Provide a safer fallback that only activates for genuine symlink-unavailable conditions and that writes the copy in a way that avoids following destination symlinks.

### Description
- Replace the unconditional catch-path with `handleSymlinkFailure(targetPath, linkPath, err)` that inspects `err.code` and rethrows non-fallback-safe errors (e.g., `EEXIST`).
- Only allow fallback for explicit symlink-unavailable error codes (`EPERM`, `EACCES`, `ENOSYS`) and rethrow other errors to avoid masking race conditions.
- Harden the copy fallback by copying into a unique temp file using `fs.copyFileSync(..., fs.constants.COPYFILE_EXCL)`, setting `0600` on the temp file, then atomically renaming it into place and performing best-effort cleanup on failure.
- Add a unit test asserting that non-fallback-safe symlink errors (simulated `EEXIST`) are rethrown instead of falling back to a copy, and adjust tests that validate the safe fallback behavior.

### Testing
- Ran `bun test tests/unit/codex-auth/codex-config-symlink.test.ts`, which passed (10 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e03dd48330a51b54bec1b32082)