### PR TITLE
docs(docker): harden remote token migration staging path

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -160,15 +160,20 @@ docker exec ccs-cliproxy supervisorctl -c /etc/supervisord.conf restart cliproxy
 For remote deployments via `ccs docker up --host`:
 
 ```bash
-# Copy tokens into the running container (no root/sudo needed)
-scp /path/to/auth/*.json my-server:/tmp/ccs-auth/
-ssh my-server 'for f in /tmp/ccs-auth/*.json; do docker cp "$f" ccs-cliproxy:/root/.ccs/cliproxy/auth/; done'
+# Create a private staging directory (0700) and print its path
+STAGE_DIR=$(ssh my-server 'umask 077 && mktemp -d "${HOME}/.ccs-auth.XXXXXX"')
+
+# Copy only JSON token files into the private staging directory
+scp /path/to/auth/*.json "my-server:${STAGE_DIR}/"
+
+# Restrict file permissions and import each staged token into the container
+ssh my-server "chmod 600 \"${STAGE_DIR}\"/*.json && for f in \"${STAGE_DIR}\"/*.json; do docker cp \"\$f\" ccs-cliproxy:/root/.ccs/cliproxy/auth/; done"
 
 # Restart CLIProxy to load new tokens
 ssh my-server "docker exec ccs-cliproxy supervisorctl -c /etc/supervisord.conf restart cliproxy"
 
-# Clean up temp files
-ssh my-server "rm -rf /tmp/ccs-auth"
+# Clean up private staging files
+ssh my-server "rm -rf \"${STAGE_DIR}\""
 ```
 
 > **Tip:** `docker cp` is preferred over writing directly to Docker volume mountpoints, which require root access.


### PR DESCRIPTION
### Motivation
- The previous remote migration recipe staged sensitive CLIProxy OAuth JSON tokens in a predictable shared `/tmp/ccs-auth` path, which allows local attackers on a multi-user host to read or inject files during the import window.
- The goal is to reduce exposure and tampering risk during remote `ccs docker up --host` token migration without changing runtime behavior.

### Description
- Replace the fixed `/tmp/ccs-auth` staging path with a per-run private staging directory created via `mktemp -d` under the SSH user home and created with `umask 077` to ensure directory mode `0700`.
- Copy token files into the generated staging directory via `scp` rather than into a shared `/tmp` path.
- Harden staged file permissions with `chmod 600` before importing and preserve the existing import loop that uses `docker cp` to copy each JSON into the container.
- Clean up the generated private staging directory (`${STAGE_DIR}`) immediately after import to minimize the exposure window.

### Testing
- Pre-commit automated checks (`tsc --noEmit`, `eslint`, `prettier --check`) were executed by the commit hook and `prettier --check` failed due to unrelated formatting issues in other source files, causing the hook to fail; the change itself is documentation-only and does not affect runtime code.
- Static verification of the updated docs was performed by searching and printing the modified section to confirm the `mktemp`, `umask`, `chmod 600`, and `${STAGE_DIR}` usage were present and correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1244e217688330beb0d50b832c981c)