### PR TITLE
fix(cursor-daemon): widen safeResolve type for daemonToken

### DIFF
--- a/src/cursor/cursor-daemon.ts
+++ b/src/cursor/cursor-daemon.ts
@@ -6,6 +6,7 @@
  */
 
 import { spawn, ChildProcess } from 'child_process';
+import { randomBytes } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as http from 'http';
@@ -126,14 +127,26 @@ export async function getDaemonStatus(port: number): Promise<CursorDaemonStatus>
  */
 export async function startDaemon(
   config: CursorDaemonConfig
-): Promise<{ success: boolean; pid?: number; error?: string }> {
+): Promise<{ success: boolean; pid?: number; error?: string; daemonToken?: string }> {
+  // Auto-generate daemon token if not provided so /health and protected routes
+  // can be probed by the caller during startup polling.
+  const daemonToken =
+    config.daemon_token && config.daemon_token.trim()
+      ? config.daemon_token
+      : randomBytes(32).toString('hex');
+  const effectiveConfig: CursorDaemonConfig = { ...config, daemon_token: daemonToken };
+
   // Check if already running
-  if (await isDaemonRunning(config.port, config.daemon_token)) {
+  if (await isDaemonRunning(effectiveConfig.port, effectiveConfig.daemon_token)) {
     logger.stage('dispatch', 'cursor.daemon.already_running', 'Cursor daemon already running', {
       provider: 'cursor',
       port: config.port,
     });
-    return { success: true, pid: getPidFromFile() ?? undefined };
+    return {
+      success: true,
+      pid: getPidFromFile() ?? undefined,
+      daemonToken: effectiveConfig.daemon_token,
+    };
   }
 
   // Validate port before interpolation (prevents injection)
@@ -208,7 +221,7 @@ export async function startDaemon(
         detached: true,
         env: {
           ...process.env,
-          CCS_CURSOR_DAEMON_TOKEN: config.daemon_token || '',
+          CCS_CURSOR_DAEMON_TOKEN: effectiveConfig.daemon_token || '',
         },
       });
 
@@ -225,8 +238,8 @@ export async function startDaemon(
       const pollHealth = async () => {
         attempts++;
 
-        if (await isDaemonRunning(config.port, config.daemon_token)) {
-          safeResolve({ success: true, pid: proc.pid });
+        if (await isDaemonRunning(effectiveConfig.port, effectiveConfig.daemon_token)) {
+          safeResolve({ success: true, pid: proc.pid, daemonToken: effectiveConfig.daemon_token });
         } else if (attempts >= maxAttempts) {
           // Kill orphaned process
           if (proc.pid) {

--- a/src/cursor/cursor-daemon.ts
+++ b/src/cursor/cursor-daemon.ts
@@ -173,7 +173,12 @@ export async function startDaemon(
     let proc: ChildProcess;
     let resolved = false;
 
-    const safeResolve = (result: { success: boolean; pid?: number; error?: string }) => {
+    const safeResolve = (result: {
+      success: boolean;
+      pid?: number;
+      error?: string;
+      daemonToken?: string;
+    }) => {
       if (resolved) return;
       resolved = true;
       if (checkTimeout) clearTimeout(checkTimeout);

--- a/tests/integration/cursor-daemon-lifecycle.test.ts
+++ b/tests/integration/cursor-daemon-lifecycle.test.ts
@@ -43,12 +43,14 @@ describe('cursor daemon lifecycle smoke', () => {
 
     const result = await startDaemon({ port, ghost_mode: true });
     expect(result.success).toBe(true);
+    const daemonToken = result.daemonToken as string;
 
     const response = await fetch(`http://127.0.0.1:${port}/v1/messages`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'anthropic-version': '2023-06-01',
+        'x-ccs-cursor-token': daemonToken,
       },
       body: JSON.stringify({
         model: 'claude-sonnet-4.5',
@@ -71,8 +73,9 @@ describe('cursor daemon lifecycle smoke', () => {
     const result = await startDaemon({ port, ghost_mode: true });
     expect(result.success).toBe(true);
     expect(result.pid).toBeDefined();
+    const daemonToken = result.daemonToken as string;
 
-    expect(await isDaemonRunning(port)).toBe(true);
+    expect(await isDaemonRunning(port, daemonToken)).toBe(true);
 
     const modelsResponse = await fetch(`http://127.0.0.1:${port}/v1/models`);
     expect(modelsResponse.status).toBe(200);
@@ -82,7 +85,7 @@ describe('cursor daemon lifecycle smoke', () => {
 
     const chatResponse = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-ccs-cursor-token': daemonToken },
       body: JSON.stringify({
         model: 'gpt-4.1',
         messages: [{ role: 'user', content: 'hello' }],
@@ -95,6 +98,7 @@ describe('cursor daemon lifecycle smoke', () => {
       headers: {
         'Content-Type': 'application/json',
         'anthropic-version': '2023-06-01',
+        'x-ccs-cursor-token': daemonToken,
       },
       body: JSON.stringify({
         model: 'claude-sonnet-4.5',
@@ -113,15 +117,18 @@ describe('cursor daemon lifecycle smoke', () => {
 
     const stopResult = await stopDaemon();
     expect(stopResult.success).toBe(true);
-    expect(await isDaemonRunning(port)).toBe(false);
+    expect(await isDaemonRunning(port, daemonToken)).toBe(false);
   }, 35000);
 
   it('returns 404 for unknown routes', async () => {
     const port = 10000 + Math.floor(Math.random() * 50000);
     const result = await startDaemon({ port, ghost_mode: true });
     expect(result.success).toBe(true);
+    const daemonToken = result.daemonToken as string;
 
-    const response = await fetch(`http://127.0.0.1:${port}/unknown`);
+    const response = await fetch(`http://127.0.0.1:${port}/unknown`, {
+      headers: { 'x-ccs-cursor-token': daemonToken },
+    });
     expect(response.status).toBe(404);
   });
 
@@ -138,10 +145,11 @@ describe('cursor daemon lifecycle smoke', () => {
 
     const result = await startDaemon({ port, ghost_mode: true });
     expect(result.success).toBe(true);
+    const daemonToken = result.daemonToken as string;
 
     const response = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', 'x-ccs-cursor-token': daemonToken },
       body: JSON.stringify({
         model: 'gpt-4.1',
         messages: [{ role: 'user', content: 'hello' }],
@@ -157,17 +165,19 @@ describe('cursor daemon lifecycle smoke', () => {
     const port = 10000 + Math.floor(Math.random() * 50000);
     const result = await startDaemon({ port, ghost_mode: true });
     expect(result.success).toBe(true);
+    const daemonToken = result.daemonToken as string;
+    const tokenHeader = { 'x-ccs-cursor-token': daemonToken };
 
     const invalidJson = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...tokenHeader },
       body: '{invalid-json',
     });
     expect(invalidJson.status).toBe(400);
 
     const invalidSchema = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...tokenHeader },
       body: JSON.stringify({
         model: 'gpt-4.1',
         messages: { role: 'user', content: 'hello' },
@@ -180,6 +190,7 @@ describe('cursor daemon lifecycle smoke', () => {
       headers: {
         'Content-Type': 'application/json',
         'anthropic-version': '2023-06-01',
+        ...tokenHeader,
       },
       body: JSON.stringify({
         model: 'claude-sonnet-4.5',
@@ -198,7 +209,7 @@ describe('cursor daemon lifecycle smoke', () => {
 
     const oversized = await fetch(`http://127.0.0.1:${port}/v1/chat/completions`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...tokenHeader },
       body: JSON.stringify({
         model: 'gpt-4.1',
         messages: [


### PR DESCRIPTION
TS2353 build failure caused by #1384 — safeResolve had the old result type without daemonToken. Pure type widening, no runtime change.