### PR TITLE
fix(claude-extension): enforce private file permissions on binding settings writes

### DIFF
--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -483,9 +483,8 @@ export async function reconcileExhaustedRotationAccounts(
     return [];
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();
@@ -593,9 +592,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/src/web-server/services/claude-extension-settings-service.ts
+++ b/src/web-server/services/claude-extension-settings-service.ts
@@ -231,8 +231,12 @@ function writeJsonDocument(
   const tempPath = `${filePath}.tmp.${uniqueFileNonce()}`;
 
   try {
-    fs.writeFileSync(tempPath, JSON.stringify(data, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(tempPath, JSON.stringify(data, null, 2) + '\n', {
+      encoding: 'utf8',
+      mode: 0o600,
+    });
     fs.renameSync(tempPath, filePath);
+    fs.chmodSync(filePath, 0o600);
   } catch (error) {
     if (fs.existsSync(tempPath)) {
       fs.rmSync(tempPath, { force: true });

--- a/tests/unit/web-server/claude-extension-routes.test.ts
+++ b/tests/unit/web-server/claude-extension-routes.test.ts
@@ -313,6 +313,12 @@ describe('web-server claude-extension-routes', () => {
 
   it('creates a binding and applies managed settings to shared + IDE targets', async () => {
     const ideSettingsPath = path.join(tempHome, 'ide', 'vscode', 'settings.json');
+    const sharedSettingsPath = path.join(tempHome, '.claude', 'settings.json');
+    fs.mkdirSync(path.dirname(ideSettingsPath), { recursive: true });
+    fs.mkdirSync(path.dirname(sharedSettingsPath), { recursive: true });
+    fs.writeFileSync(sharedSettingsPath, JSON.stringify({ env: {} }, null, 2) + '\n', { mode: 0o600 });
+    fs.writeFileSync(ideSettingsPath, JSON.stringify({}, null, 2) + '\n', { mode: 0o600 });
+
     const createResponse = await fetch(`${baseUrl}/api/claude-extension/bindings`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -352,7 +358,6 @@ describe('web-server claude-extension-routes', () => {
     expect(applied.sharedSettings.state).toBe('applied');
     expect(applied.ideSettings.state).toBe('applied');
 
-    const sharedSettingsPath = path.join(tempHome, '.claude', 'settings.json');
     const sharedSettings = JSON.parse(fs.readFileSync(sharedSettingsPath, 'utf8')) as {
       env?: Record<string, string>;
     };
@@ -370,6 +375,9 @@ describe('web-server claude-extension-routes', () => {
         )
     ).toBe(true);
     expect(ideSettings['claudeCode.disableLoginPrompt']).toBe(true);
+
+    expect(fs.statSync(sharedSettingsPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(ideSettingsPath).mode & 0o777).toBe(0o600);
   });
 
   it('resets only managed keys and preserves unrelated shared + IDE settings', async () => {


### PR DESCRIPTION
### Motivation
- Prevent disclosure of secret-bearing environment variables written by the Claude extension binding workflow because the JSON writer previously created temp files without restrictive permissions, allowing replaced files to become world-readable under common umasks.
- The binding apply/reset flows persist `extensionEnv` (which can contain API keys/tokens) into shared Claude settings and user-specified IDE settings paths, so writes must preserve restrictive permissions.

### Description
- Tighten `writeJsonDocument` in `src/web-server/services/claude-extension-settings-service.ts` to create temp JSON files with `mode: 0o600` and to explicitly `chmod` the target to `0o600` after the atomic rename. 
- Add a regression in `tests/unit/web-server/claude-extension-routes.test.ts` that pre-creates shared and IDE settings with `0600`, applies a binding, and asserts both files remain `0600` while still receiving the expected managed entries. 
- Preserve existing safety checks (e.g., refusing to manage symlinks) and keep the atomic write/backup semantics via `backupIfPresent` and rename.
- Apply repository formatting updates from `bun run format` which touched two unrelated files but introduced no behavior changes (`src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`).

### Testing
- Ran the modified claude-extension unit suite with `bun test tests/unit/web-server/claude-extension-routes.test.ts`, and all tests passed. 
- Pre-commit verification steps executed and passed: `tsc --noEmit`, `eslint src/ --fix`, and `prettier --check src/`.
- Ran repository formatting with `bun run format` to satisfy style checks and ensure CI parity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e1d4908330bf67665b9d0040ea)