### PR TITLE
fix(web): avoid runtime proxy probes on public masked settings route

### DIFF
--- a/src/web-server/routes/settings-routes.ts
+++ b/src/web-server/routes/settings-routes.ts
@@ -22,7 +22,10 @@ import { deduplicateCcsHooks } from '../../utils/websearch/hook-utils';
 import { removeCcsImageAnalyzerHooks } from '../../utils/hooks/image-analyzer-hook-utils';
 import { resolveCliproxyBridgeMetadata } from '../../api/services';
 
-import { requireLocalAccessWhenAuthDisabled } from '../middleware/auth-middleware';
+import {
+  isLoopbackRemoteAddress,
+  requireLocalAccessWhenAuthDisabled,
+} from '../middleware/auth-middleware';
 import type { Settings } from '../../types/config';
 import type { CLIProxyProvider } from '../../cliproxy/types';
 import { mapExternalProviderName } from '../../cliproxy/provider-capabilities';
@@ -43,6 +46,7 @@ import { resolveImageAnalysisRuntimeStatus } from '../../utils/hooks';
 import {
   getCcsDir,
   getImageAnalysisConfig,
+  isDashboardAuthEnabled,
   loadConfigSafe,
   loadOrCreateUnifiedConfig,
   loadSettings,
@@ -153,6 +157,14 @@ function requireSensitiveLocalAccess(req: Request, res: Response): boolean {
     res,
     'Sensitive settings endpoints require localhost access when dashboard auth is disabled.'
   );
+}
+
+function canResolveSensitiveRuntimeStatus(req: Request): boolean {
+  if (isDashboardAuthEnabled()) {
+    return true;
+  }
+
+  return isLoopbackRemoteAddress(req.socket.remoteAddress);
 }
 
 function classifyConfigSaveFailure(error: unknown): { statusCode: number; message: string } {
@@ -498,17 +510,17 @@ router.get('/:profile', async (req: Request, res: Response): Promise<void> => {
     const stat = fs.statSync(settingsPath);
     const masked = maskApiKeys(settings);
 
+    const imageAnalysisStatus = canResolveSensitiveRuntimeStatus(req)
+      ? await resolveImageAnalysisStatusForProfile(profile, settings, settingsPath)
+      : null;
+
     res.json({
       profile,
       settings: masked,
       mtime: stat.mtime.getTime(),
       path: settingsPath,
       cliproxyBridge: resolveCliproxyBridgeMetadata(settings),
-      imageAnalysisStatus: await resolveImageAnalysisStatusForProfile(
-        profile,
-        settings,
-        settingsPath
-      ),
+      imageAnalysisStatus,
     });
   } catch (error) {
     respondInternalError(res, error, 'Internal server error.');


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated, non-local clients from triggering server-side CLIProxy management probes and learning proxy/auth readiness via the masked `GET /api/settings/:profile` response.

### Description

- Add `canResolveSensitiveRuntimeStatus(req)` which allows resolving runtime image-analysis status only when `isDashboardAuthEnabled()` or the request is from a loopback address via `isLoopbackRemoteAddress`.
- Import `isLoopbackRemoteAddress` and `isDashboardAuthEnabled` and use them in the helper to reuse existing auth/loopback primitives.
- Gate the masked settings route so it only `await resolveImageAnalysisStatusForProfile(...)` when the helper permits, otherwise return `imageAnalysisStatus: null` while preserving the rest of the masked response.
- Leave the raw settings/read/write endpoints unchanged and keep all existing behavior for authenticated or local accesses.

### Testing

- Ran `bun test tests/unit/web-server/settings-routes-image-analysis-status.test.ts`, and all tests passed (`11 pass`, `0 fail`).
- The change is minimal and covered by the existing unit tests for settings routes and image-analysis status diagnostics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a124bb98ea08330a72bd861e406add9)