### PR TITLE
fix: restrict Codex usage cache permissions

### DIFF
--- a/src/web-server/usage/codex-native-usage-collector.ts
+++ b/src/web-server/usage/codex-native-usage-collector.ts
@@ -14,6 +14,8 @@ interface CodexNativeUsageCollectorOptions {
 }
 
 const CODEX_NATIVE_USAGE_CACHE_VERSION = 1;
+const SECURE_CACHE_DIR_MODE = 0o700;
+const SECURE_CACHE_FILE_MODE = 0o600;
 
 interface CachedRolloutFile {
   path: string;
@@ -133,6 +135,14 @@ function isCodexNativeUsageCache(value: unknown): value is CodexNativeUsageCache
   return Object.values(value.files).every(isCachedRolloutFile);
 }
 
+function chmodBestEffort(targetPath: string, mode: number): void {
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch {
+    // Cache reads and writes remain best-effort on filesystems that do not support chmod.
+  }
+}
+
 function readUsageCache(
   cacheDir: string,
   includeCliproxySessions: boolean
@@ -153,11 +163,17 @@ function readUsageCache(
 
 function writeUsageCache(cacheDir: string, cache: CodexNativeUsageCache): void {
   try {
-    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.mkdirSync(cacheDir, { recursive: true, mode: SECURE_CACHE_DIR_MODE });
+    chmodBestEffort(cacheDir, SECURE_CACHE_DIR_MODE);
     const cachePath = getCacheFilePath(cacheDir, cache.includeCliproxySessions);
     const tempPath = `${cachePath}.${process.pid}.tmp`;
-    fs.writeFileSync(tempPath, JSON.stringify(cache), 'utf8');
+    fs.writeFileSync(tempPath, JSON.stringify(cache), {
+      encoding: 'utf8',
+      mode: SECURE_CACHE_FILE_MODE,
+    });
+    chmodBestEffort(tempPath, SECURE_CACHE_FILE_MODE);
     fs.renameSync(tempPath, cachePath);
+    chmodBestEffort(cachePath, SECURE_CACHE_FILE_MODE);
   } catch {
     // Best-effort only.
   }

--- a/tests/unit/web-server/codex-native-usage-collector.test.ts
+++ b/tests/unit/web-server/codex-native-usage-collector.test.ts
@@ -311,6 +311,28 @@ describe('codex native usage collector', () => {
     expect(entries).toHaveLength(2);
   });
 
+  it('writes native usage caches with owner-only permissions', async () => {
+    if (process.platform === 'win32') return;
+
+    writeCodexRollout(tempRoot);
+    const cacheDir = getCacheDir();
+    const previousUmask = process.umask(0o022);
+
+    try {
+      await scanCodexNativeUsageEntries({
+        env: { CODEX_HOME: tempRoot },
+        homeDir: tempRoot,
+        cacheDir,
+      });
+    } finally {
+      process.umask(previousUmask);
+    }
+
+    const cachePath = path.join(cacheDir, 'codex-native-usage-v1.json');
+    expect(fs.statSync(cacheDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(cachePath).mode & 0o777).toBe(0o600);
+  });
+
   it('keeps default and include-cliproxy cache entries separate', async () => {
     writeCodexRollout(tempRoot, { modelProvider: 'cliproxy' });
     const cacheDir = getCacheDir();


### PR DESCRIPTION
### Motivation
- Prevent unintended local information disclosure by ensuring the persistent Codex usage cache directory and files are created with owner-only permissions instead of relying on process umask.

### Description
- Add `SECURE_CACHE_DIR_MODE = 0o700` and `SECURE_CACHE_FILE_MODE = 0o600` and ensure the cache directory is created with `fs.mkdirSync(..., { mode })` and a best-effort `chmod` is applied where appropriate.
- Write cache to a temp file using `fs.writeFileSync(..., { encoding: 'utf8', mode })`, rename it into place, and apply a best-effort `chmod` to both temp and final cache files to harden file permissions.
- Introduce `chmodBestEffort()` helper so the code remains non-fatal on filesystems that do not support `chmod` while still hardening POSIX hosts.
- Add a regression test that simulates a common permissive umask and asserts the cache directory is `0700` and cache file is `0600`, and apply formatting fixes flagged by the repo style checks.

### Testing
- Ran `bun test tests/unit/web-server/codex-native-usage-collector.test.ts` and the updated suite passed (8 tests, 0 failures).
- Ran `bun run typecheck`, `bun run lint`, and `bun run format:check`, and these checks completed successfully for the modified files.
- Ran broader validation (`env -u CODEX_HOME bun run validate` and `bun run validate:ci-parity`), which executed full build and test buckets; these runs reported unrelated pre-existing failures in other test areas (account-routes / browser-status and multiple settings-profile launch/image-analysis tests) and are not caused by the cache-permissions change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199ff66ed08330b40963585e7fa5eb)