### PR TITLE
fix: compare cliproxy fork release suffixes

### DIFF
--- a/src/cliproxy/binary/__tests__/version-checker-suffix.test.ts
+++ b/src/cliproxy/binary/__tests__/version-checker-suffix.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'bun:test';
+
+import { compareCliproxyVersions, isNewerVersion } from '../version-checker';
+
+describe('cliproxy version comparison', () => {
+  it('treats missing fork release suffix as zero', () => {
+    expect(compareCliproxyVersions('6.6.81', '6.6.81-0')).toBe(0);
+    expect(isNewerVersion('6.6.81-0', '6.6.81')).toBe(false);
+  });
+
+  it('orders patched fork release suffixes after core version equality', () => {
+    expect(compareCliproxyVersions('7.1.31-1', '7.1.31-0')).toBe(1);
+    expect(compareCliproxyVersions('7.1.31-0', '7.1.31-1')).toBe(-1);
+    expect(isNewerVersion('7.1.31-1', '7.1.31-0')).toBe(true);
+  });
+
+  it('lets core version precedence win before fork release suffixes', () => {
+    expect(compareCliproxyVersions('7.1.32-0', '7.1.31-99')).toBe(1);
+    expect(isNewerVersion('7.1.31-99', '7.1.32-0')).toBe(false);
+  });
+});

--- a/src/cliproxy/binary/version-checker.ts
+++ b/src/cliproxy/binary/version-checker.ts
@@ -33,28 +33,49 @@ interface FetchAllVersionsDeps {
   fetchJsonFn?: typeof fetchJson;
 }
 
