### PR TITLE
fix(proxy): honor downstream backpressure in cliproxy local proxy

### DIFF
--- a/src/web-server/routes/cliproxy-local-proxy.ts
+++ b/src/web-server/routes/cliproxy-local-proxy.ts
@@ -116,9 +116,22 @@ export function createCliproxyLocalProxyRouter(deps: CliproxyLocalProxyDeps = {}
         }
 
         res.writeHead(proxyStatus, proxyRes.headers);
-        // Manual streaming instead of pipe() for Bun runtime compatibility
-        proxyRes.on('data', (chunk: Buffer) => res.write(chunk));
-        proxyRes.on('end', () => res.end());
+        // Manual streaming instead of pipe() for Bun runtime compatibility.
+        // Explicitly honor downstream backpressure to avoid unbounded buffering.
+        const onDrain = () => proxyRes.resume();
+
+        proxyRes.on('data', (chunk: Buffer) => {
+          const canContinue = res.write(chunk);
+          if (!canContinue) {
+            proxyRes.pause();
+            res.once('drain', onDrain);
+          }
+        });
+
+        proxyRes.on('end', () => {
+          res.off('drain', onDrain);
+          res.end();
+        });
       }
     );
 


### PR DESCRIPTION
### Motivation
- The local CLIProxy reverse proxy forwarded upstream response chunks with `proxyRes.on('data', ...)` and called `res.write(chunk)` without honoring Node-style backpressure, allowing slow or stalled clients to cause unbounded buffering and potential OOM/DoS.
- Maintain Bun-compatible manual streaming while ensuring the dashboard process cannot be overwhelmed by a fast upstream and a slow downstream.

### Description
- Update `src/web-server/routes/cliproxy-local-proxy.ts` to handle downstream backpressure when streaming proxy responses by checking `res.write()` return value, pausing `proxyRes` on `false`, and resuming on downstream `drain`.
- Remove the risk of stale listeners by removing the `drain` handler when the upstream `end` event fires, and keep existing synthetic 502 handling and request flow unchanged.
- The change is minimal and scoped only to the response-streaming section; other proxy behavior (timeouts, error handling, request body handling) is preserved.

### Testing
- Ran `bun test tests/unit/web-server/cliproxy-local-proxy.test.ts` and all tests passed (4 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e1fde88330abc1bc7ed0a8bcae)