### PR TITLE
fix: redact OAuth trace error messages

### DIFF
--- a/src/cliproxy/auth/__tests__/oauth-handler-paste-callback.test.ts
+++ b/src/cliproxy/auth/__tests__/oauth-handler-paste-callback.test.ts
@@ -306,7 +306,11 @@ describe('handlePasteCallbackMode traceability', () => {
       },
       {
         url: /\/v0\/management\/oauth-callback$/,
-        response: { status: 'error', error: 'invalid_grant: expired code' },
+        response: {
+          status: 'error',
+          error:
+            'invalid_grant: bad redirect http://localhost:1455/callback?code=oauth-code-secret&state=upstream-state-secret',
+        },
         status: 400,
       },
     ]);

--- a/src/cliproxy/auth/__tests__/oauth-trace-recorder.test.ts
+++ b/src/cliproxy/auth/__tests__/oauth-trace-recorder.test.ts
@@ -120,9 +120,29 @@ describe('createOAuthTraceRecorder', () => {
     expect(snap[0].error).toEqual({ code: 'E1', message: 'boom' });
   });
 
-  test('Error instance accepted', () => {
+  test('redacts OAuth secrets from error messages before they reach sinks', () => {
+    const lines: string[] = [];
+    const { rec } = makeRecorder(true, lines);
+    rec.record(OAuthTracePhase.Error, undefined, {
+      code: 'CALLBACK_REJECTED',
+      message:
+        'bad redirect http://localhost:1455/callback?code=AUTHCODE_SECRET&state=STATE_SECRET',
+    });
+
+    const blob = JSON.stringify(rec.snapshot()) + '\n' + lines.join('\n');
+    expect(blob).not.toContain('AUTHCODE_SECRET');
+    expect(blob).not.toContain('STATE_SECRET');
+    expect(blob).toContain(REDACTED_PLACEHOLDER);
+  });
+
+  test('Error instance accepted and redacted', () => {
     const { rec } = makeRecorder();
-    rec.record(OAuthTracePhase.Error, undefined, new Error('plain'));
-    expect(rec.snapshot()[0].error?.message).toBe('plain');
+    rec.record(
+      OAuthTracePhase.Error,
+      undefined,
+      new Error('bad redirect http://localhost:1455/callback?code=AUTHCODE_SECRET')
+    );
+    expect(rec.snapshot()[0].error?.message).toContain(REDACTED_PLACEHOLDER);
+    expect(rec.snapshot()[0].error?.message).not.toContain('AUTHCODE_SECRET');
   });
 });

--- a/src/cliproxy/auth/oauth-handler.ts
+++ b/src/cliproxy/auth/oauth-handler.ts
@@ -82,6 +82,7 @@ import { generateSessionId } from './project-selection-handler';
 import { createFileSink } from './oauth-trace/sink-file';
 import { createOAuthTraceRecorder, OAuthTracePhase, type OAuthTraceRecorder } from './oauth-trace';
 import { diagnoseFailure, formatErrorMessage } from './oauth-trace/diagnose-failure';
+import { redactString } from './oauth-trace/redactor';
 
 interface PasteCallbackStartData {
   url?: string;
@@ -889,8 +890,9 @@ export async function handlePasteCallbackMode(
     if (!callbackResponse.ok || callbackData.status === 'error') {
       const callbackError =
         callbackData.error || `OAuth callback failed with status ${callbackResponse.status}`;
-      console.log(fail(callbackError));
-      warnPossible403Ban(provider, callbackError);
+      const redactedCallbackError = redactString(callbackError);
+      console.log(fail(redactedCallbackError));
+      warnPossible403Ban(provider, redactedCallbackError);
       trace.record(
         OAuthTracePhase.Error,
         { status: callbackResponse.status },
@@ -915,8 +917,9 @@ export async function handlePasteCallbackMode(
     );
 
     if (tokenWaitError) {
-      console.log(fail(tokenWaitError));
-      warnPossible403Ban(provider, tokenWaitError);
+      const redactedTokenWaitError = redactString(tokenWaitError);
+      console.log(fail(redactedTokenWaitError));
+      warnPossible403Ban(provider, redactedTokenWaitError);
       trace.record(
         OAuthTracePhase.Error,
         {},

--- a/src/cliproxy/auth/oauth-trace/trace-recorder.ts
+++ b/src/cliproxy/auth/oauth-trace/trace-recorder.ts
@@ -1,7 +1,7 @@
 import { OAuthTraceEvent, OAuthTracePhase, OAuthTraceSink } from './trace-events';
 import { createMemorySink } from './sink-memory';
 import { createVerboseStdoutSink } from './sink-verbose-stdout';
-import { redactJsonShallow } from './redactor';
+import { redactJsonShallow, redactString } from './redactor';
 
 export interface OAuthTraceRecorder {
   record(
@@ -53,9 +53,9 @@ export function createOAuthTraceRecorder(options: OAuthTraceRecorderOptions): OA
   ): { code?: string; message: string } | undefined {
     if (!err) return undefined;
     if (err instanceof Error) {
-      return { message: err.message };
+      return { message: redactString(err.message) };
     }
-    return { code: err.code, message: err.message };
+    return { code: err.code, message: redactString(err.message) };
   }
 
   return {


### PR DESCRIPTION
### Motivation
- Prevent OAuth authorization codes/state from being persisted or printed by ensuring error messages passed to tracing and sinks are redacted before they reach any sink or CLI output.
- Close a confidentiality gap where management endpoints that echo the callback URL could leak secrets into the optional file sink or verbose trace output.

### Description
- Redact error message text before creating trace events by applying `redactString` to `Error` instances and provided error objects in `src/cliproxy/auth/oauth-trace/trace-recorder.ts` so `event.error.message` no longer contains raw secrets.
- Redact paste-callback endpoint and token-wait error strings before printing or handing them to account-safety warnings in `src/cliproxy/auth/oauth-handler.ts` so CLI output and ban-warning logic do not expose callback secrets.
- Add/adjust tests in `src/cliproxy/auth/__tests__/oauth-trace-recorder.test.ts` and `src/cliproxy/auth/__tests__/oauth-handler-paste-callback.test.ts` to cover echoing callback URLs in management errors and assert that `code`/`state` and OAuth codes are redacted in snapshots and verbose output.

### Testing
- Ran the modified unit tests with `bun test ./src/cliproxy/auth/__tests__/oauth-trace-recorder.test.ts ./src/cliproxy/auth/__tests__/oauth-handler-paste-callback.test.ts` and they passed (both files: 41 tests, 0 failures).
- Ran formatting and linting with `bun run format` and `bun run lint:fix` and they completed successfully for the repository changes made.
- Ran full validation via `bun run validate`, which exercised the broader test suite; validation reported two unrelated fast-test failures in existing tests (`web-server account-routes context normalization` and `browser status`) that are pre-existing and not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19955b65808330ad3442fe5e8bdc8f)