### PR TITLE
fix(browser): track explicit devtools_port from config

### DIFF
--- a/src/utils/browser/browser-settings.ts
+++ b/src/utils/browser/browser-settings.ts
@@ -230,6 +230,7 @@ export function getEffectiveClaudeBrowserAttachConfig(
   const override = getBrowserAttachOverride(env);
   const configUserDataDir =
     resolveBrowserUserDataDir(config.claude.user_data_dir) ?? getRecommendedBrowserUserDataDir();
+  const configHasExplicitPort = config.claude.devtools_port !== undefined;
   const configPort = normalizeDevtoolsPort(config.claude.devtools_port);
   const configEvalMode = config.claude.eval_mode ?? 'readonly';
   const envEvalMode = parseBrowserEvalMode(env.CCS_BROWSER_EVAL_MODE);
@@ -253,7 +254,7 @@ export function getEffectiveClaudeBrowserAttachConfig(
     overrideActive: false,
     userDataDir: configUserDataDir,
     devtoolsPort: configPort,
-    hasExplicitDevtoolsPort: false,
+    hasExplicitDevtoolsPort: configHasExplicitPort,
     evalMode: effectiveEvalMode,
   };
 }


### PR DESCRIPTION
Hotfix for regression introduced by #1369. The PR unconditionally set hasExplicitDevtoolsPort=false for config-attach sessions, which broke users who explicitly configured devtools_port in their config.

Fixes the test `browser status > always forwards an explicit port for config-backed browser attach sessions`.