### PR TITLE
fix(cursor): reject cross-origin POST to /api/cursor/probe

### DIFF
--- a/src/web-server/routes/cursor-routes.ts
+++ b/src/web-server/routes/cursor-routes.ts
@@ -18,6 +18,7 @@ import {
 
 import cursorSettingsRoutes from './cursor-settings-routes';
 import { getCursorConfig } from '../../config/config-loader-facade';
+import { isDashboardWebSocketOriginAllowed } from '../middleware/auth-middleware';
 
 const router = Router();
 
@@ -192,7 +193,12 @@ router.get('/models', async (_req: Request, res: Response): Promise<void> => {
 /**
  * POST /api/cursor/probe - Run a live authenticated runtime probe
  */
-router.post('/probe', async (_req: Request, res: Response): Promise<void> => {
+router.post('/probe', async (req: Request, res: Response): Promise<void> => {
+  if (!isDashboardWebSocketOriginAllowed(req)) {
+    res.status(403).json({ error: 'Cross-origin probe requests are not allowed.' });
+    return;
+  }
+
   try {
     const cursorConfig = getCursorConfig();
     const result = await probeCursorRuntime(cursorConfig);

--- a/tests/unit/web-server/cursor-routes.test.ts
+++ b/tests/unit/web-server/cursor-routes.test.ts
@@ -510,6 +510,17 @@ describe('Cursor Routes Logic', () => {
       expect(json.current).toBe('gpt-5.3-codex');
     });
 
+    it('POST /api/cursor/probe rejects cross-origin requests', async () => {
+      const res = await fetch(`${baseUrl}/api/cursor/probe`, {
+        method: 'POST',
+        headers: { Origin: 'https://attacker.example' },
+      });
+      expect(res.status).toBe(403);
+
+      const json = (await res.json()) as { error?: string };
+      expect(json.error).toContain('Cross-origin probe requests are not allowed.');
+    });
+
     it('POST /api/cursor/probe returns auth failure when credentials are missing', async () => {
       const res = await fetch(`${baseUrl}/api/cursor/probe`, { method: 'POST' });
       expect(res.status).toBe(401);


### PR DESCRIPTION
### Motivation

- The `POST /api/cursor/probe` endpoint could be triggered by a cross-origin simple POST from a web page and would run `probeCursorRuntime()` using stored Cursor credentials, allowing drive-by upstream requests and potential daemon starts. 
- The intent is to prevent CSRF-style cross-origin browser requests from causing authenticated side effects while preserving same-origin and non-browser (CLI/local) behavior.

### Description

- Added an origin guard to the `POST /api/cursor/probe` route by importing and invoking `isDashboardWebSocketOriginAllowed` from `src/web-server/middleware/auth-middleware.ts` and returning HTTP `403` with a short error message for disallowed origins. 
- Kept the probe logic intact for allowed requests and non-browser/local callers by performing the origin check early and returning before calling `probeCursorRuntime`. 
- Added a unit test in `tests/unit/web-server/cursor-routes.test.ts` that sends a `POST` with `Origin: https://attacker.example` to assert the route returns `403` and the expected error message.

### Testing

- Ran the unit test file with `bun test tests/unit/web-server/cursor-routes.test.ts`, and all tests passed (`22 pass, 0 fail`).
- The added test specifically asserting cross-origin rejection passed, confirming the origin gate prevents browser-origin probe side effects.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e0bc74833082ed44d3cc8fe2e2)