+interface ParsedCliproxyVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  forkRelease: number;
+}
+
+function parseCliproxyVersion(version: string): ParsedCliproxyVersion {
+  const normalized = version.trim().replace(/^v/, '');
+  const [coreVersion, forkReleaseValue = '0'] = normalized.split('-', 2);
+  const [major = 0, minor = 0, patch = 0] = coreVersion
+    .split('.')
+    .map((part) => parseInt(part, 10) || 0);
+  const forkRelease = /^\d+$/.test(forkReleaseValue) ? parseInt(forkReleaseValue, 10) || 0 : 0;
+
+  return { major, minor, patch, forkRelease };
+}
+
+function compareVersionPart(a: number, b: number): number {
+  if (a > b) return 1;
+  if (a < b) return -1;
+  return 0;
+}
+
+export function compareCliproxyVersions(a: string, b: string): number {
+  const left = parseCliproxyVersion(a);
+  const right = parseCliproxyVersion(b);
+
+  return (
+    compareVersionPart(left.major, right.major) ||
+    compareVersionPart(left.minor, right.minor) ||
+    compareVersionPart(left.patch, right.patch) ||
+    compareVersionPart(left.forkRelease, right.forkRelease)
+  );
+}
+
 /**
- * Compare semver versions (true if latest > current)
- * Handles CLIProxyAPIPlus versioning: strips -0 suffix before comparison
+ * Compare CLIProxy release versions (true if latest > current).
+ * Missing fork suffixes are treated as -0, while patched fork suffixes such as
+ * 7.1.31-1 still sort newer than 7.1.31-0.
  */
 export function isNewerVersion(latest: string, current: string): boolean {
-  // Strip -0 suffix from CLIProxyAPIPlus versions (e.g., "6.6.40-0" -> "6.6.40")
-  const cleanLatest = latest.replace(/-\d+$/, '');
-  const cleanCurrent = current.replace(/-\d+$/, '');
-
-  const latestParts = cleanLatest.split('.').map((p) => parseInt(p, 10) || 0);
-  const currentParts = cleanCurrent.split('.').map((p) => parseInt(p, 10) || 0);
-
-  // Pad arrays to same length
-  while (latestParts.length < 3) latestParts.push(0);
-  while (currentParts.length < 3) currentParts.push(0);
-
-  for (let i = 0; i < 3; i++) {
-    if (latestParts[i] > currentParts[i]) return true;
-    if (latestParts[i] < currentParts[i]) return false;
-  }
-
-  return false; // Equal versions
+  return compareCliproxyVersions(latest, current) > 0;
 }
 
 /**

--- a/tests/unit/ui/cliproxy-version-risk.test.ts
+++ b/tests/unit/ui/cliproxy-version-risk.test.ts
@@ -6,9 +6,11 @@ import {
 } from '../../../ui/src/lib/cliproxy-version-risk';
 
 describe('cliproxy-version-risk helpers', () => {
-  it('compares versions while ignoring release suffixes', () => {
+  it('compares fork release suffixes after core versions', () => {
     expect(compareCliproxyVersions('6.6.88', '6.6.81-0')).toBe(1);
     expect(compareCliproxyVersions('6.6.81-0', '6.6.81')).toBe(0);
+    expect(compareCliproxyVersions('7.1.31-1', '7.1.31-0')).toBe(1);
+    expect(compareCliproxyVersions('7.1.31-0', '7.1.31-1')).toBe(-1);
     expect(compareCliproxyVersions('6.6.80', '6.6.81')).toBe(-1);
   });
 

--- a/ui/src/lib/cliproxy-version-risk.ts
+++ b/ui/src/lib/cliproxy-version-risk.ts
@@ -1,20 +1,39 @@
-function normalizeVersionParts(version: string): number[] {
-  return version.replace(/-\d+$/, '').split('.').map(Number);
+interface ParsedCliproxyVersion {
+  major: number;
+  minor: number;
+  patch: number;
+  forkRelease: number;
+}
+
+function parseCliproxyVersion(version: string): ParsedCliproxyVersion {
+  const normalized = version.trim().replace(/^v/, '');
+  const [coreVersion, forkReleaseValue = '0'] = normalized.split('-', 2);
+  const [major = 0, minor = 0, patch = 0] = coreVersion
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+  const forkRelease = /^\d+$/.test(forkReleaseValue)
+    ? Number.parseInt(forkReleaseValue, 10) || 0
+    : 0;
+
+  return { major, minor, patch, forkRelease };
+}
+
+function compareVersionPart(a: number, b: number): number {
+  if (a > b) return 1;
+  if (a < b) return -1;
+  return 0;
 }
 
 export function compareCliproxyVersions(a: string, b: string): number {
-  const aParts = normalizeVersionParts(a);
-  const bParts = normalizeVersionParts(b);
+  const left = parseCliproxyVersion(a);
+  const right = parseCliproxyVersion(b);
 
-  for (let index = 0; index < 3; index += 1) {
-    const aPart = aParts[index] || 0;
-    const bPart = bParts[index] || 0;
-
-    if (aPart > bPart) return 1;
-    if (aPart < bPart) return -1;
-  }
-
-  return 0;
+  return (
+    compareVersionPart(left.major, right.major) ||
+    compareVersionPart(left.minor, right.minor) ||
+    compareVersionPart(left.patch, right.patch) ||
+    compareVersionPart(left.forkRelease, right.forkRelease)
+  );
 }
 
 export function isCliproxyVersionExperimental(version: string, maxStableVersion: string): boolean {


### PR DESCRIPTION
Closes #1418.

## Summary
- compare CLIProxy Plus fork release suffixes instead of stripping them
- treat a missing suffix as -0 for current compatibility
- keep dashboard version-risk helpers aligned with updater semantics

## Validation
- bun test ./src/cliproxy/binary/__tests__/version-checker-suffix.test.ts tests/unit/ui/cliproxy-version-risk.test.ts
- bun run format && bun run lint:fix && bun run validate
- commit hook: tsc --noEmit, eslint src/ --fix, prettier --check src/, ui validate

Docs impact: none
Action: no update needed - internal update-resolution comparator; no command/config/docs surface changed