### PR TITLE
fix(codex): cap buffered upstream error response size

### DIFF
--- a/src/cliproxy/ai-providers/__tests__/codex-reasoning-proxy-extended-context.test.ts
+++ b/src/cliproxy/ai-providers/__tests__/codex-reasoning-proxy-extended-context.test.ts
@@ -296,6 +296,39 @@ describe('CodexReasoningProxy extended-context compatibility', () => {
     expect((capturedBody?.reasoning as JsonRecord | undefined)?.effort).toBeUndefined();
   });
 
+  it('rejects oversized non-2xx upstream error bodies', async () => {
+    const upstream = http.createServer((_req, res) => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      const chunk = 'x'.repeat(1024 * 1024);
+      for (let i = 0; i < 11; i += 1) {
+        res.write(chunk);
+      }
+      res.end();
+    });
+    cleanupServers.push(upstream);
+
+    const upstreamPort = await listenOnRandomPort(upstream);
+    const proxy = new CodexReasoningProxy({
+      upstreamBaseUrl: `http://127.0.0.1:${upstreamPort}`,
+      modelMap: { defaultModel: 'gpt-5.4' },
+      defaultEffort: 'medium',
+    });
+
+    const proxyPort = await proxy.start();
+    const response = await postJson(
+      `http://127.0.0.1:${proxyPort}/api/provider/codex/v1/messages`,
+      {
+        model: 'gpt-5.4',
+        messages: [],
+      }
+    );
+
+    proxy.stop();
+
+    expect(response.statusCode).toBe(502);
+    expect(response.body.error).toContain('Upstream error response exceeded 10MB limit');
+  });
+
   it('keeps fast service tier when disableEffort is enabled', async () => {
     let capturedBody: JsonRecord | null = null;
 

--- a/src/cliproxy/ai-providers/codex-reasoning-proxy.ts
+++ b/src/cliproxy/ai-providers/codex-reasoning-proxy.ts
@@ -680,9 +680,24 @@ export class CodexReasoningProxy {
             return;
           }
 
+          const maxErrorResponseSize = 10 * 1024 * 1024; // 10MB
+          let totalResponseBytes = 0;
+          let responseTooLarge = false;
           const chunks: Buffer[] = [];
-          upstreamRes.on('data', (chunk: Buffer) => chunks.push(chunk));
+          upstreamRes.on('data', (chunk: Buffer) => {
+            totalResponseBytes += chunk.length;
+            if (totalResponseBytes > maxErrorResponseSize) {
+              responseTooLarge = true;
+              upstreamRes.destroy(new Error('Upstream error response exceeded 10MB limit'));
+              return;
+            }
+            chunks.push(chunk);
+          });
           upstreamRes.on('end', async () => {
+            if (responseTooLarge) {
+              reject(new Error('Upstream error response exceeded 10MB limit'));
+              return;
+            }
             try {
               const responseBody = Buffer.concat(chunks).toString('utf8');
               const unsupportedError =


### PR DESCRIPTION
### Motivation

- Non-2xx upstream JSON responses were fully buffered in memory before parsing, which allows a malicious or misbehaving upstream to cause unbounded memory growth and crash the proxy.
- The retry logic for unsupported-model detection required inspecting full error bodies, but there was no safety cap on upstream error size.

### Description

- Add a 10MB cap (`maxErrorResponseSize = 10 * 1024 * 1024`) when buffering non-2xx upstream responses in `CodexReasoningProxy.forwardJson` and abort the upstream stream if exceeded.
- Abort the upstream response by destroying the stream and reject the buffering promise so the proxy fails fast instead of consuming unbounded memory.
- Preserve the existing unsupported-model retry flow for error bodies that fit within the cap.
- Add a regression test (`__tests__/codex-reasoning-proxy-extended-context.test.ts`) that simulates an 11MB non-2xx upstream response and asserts the proxy returns `502` with the expected error message.

### Testing

- Ran the updated unit tests for the file with `bun test ./src/cliproxy/ai-providers/__tests__/codex-reasoning-proxy-extended-context.test.ts`, and all tests passed (11 pass, 0 fail).
- The new regression test verifies that an oversized non-2xx upstream body is rejected and the proxy returns a 502 and an explanatory error string.
- No full-suite test run was performed in this change set; only the targeted tests above were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e087888330bc1a697e587f5249)