### PR TITLE
hotfix: add integrated Docker healthcheck

### DIFF
--- a/docker/Dockerfile.integrated
+++ b/docker/Dockerfile.integrated
@@ -45,4 +45,7 @@ RUN chmod +x /entrypoint-integrated.sh \
 
 EXPOSE 3000 8085 8317
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "const http=require('http');const probe=(url)=>new Promise((resolve)=>{const req=http.get(url,(res)=>{res.resume();resolve(res.statusCode<400);});req.on('error',()=>resolve(false));req.setTimeout(4500,()=>{req.destroy();resolve(false);});});Promise.all([probe('http://127.0.0.1:3000/'),probe('http://127.0.0.1:8317/')]).then((results)=>process.exit(results.every(Boolean)?0:1));"
+
 ENTRYPOINT ["/entrypoint-integrated.sh"]

--- a/tests/unit/docker/docker-release-workflow-context.test.ts
+++ b/tests/unit/docker/docker-release-workflow-context.test.ts
@@ -35,4 +35,12 @@ describe('docker release workflow context', () => {
       /Verify promoted tags are anonymously pullable[\s\S]*DOCKER_CONFIG="\$\{CLEAN_DOCKER_CONFIG\}" docker pull/
     );
   });
+
+  test('gives the raw integrated image a Docker healthcheck for release smoke tests', () => {
+    const dockerfile = readFileSync(join(repoRoot, 'docker/Dockerfile.integrated'), 'utf8');
+
+    expect(dockerfile).toContain('HEALTHCHECK');
+    expect(dockerfile).toContain('127.0.0.1:3000');
+    expect(dockerfile).toContain('127.0.0.1:8317');
+  });
 });


### PR DESCRIPTION
## Summary
- add a Docker HEALTHCHECK to the integrated CCS image
- probe both Dashboard :3000 and CLIProxy :8317 from inside the raw image
- add regression coverage so release smoke tests do not wait on a missing health object

## Verification
- TDD red: `bun test tests/unit/docker/docker-release-workflow-context.test.ts` failed before Dockerfile change on missing HEALTHCHECK
- `bun test tests/unit/docker/docker-release-workflow-context.test.ts`
- `bun test tests/unit/docker/docker-release-workflow-context.test.ts tests/unit/docker/dockerfile-lifecycle-scripts.test.ts tests/unit/scripts/docker-dashboard-sunset-guard.test.ts`
- `bash tests/docker/dashboard-sunset-guard.test.sh`
- `bash tests/docker/image-size-logic.test.sh`
- `bun run validate`
- pre-push `scripts/ci-parity-gate.sh`

Local Docker parser check was not run because this workstation has no `docker` CLI.

Refs #1400