### PR TITLE
hotfix: repair Docker release publishing

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -260,7 +260,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: docker
           file: docker/Dockerfile.integrated
           platforms: linux/amd64,linux/arm64
           push: true
@@ -331,6 +331,17 @@ jobs:
 
       - name: Pull image
         run: docker pull "${{ steps.image.outputs.ref }}"
+
+      - name: Verify anonymous pull access
+        run: |
+          CLEAN_DOCKER_CONFIG="$(mktemp -d)"
+          trap 'rm -rf "${CLEAN_DOCKER_CONFIG}"' EXIT
+          if ! DOCKER_CONFIG="${CLEAN_DOCKER_CONFIG}" docker pull "${{ steps.image.outputs.ref }}"; then
+            echo "[X] ghcr.io/kaitranntt/ccs is not anonymously pullable." >&2
+            echo "[i] Make the GHCR package public, then rerun the Docker publish workflow." >&2
+            exit 1
+          fi
+          echo "[OK] Anonymous pull succeeded for ${{ steps.image.outputs.ref }}"
 
       - name: Assert image size budget (amd64)
         run: |
@@ -471,3 +482,24 @@ jobs:
             "${IMAGE_REF}"
 
           echo "[OK] Promoted: :latest :${MINOR} :${MAJOR} → ${IMAGE_REF}"
+
+      - name: Verify promoted tags are anonymously pullable
+        env:
+          VERSION: ${{ needs.publish-integrated.outputs.version }}
+        run: |
+          OWNER_LOWER=$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${OWNER_LOWER}/ccs"
+          MINOR="${VERSION%.*}"
+          MAJOR="${VERSION%%.*}"
+          CLEAN_DOCKER_CONFIG="$(mktemp -d)"
+          trap 'rm -rf "${CLEAN_DOCKER_CONFIG}"' EXIT
+
+          for TAG in latest "${MINOR}" "${MAJOR}"; do
+            REF="${IMAGE}:${TAG}"
+            if ! DOCKER_CONFIG="${CLEAN_DOCKER_CONFIG}" docker pull "${REF}"; then
+              echo "[X] ${REF} is not anonymously pullable." >&2
+              echo "[i] Confirm the GHCR package is public, then rerun promotion." >&2
+              exit 1
+            fi
+            echo "[OK] Anonymous pull succeeded for ${REF}"
+          done

