### PR TITLE
fix(dashboard): avoid persisting local CLIProxy management secret in localStorage

### DIFF
--- a/ui/src/components/cliproxy/control-panel-embed.tsx
+++ b/ui/src/components/cliproxy/control-panel-embed.tsx
@@ -57,6 +57,10 @@ function clearLocalControlPanelSession(): void {
   window.localStorage.removeItem(CONTROL_PANEL_LOGIN_FLAG_KEY);
 }
 
+function clearPersistedLocalControlPanelSecret(): void {
+  window.localStorage.removeItem(CONTROL_PANEL_MANAGEMENT_KEY);
+}
+
 export function ControlPanelEmbed({ port = CLIPROXY_DEFAULT_PORT }: ControlPanelEmbedProps) {
   const { t } = useTranslation();
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -162,7 +166,13 @@ export function ControlPanelEmbed({ port = CLIPROXY_DEFAULT_PORT }: ControlPanel
       return;
     }
 
+    const handleBeforeUnload = () => {
+      clearLocalControlPanelSession();
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
     return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
       clearLocalControlPanelSession();
     };
   }, [isRemote]);
@@ -266,9 +276,15 @@ export function ControlPanelEmbed({ port = CLIPROXY_DEFAULT_PORT }: ControlPanel
   const handleIframeLoad = () => {
     setLoadedFrameKey(iframeKey);
     postRemoteAutoLoginCredentials();
+    if (!isRemote) {
+      clearPersistedLocalControlPanelSecret();
+    }
   };
 
   const handleRefresh = () => {
+    if (!isRemote) {
+      clearLocalControlPanelSession();
+    }
     setLoadedFrameKey(null);
     setIframeRevision((value) => value + 1);
     setError(null);

--- a/ui/tests/unit/components/cliproxy/control-panel-embed.test.tsx
+++ b/ui/tests/unit/components/cliproxy/control-panel-embed.test.tsx
@@ -94,6 +94,7 @@ describe('ControlPanelEmbed', () => {
     const iframe = await screen.findByTitle('CLIProxy Management Panel');
 
     expect(iframe).toHaveAttribute('src', '/api/cliproxy-local/management.html');
+    fireEvent.load(iframe);
 
     await waitFor(() => {
       expect(window.localStorage.removeItem).toHaveBeenCalledWith('cli-proxy-auth');
@@ -107,6 +108,7 @@ describe('ControlPanelEmbed', () => {
       );
       expect(window.localStorage.setItem).toHaveBeenCalledWith('managementKey', 'custom-secret');
       expect(window.localStorage.setItem).toHaveBeenCalledWith('isLoggedIn', 'true');
+      expect(window.localStorage.removeItem).toHaveBeenCalledWith('managementKey');
     });
 
     vi.clearAllMocks();


### PR DESCRIPTION
### Motivation
- The local control-panel bootstrap previously wrote the raw CLIProxy `managementKey` into `window.localStorage`, which created durable, script-readable credential storage that could be exposed to same-origin scripts or persist after logout.

### Description
- Remove the persisted management secret immediately after the local iframe finishes bootstrapping by adding `clearPersistedLocalControlPanelSecret` and calling it from `handleIframeLoad` in `ControlPanelEmbed`.
- Harden lifecycle cleanup by clearing the control-panel session storage on browser `beforeunload` and when the user triggers a manual refresh in local mode via `handleRefresh`.
- Preserve existing remote `postMessage` bootstrap behavior and keep the failure-path cleanup that clears keys when token bootstrap fails.
- Update the unit test `ui/tests/unit/components/cliproxy/control-panel-embed.test.tsx` to simulate the iframe `load` event and assert that the `managementKey` is removed after local bootstrap.

### Testing
- Ran the focused unit test with `bun run test:run tests/unit/components/cliproxy/control-panel-embed.test.tsx` which passed (`3 tests` passed) against the modified code.
- Verified that the token-bootstrap failure-path and remote `postMessage` bootstrap tests in the same file continue to pass under the updated behavior.
- No additional automated tests were modified for unrelated areas; only the targeted control-panel unit test was executed for validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e06ba48330b231a8e072b8b0ed)