### PR TITLE
fix: create explicit CODEX_HOME with owner-only permissions

### DIFF
--- a/src/targets/codex-adapter.ts
+++ b/src/targets/codex-adapter.ts
@@ -222,7 +222,7 @@ function prepareExplicitCodexHome(
   }
 
   try {
-    fs.mkdirSync(codexHome, { recursive: true });
+    fs.mkdirSync(codexHome, { mode: 0o700, recursive: true });
   } catch (err) {
     const error = err as NodeJS.ErrnoException;
     if (error.code !== 'EEXIST') {

--- a/tests/unit/targets/codex-runtime-integration.test.ts
+++ b/tests/unit/targets/codex-runtime-integration.test.ts
@@ -596,7 +596,9 @@ process.exit(0);
 
     expect(result.status).toBe(0);
     expect(fs.existsSync(freshCodexHome)).toBe(true);
-    expect(fs.statSync(freshCodexHome).isDirectory()).toBe(true);
+    const codexHomeStat = fs.statSync(freshCodexHome);
+    expect(codexHomeStat.isDirectory()).toBe(true);
+    expect(codexHomeStat.mode & 0o777).toBe(0o700);
     expect(readLoggedCodexCalls(codexArgsLogPath)).toEqual([
       ['-c', 'model="gpt-5"', '--version'],
       ['-c', 'model_reasoning_effort="high"', 'fix failing tests'],


### PR DESCRIPTION
### Motivation

- Prevent newly bootstraped `CODEX_HOME` directories from being created with default umask-derived permissions (e.g. `0755`) which can expose Codex config/auth material to other local users.
- Apply a minimal, low-risk change that enforces owner-only access while preserving existing behavior and error handling when preparing explicit `CODEX_HOME` for native Codex launches.

### Description

- Change `prepareExplicitCodexHome` in `src/targets/codex-adapter.ts` to create the directory with `fs.mkdirSync(codexHome, { mode: 0o700, recursive: true })` so `CODEX_HOME` is owner-only by default.
- Add an assertion in `tests/unit/targets/codex-runtime-integration.test.ts` to verify the created explicit `CODEX_HOME` mode is `0o700` via `fs.statSync(...).mode & 0o777` to prevent regressions.
- Preserve existing validation and error branches (unchanged after directory creation) so behavior remains the same when the path is a file or inaccessible.

### Testing

- Ran `env -u CODEX_HOME bun test tests/unit/targets/codex-runtime-integration.test.ts` and the file's tests passed (46 tests, 0 failures).
- Running the same test file without unsetting `CODEX_HOME` initially produced unrelated environment-dependent mismatches, so the targeted run above is used to validate the permission fix.
- The added permission assertion test passed in the targeted test run described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e1b7e88330918e138c2c025e19)