--- a/scripts/docker-dashboard-sunset-guard.js
+++ b/scripts/docker-dashboard-sunset-guard.js
@@ -97,9 +97,11 @@ function evaluateDashboardSunset({ targetTag, baselineVersion, releaseWindow, st
   const versions = parseStableTags(stableTags);
   const hasBaseline = versions.some((version) => compareVersions(version, baseline) === 0);
   if (compareVersions(target, baseline) > 0 && !hasBaseline) {
-    throw new Error(
-      `Cannot count dashboard sunset releases: baseline tag ${baseline.raw} is missing from git tags`,
-    );
+    return {
+      publish: false,
+      elapsed: releaseWindow,
+      reason: `legacy dashboard sunset baseline ${baseline.raw} is missing from git tags; skipping deprecated image publish`,
+    };
   }
 
   if (!versions.some((version) => compareVersions(version, target) === 0)) {

--- a/tests/docker/dashboard-sunset-guard.test.sh
+++ b/tests/docker/dashboard-sunset-guard.test.sh
@@ -106,8 +106,9 @@ assert_case "skips at the larger configured window boundary" 0 false 3 \
 assert_failure "rejects prerelease target tags" \
   --target "v7.80.0-rc.1" --baseline "7.80.0" --window "2"
 
-assert_failure "fails loudly when baseline tag is unavailable after baseline" \
-  --target "v7.81.2" --baseline "7.81.0" --window "2"
+assert_case "skips deprecated publish when baseline tag is unavailable after baseline" 0 false 2 \
+  "v7.81.2" "7.81.0" "2" \
+  $'v7.80.0'
 
 echo ""
 echo "Dashboard sunset guard tests complete: ${PASS} passed, ${FAIL} failed."

--- a/tests/unit/docker/docker-release-workflow-context.test.ts
+++ b/tests/unit/docker/docker-release-workflow-context.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const repoRoot = join(import.meta.dir, '../../..');
+
+describe('docker release workflow context', () => {
+  test('builds the integrated Dockerfile with the context its COPY paths expect', () => {
+    const workflow = readFileSync(join(repoRoot, '.github/workflows/docker-release.yml'), 'utf8');
+    const dockerfile = readFileSync(join(repoRoot, 'docker/Dockerfile.integrated'), 'utf8');
+
+    expect(workflow).toMatch(
+      /Build and push integrated image[\s\S]*context: docker[\s\S]*file: docker\/Dockerfile\.integrated/,
+    );
+    expect(dockerfile).toContain('COPY supervisord.conf /etc/supervisord.conf');
+    expect(dockerfile).toContain('COPY entrypoint-integrated.sh /entrypoint-integrated.sh');
+    expect(existsSync(join(repoRoot, 'docker/supervisord.conf'))).toBe(true);
+    expect(existsSync(join(repoRoot, 'docker/entrypoint-integrated.sh'))).toBe(true);
+  });
+
+  test('keeps integrated smoke tests independent from legacy dashboard publish', () => {
+    const workflow = readFileSync(join(repoRoot, '.github/workflows/docker-release.yml'), 'utf8');
+
+    expect(workflow).not.toMatch(/publish-integrated:[\s\S]*?needs:\s*\[?publish-dashboard/);
+    expect(workflow).toMatch(/smoke-test:[\s\S]*?needs:\s*\[publish-integrated\]/);
+  });
+
+  test('verifies immutable and promoted tags without registry credentials', () => {
+    const workflow = readFileSync(join(repoRoot, '.github/workflows/docker-release.yml'), 'utf8');
+
+    expect(workflow).toMatch(
+      /Verify anonymous pull access[\s\S]*DOCKER_CONFIG="\$\{CLEAN_DOCKER_CONFIG\}" docker pull/
+    );
+    expect(workflow).toMatch(
+      /Verify promoted tags are anonymously pullable[\s\S]*DOCKER_CONFIG="\$\{CLEAN_DOCKER_CONFIG\}" docker pull/
+    );
+  });
+});

--- a/tests/unit/scripts/docker-dashboard-sunset-guard.test.ts
+++ b/tests/unit/scripts/docker-dashboard-sunset-guard.test.ts
@@ -45,14 +45,18 @@ describe('docker dashboard sunset guard', () => {
     });
   });
 
-  test('fails loudly if the baseline tag is missing after the baseline', () => {
-    expect(() =>
-      evaluateDashboardSunset({
-        targetTag: 'v7.81.2',
-        baselineVersion: '7.81.0',
-        releaseWindow: 2,
-        stableTags: ['v7.80.0'],
-      }),
-    ).toThrow('baseline tag v7.81.0 is missing');
+  test('skips deprecated publish if the baseline tag is missing after the baseline', () => {
+    const result = evaluateDashboardSunset({
+      targetTag: 'v7.81.2',
+      baselineVersion: '7.81.0',
+      releaseWindow: 2,
+      stableTags: ['v7.80.0'],
+    });
+
+    expect(result).toMatchObject({
+      elapsed: 2,
+      publish: false,
+    });
+    expect(result.reason).toContain('baseline v7.81.0 is missing');
   });
 });


### PR DESCRIPTION
Refs #1400

## Summary
- fix integrated Docker build context so docker/Dockerfile.integrated can copy sibling docker assets
- make missing legacy dashboard baseline tags skip deprecated publishing instead of failing stable Docker releases
- add anonymous GHCR pull verification for immutable and promoted container tags

## Validation
- bun test tests/unit/scripts/docker-dashboard-sunset-guard.test.ts tests/unit/docker/docker-release-workflow-context.test.ts
- bash tests/docker/dashboard-sunset-guard.test.sh
- bun run validate
- bun run validate:ci-parity

## Release note
Do not close #1400 on merge alone. Close after stable release, latest promotion, and anonymous pull verification pass.