### PR TITLE
fix(cliproxy): prevent management key leak on runtime proxy overrides

### DIFF
--- a/src/cliproxy/proxy/__tests__/proxy-config-resolver.test.js
+++ b/src/cliproxy/proxy/__tests__/proxy-config-resolver.test.js
@@ -294,6 +294,33 @@ describe('proxy-config-resolver', () => {
         expect(config.managementKey).toBe('remote-management-key');
       });
 
+      it('should clear YAML management key when CLI overrides remote host', () => {
+        const { config } = resolveProxyConfig(['--proxy-host', 'cli-host.example.com'], {
+          remote: {
+            host: 'yaml-host.example.com',
+            auth_token: 'remote-auth-token',
+            management_key: 'remote-management-key',
+          },
+        });
+        expect(config.mode).toBe('remote');
+        expect(config.host).toBe('cli-host.example.com');
+        expect(config.managementKey).toBeUndefined();
+      });
+
+      it('should clear YAML management key when ENV overrides auth token', () => {
+        process.env.CCS_PROXY_AUTH_TOKEN = 'env-auth-token';
+        const { config } = resolveProxyConfig([], {
+          remote: {
+            host: 'yaml-host.example.com',
+            auth_token: 'remote-auth-token',
+            management_key: 'remote-management-key',
+          },
+        });
+        expect(config.mode).toBe('remote');
+        expect(config.authToken).toBe('env-auth-token');
+        expect(config.managementKey).toBeUndefined();
+      });
+
       it('should allow CLI --proxy-host to override YAML enabled:false', () => {
         const { config } = resolveProxyConfig(['--proxy-host', 'cli-host'], {
           remote: { enabled: false, host: 'yaml-host' },

--- a/src/cliproxy/proxy/proxy-config-resolver.ts
+++ b/src/cliproxy/proxy/proxy-config-resolver.ts
@@ -303,9 +303,7 @@ export function resolveProxyConfig(
     envConfig.protocol !== undefined ||
     cliFlags.authToken !== undefined ||
     envConfig.authToken !== undefined;
-  resolved.managementKey = hasRuntimeRemoteOverride
-    ? undefined
-    : yamlConfig.remote?.management_key;
+  resolved.managementKey = hasRuntimeRemoteOverride ? undefined : yamlConfig.remote?.management_key;
 
   // Merge timeout: CLI > ENV > config.yaml > default (2000ms in executor)
   resolved.timeout = cliFlags.timeout ?? envConfig.timeout ?? yamlConfig.remote?.timeout;

--- a/src/cliproxy/proxy/proxy-config-resolver.ts
+++ b/src/cliproxy/proxy/proxy-config-resolver.ts
@@ -291,7 +291,21 @@ export function resolveProxyConfig(
 
   // Merge auth token: CLI > ENV > config.yaml
   resolved.authToken = cliFlags.authToken ?? envConfig.authToken ?? yamlConfig.remote?.auth_token;
-  resolved.managementKey = yamlConfig.remote?.management_key;
+
+  // Keep YAML management key only when remote target/auth are not overridden via CLI/ENV.
+  // Prevents leaking a saved management key to a different runtime target.
+  const hasRuntimeRemoteOverride =
+    cliFlags.host !== undefined ||
+    envConfig.host !== undefined ||
+    cliFlags.port !== undefined ||
+    envConfig.port !== undefined ||
+    cliFlags.protocol !== undefined ||
+    envConfig.protocol !== undefined ||
+    cliFlags.authToken !== undefined ||
+    envConfig.authToken !== undefined;
+  resolved.managementKey = hasRuntimeRemoteOverride
+    ? undefined
+    : yamlConfig.remote?.management_key;
 
   // Merge timeout: CLI > ENV > config.yaml > default (2000ms in executor)
   resolved.timeout = cliFlags.timeout ?? envConfig.timeout ?? yamlConfig.remote?.timeout;


### PR DESCRIPTION
### Motivation
- A YAML-saved `management_key` could be attached to a different runtime proxy when the proxy host/auth were overridden via CLI or environment variables, causing a cross-target credential leak during management calls.
- The image-analysis readiness path uses management credentials from the resolved ProxyTarget and prefers `managementKey` over `authToken`, making the leak exploitable when overrides change the target but the YAML secret remains attached.
- The change prevents accidental disclosure of a high-value management secret to an overridden endpoint.

### Description
- In `resolveProxyConfig` (`src/cliproxy/proxy/proxy-config-resolver.ts`) only retain `yamlConfig.remote.management_key` when there are no runtime CLI/ENV overrides for host, port, protocol, or auth token; otherwise `managementKey` is cleared (`undefined`).
- This preserves existing behavior for YAML-only remote configurations while preventing the YAML `management_key` from being carried into runtime-overridden targets.
- Added regression tests to `src/cliproxy/proxy/__tests__/proxy-config-resolver.test.js` that assert the `managementKey` is preserved for YAML-only remote mode and cleared when CLI (`--proxy-host`) or ENV (`CCS_PROXY_AUTH_TOKEN`) overrides are present.

### Testing
- Ran a full build with `bun run build`, which completed successfully.
- Executed the proxy-config unit tests with `bun test ./src/cliproxy/proxy/__tests__/proxy-config-resolver.test.js`, and all tests passed (38 passed, 0 failed).
- The changes are minimal and covered by the added unit tests to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a124a7ad2508330b8ca79e9662a9c2a)