### PR TITLE
fix: forward bare Claude subcommands through the default profile

### DIFF
--- a/src/dispatcher/profile-resolver.ts
+++ b/src/dispatcher/profile-resolver.ts
@@ -29,6 +29,7 @@ import { resolveTargetType, stripTargetFlag } from '../targets/target-resolver';
 import { DroidReasoningFlagError } from '../targets/droid-reasoning-runtime';
 import { DroidCommandRouterError, routeDroidCommandArgs } from '../targets/droid-command-router';
 import { resolveCliproxyBridgeMetadata } from '../api/services/cliproxy-profile-bridge';
+import { getClaudeSubcommandName } from '../utils/claude-subcommand-detector';
 import { resolveCodexRuntimeConfigOverrides } from './environment-builder';
 import {
   detectProfile,
@@ -83,6 +84,31 @@ function usesImplicitDefaultProfile(cleanArgs: string[]): boolean {
   return cleanArgs.length === 0 || cleanArgs[0]?.startsWith('-') === true;
 }
 
+/**
+ * Decide whether a first token that has no matching profile is actually a bare
+ * Claude subcommand that should be forwarded through the default profile.
+ *
+ * Claude Code exposes subcommands like `claude agents`, `claude mcp`,
+ * `claude plugin`, `claude setup-token`. Invoked through CCS as `ccs agents`,
+ * `ccs mcp`, ... the first token is treated as a profile name, so profile
+ * resolution throws "profile not found". Instead, forward such tokens to
+ * `claude <subcommand>` under the default profile (matching `ccs default
+ * agents`), where the launcher already strips interactive-session args.
+ *
+ * Gated to the claude target — codex/droid run their own subcommand routing —
+ * and only reached on the profile-not-found path, so a real configured profile
+ * of the same name always wins.
+ */
+export function isBareClaudeSubcommandPassthrough(profile: string, args: string[]): boolean {
+  if (profile === 'default') return false;
+  if (getClaudeSubcommandName([profile]) === null) return false;
+  try {
+    return resolveTargetType(args) === 'claude';
+  } catch {
+    return false;
+  }
+}
+
 function buildNativeCodexDefaultProfile(): ProfileDetectionResult {
   return {
     type: 'default',
@@ -123,8 +149,23 @@ export async function resolveProfileAndTarget(
 
   // Detect profile (strip --target flags before profile detection)
   const cleanArgs = stripTargetFlag(args);
-  const { profile, remainingArgs } = detectProfile(cleanArgs);
-  let profileInfo: ProfileDetectionResult = detector.detectProfileType(profile);
+  const detected = detectProfile(cleanArgs);
+  let profile = detected.profile;
+  let remainingArgs = detected.remainingArgs;
+  let profileInfo: ProfileDetectionResult;
+  try {
+    profileInfo = detector.detectProfileType(profile);
+  } catch (profileError) {
+    // Bare Claude subcommand passthrough: forward `ccs agents`, `ccs mcp`, ...
+    // through the default profile instead of failing as an unknown profile.
+    if (isBareClaudeSubcommandPassthrough(profile, args)) {
+      remainingArgs = [profile, ...remainingArgs];
+      profile = 'default';
+      profileInfo = detector.detectProfileType(profile);
+    } else {
+      throw profileError;
+    }
+  }
 
   let resolvedTarget: ReturnType<typeof resolveTargetType>;
   try {

--- a/tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts
+++ b/tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test';
+import { isBareClaudeSubcommandPassthrough } from '../../../src/dispatcher/profile-resolver';
+
+/**
+ * Bare Claude subcommand passthrough decision (`ccs agents`, `ccs mcp`, ...).
+ *
+ * The predicate is consulted only on the profile-not-found path, so a real
+ * configured profile of the same name is resolved earlier and never reaches
+ * this gate. These tests pin the decision matrix: forward documented Claude
+ * subcommands on the claude target, leave everything else alone.
+ */
+describe('isBareClaudeSubcommandPassthrough', () => {
+  it('reroutes a bare Claude subcommand on the default (claude) target', () => {
+    expect(isBareClaudeSubcommandPassthrough('agents', ['agents'])).toBe(true);
+    expect(isBareClaudeSubcommandPassthrough('mcp', ['mcp'])).toBe(true);
+    expect(isBareClaudeSubcommandPassthrough('plugin', ['plugin'])).toBe(true);
+    expect(isBareClaudeSubcommandPassthrough('setup-token', ['setup-token'])).toBe(true);
+  });
+
+  it('reroutes when the subcommand carries its own flags', () => {
+    expect(
+      isBareClaudeSubcommandPassthrough('agents', [
+        'agents',
+        '--permission-mode',
+        'bypassPermissions',
+      ])
+    ).toBe(true);
+  });
+
+  it('does not reroute the implicit default profile', () => {
+    expect(isBareClaudeSubcommandPassthrough('default', [])).toBe(false);
+  });
+
+  it('does not reroute an unknown non-subcommand token', () => {
+    expect(isBareClaudeSubcommandPassthrough('notaprofile', ['notaprofile'])).toBe(false);
+    expect(isBareClaudeSubcommandPassthrough('glm', ['glm'])).toBe(false);
+  });
+
+  it('does not reroute when an explicit non-claude target is selected', () => {
+    expect(isBareClaudeSubcommandPassthrough('agents', ['agents', '--target', 'droid'])).toBe(
+      false
+    );
+    expect(isBareClaudeSubcommandPassthrough('mcp', ['mcp', '--target', 'codex'])).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`ccs agents` exits with `[X] Profile not found: agents` instead of opening the Claude agent view. The same failure hits every bare Claude subcommand that is not also a CCS command: `ccs mcp`, `ccs plugin`, `ccs project`, `ccs setup-token`, `ccs auto-mode`, `ccs remote-control`, `ccs ultrareview`, `ccs upgrade`, `ccs install`.

`ccs <profile> agents` (e.g. `ccs glm agents`) was fixed in #1218, and `ccs default agents` already works — only the bare form was never routed.

Closes #1404

## Root Cause

In `resolveProfileAndTarget`, the first positional token is treated as a profile name. For a bare Claude subcommand no profile matches, so `ProfileDetector.detectProfileType()` throws `ProfileNotFoundError` (`profile-detector.ts:409`). Bare subcommands never reach the launcher that already strips interactive-session args and forwards `claude <subcommand>`.

## Fix

On the profile-not-found path, reroute documented Claude subcommands through the default profile (identical to `ccs default agents`):

- Uses the existing `CLAUDE_SUBCOMMANDS` set via `getClaudeSubcommandName` — no new list to keep in sync.
- Gated to the claude target; codex/droid keep their own subcommand routing.
- Only reached when no profile of that name exists, so a real configured profile of the same name still wins.
- CCS commands that shadow Claude subcommands (`doctor`, `update`, `auth`) are intercepted earlier by the root-command router and are unaffected.

## What changed

| File | Change |
|------|--------|
| `src/dispatcher/profile-resolver.ts` | Add `isBareClaudeSubcommandPassthrough` predicate; wrap profile-type detection to reroute bare Claude subcommands to the default profile |
| `tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts` | New unit tests pinning the reroute decision matrix |

## Validation

Verified end-to-end in a sandbox `CCS_HOME`:

```text
$ ccs agents      -> forwards to `claude agents` (no "profile not found")
$ ccs mcp         -> forwards to `claude mcp` (help renders)
$ ccs notaprofile -> still "[X] Profile not found: notaprofile" (no regression)
$ ccs --target droid agents -> not rerouted (droid path unchanged)
```

- [x] `bun run typecheck`
- [x] `bun run lint` / `format:check`
- [x] `bun run test:fast` (2299 pass, 0 fail)
- [x] `bun run validate:ci-parity` (full unit + e2e suites pass)
