### PR TITLE
fix: honor CCS_BROWSER_EVAL_MODE in effective browser attach config

### DIFF
--- a/src/utils/browser/browser-settings.ts
+++ b/src/utils/browser/browser-settings.ts
@@ -232,6 +232,8 @@ export function getEffectiveClaudeBrowserAttachConfig(
     resolveBrowserUserDataDir(config.claude.user_data_dir) ?? getRecommendedBrowserUserDataDir();
   const configPort = normalizeDevtoolsPort(config.claude.devtools_port);
   const configEvalMode = config.claude.eval_mode ?? 'readonly';
+  const envEvalMode = parseBrowserEvalMode(env.CCS_BROWSER_EVAL_MODE);
+  const effectiveEvalMode = envEvalMode ?? configEvalMode;
 
   if (override.userDataDir) {
     return {
@@ -241,7 +243,7 @@ export function getEffectiveClaudeBrowserAttachConfig(
       userDataDir: override.userDataDir,
       devtoolsPort: override.devtoolsPort ?? configPort,
       hasExplicitDevtoolsPort: override.devtoolsPort !== undefined,
-      evalMode: configEvalMode,
+      evalMode: effectiveEvalMode,
     };
   }
 
@@ -252,7 +254,7 @@ export function getEffectiveClaudeBrowserAttachConfig(
     userDataDir: configUserDataDir,
     devtoolsPort: configPort,
     hasExplicitDevtoolsPort: true,
-    evalMode: configEvalMode,
+    evalMode: effectiveEvalMode,
   };
 }
 
@@ -302,6 +304,15 @@ function parseDevtoolsPort(value?: string): number | undefined {
   }
 
   return normalizeDevtoolsPort(Number.parseInt(value.trim(), 10));
+}
+
+function parseBrowserEvalMode(value?: string): BrowserEvalMode | undefined {
+  const trimmed = value?.trim();
+  if (trimmed === 'disabled' || trimmed === 'readonly' || trimmed === 'readwrite') {
+    return trimmed;
+  }
+
+  return undefined;
 }
 
 function normalizeDevtoolsPort(value: number | undefined): number {

--- a/tests/unit/utils/browser/browser-status.test.ts
+++ b/tests/unit/utils/browser/browser-status.test.ts
@@ -22,6 +22,7 @@ describe('browser status', () => {
   let originalBrowserUserDataDir: string | undefined;
   let originalBrowserProfileDir: string | undefined;
   let originalBrowserDevtoolsPort: string | undefined;
+  let originalBrowserEvalMode: string | undefined;
 
   beforeEach(() => {
     tempHome = mkdtempSync(join(tmpdir(), 'ccs-browser-status-'));
@@ -29,11 +30,13 @@ describe('browser status', () => {
     originalBrowserUserDataDir = process.env.CCS_BROWSER_USER_DATA_DIR;
     originalBrowserProfileDir = process.env.CCS_BROWSER_PROFILE_DIR;
     originalBrowserDevtoolsPort = process.env.CCS_BROWSER_DEVTOOLS_PORT;
+    originalBrowserEvalMode = process.env.CCS_BROWSER_EVAL_MODE;
 
     process.env.CCS_HOME = tempHome;
     delete process.env.CCS_BROWSER_USER_DATA_DIR;
     delete process.env.CCS_BROWSER_PROFILE_DIR;
     delete process.env.CCS_BROWSER_DEVTOOLS_PORT;
+    delete process.env.CCS_BROWSER_EVAL_MODE;
   });
 
   afterEach(() => {
@@ -59,6 +62,11 @@ describe('browser status', () => {
       process.env.CCS_BROWSER_DEVTOOLS_PORT = originalBrowserDevtoolsPort;
     } else {
       delete process.env.CCS_BROWSER_DEVTOOLS_PORT;
+    }
+    if (originalBrowserEvalMode !== undefined) {
+      process.env.CCS_BROWSER_EVAL_MODE = originalBrowserEvalMode;
+    } else {
+      delete process.env.CCS_BROWSER_EVAL_MODE;
     }
 
     rmSync(tempHome, { recursive: true, force: true });
@@ -288,6 +296,29 @@ describe('browser status', () => {
       userDataDir: '/env-browser',
       devtoolsPort: 9444,
     });
+  });
+
+  it('honors CCS_BROWSER_EVAL_MODE over configured eval_mode', () => {
+    mutateUnifiedConfig((config) => {
+      config.browser = {
+        claude: {
+          enabled: true,
+          policy: 'manual',
+          user_data_dir: '/config-browser',
+          devtools_port: 9333,
+          eval_mode: 'readonly',
+        },
+        codex: {
+          enabled: false,
+          policy: 'manual',
+        },
+      };
+    });
+    process.env.CCS_BROWSER_EVAL_MODE = 'disabled';
+
+    const effective = getEffectiveClaudeBrowserAttachConfig(getBrowserConfig());
+
+    expect(effective.evalMode).toBe('disabled');
   });
 
   it('returns the same managed attach warning when the configured DevTools port is unreachable', async () => {


### PR DESCRIPTION
### Motivation
- A runtime launch path was overwriting a parent `CCS_BROWSER_EVAL_MODE` value with the persisted `claude.eval_mode`, which broke the documented kill-switch and could expose `browser_eval` when a parent set `CCS_BROWSER_EVAL_MODE=disabled`.
- Restore the intended precedence so a parent process can enforce `CCS_BROWSER_EVAL_MODE` without being overridden by saved config defaults.

### Description
- Read and validate `CCS_BROWSER_EVAL_MODE` in `getEffectiveClaudeBrowserAttachConfig` and derive an `effectiveEvalMode` that takes the env value when valid, falling back to the configured `claude.eval_mode` otherwise.
- Apply the `effectiveEvalMode` to both override-backed and config-backed attach resolutions so child launches receive the correct eval policy.
- Added a strict `parseBrowserEvalMode` helper that accepts only `disabled`, `readonly`, or `readwrite` to avoid accepting arbitrary strings from the env.
- Added a focused unit test and test harness cleanup to assert that `CCS_BROWSER_EVAL_MODE` takes precedence over the persisted `eval_mode`.

### Testing
- Ran the focused unit test: `bun test tests/unit/utils/browser/browser-status.test.ts -t "honors CCS_BROWSER_EVAL_MODE over configured eval_mode"` which passed.
- Ran the full test file: `bun test tests/unit/utils/browser/browser-status.test.ts`, which produced 10 passing tests and 1 failing test; the failing test is an existing metadata-related/bootstrapping assertion in the local test environment and is unrelated to the eval-mode precedence change.
- The change is minimal and covered by a new unit test that verifies the env override semantics; no other automated test failures were introduced by the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e014b88330bcf5813aa2952b56)