### PR TITLE
fix(browser): log only matched intercepted requests

### DIFF
--- a/lib/mcp/ccs-browser-server.cjs
+++ b/lib/mcp/ccs-browser-server.cjs
@@ -5097,16 +5097,18 @@ async function ensureInterceptSession(page) {
           })
         );
       }
-      pushRecentRequest({
-        requestId: String(paused.requestId || ''),
-        pageId: page.id,
-        url: String(paused.request?.url || ''),
-        method: String(paused.request?.method || ''),
-        resourceType: String(paused.resourceType || ''),
-        matchedRuleId: matchedRule ? matchedRule.ruleId : '',
-        action,
-        statusCode: action === 'fulfill' ? matchedRule.statusCode : 0,
-      });
+      if (matchedRule) {
+        pushRecentRequest({
+          requestId: String(paused.requestId || ''),
+          pageId: page.id,
+          url: String(paused.request?.url || ''),
+          method: String(paused.request?.method || ''),
+          resourceType: String(paused.resourceType || ''),
+          matchedRuleId: matchedRule.ruleId,
+          action,
+          statusCode: action === 'fulfill' ? matchedRule.statusCode : 0,
+        });
+      }
     })();
     activityChain = activityChain
       .catch(() => {})

--- a/tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts
+++ b/tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts
@@ -780,8 +780,7 @@ describe('ccs-browser MCP server - session and interception', () => {
     expect(listText).toContain('requestId: req-1');
     expect(listText).toContain('matchedRuleId: rule-1');
     expect(listText).toContain('action: fail');
-    expect(listText).toContain('requestId: req-2');
-    expect(listText).toContain('action: continue');
+    expect(listText).not.toContain('requestId: req-2');
   });
 
   it('removes rules and recent requests bound to a page after that page is closed', async () => {


### PR DESCRIPTION
### Motivation
- Close an information-disclosure issue where paused Fetch requests were being recorded and returned by `browser_list_requests` even when they did not match any interception rule, potentially leaking URL-carried secrets.

### Description
- Only persist a paused request via `pushRecentRequest` when a matching intercept rule exists (retain existing `continue`/`fail`/`fulfill` behavior), and update the interception unit test to assert unmatched paused requests are not listed.

### Testing
- Ran the interception unit suite with `bun test tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts` and the tests in that file passed (46 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e048b083309d1c42726c864458)