### PR TITLE
fix(ui): prevent log coalescing key collisions

### DIFF
--- a/ui/src/components/logs/derive-trace-groups.ts
+++ b/ui/src/components/logs/derive-trace-groups.ts
@@ -30,7 +30,7 @@ export type DerivedItem = LeafItem | TraceGroup;
  * stay individually inspectable.
  */
 function coalesceKey(entry: LogsEntry): string {
-  return [
+  return JSON.stringify([
     entry.event ?? '',
     entry.message ?? '',
     entry.stage ?? '',
@@ -38,7 +38,7 @@ function coalesceKey(entry: LogsEntry): string {
     entry.level,
     entry.requestId ?? '',
     entry.source ?? '',
-  ].join(' ');
+  ]);
 }
 
 /**

--- a/ui/tests/unit/ui/components/logs-derive-trace-groups.test.ts
+++ b/ui/tests/unit/ui/components/logs-derive-trace-groups.test.ts
@@ -141,6 +141,19 @@ describe('deriveTraceGroups', () => {
     expect(result.every((r) => r.kind === 'leaf' && r.repeatCount === undefined)).toBe(true);
   });
 
+  it('keeps adjacent leaves with tuple fields that differ only by spaces as separate rows', () => {
+    const result = deriveTraceGroups(
+      leafEntries(
+        { id: '1', timestamp: 't1', event: 'auth', message: 'failed login' },
+        { id: '2', timestamp: 't2', event: 'auth failed', message: 'login' }
+      )
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.kind === 'leaf' && r.repeatCount === undefined)).toBe(true);
+    expect(result.map((r) => (r.kind === 'leaf' ? r.entry.id : 'trace'))).toEqual(['2', '1']);
+  });
+
   it('display-sorts items reverse-chronologically', () => {
     // Use distinct events so leaves don't coalesce — testing display sort,
     // not coalesce.


### PR DESCRIPTION
### Motivation
- The standalone-leaf coalescing key was previously serialized with a space-delimited `join(' ')`, which is not injective for fields that can contain spaces and can cause distinct adjacent log rows to collapse into a single ×N row in the dashboard.

### Description
- Replace the space-joined tuple key with a stable JSON serialization using `JSON.stringify([...])` in `coalesceKey` so tuple fields containing spaces cannot collide.
- Add a regression unit test that ensures adjacent leaves whose tuple fields differ only by spaces remain separate rows in `deriveTraceGroups`.
- Preserve the existing adjacency/coalescing semantics so only the key serialization changed and trace-group behavior is unchanged.

### Testing
- Ran the focused unit tests with `cd ui && bun run test:run tests/unit/ui/components/logs-derive-trace-groups.test.ts`, and the test file passed (`18 tests` all green).
- Ran `cd ui && bun run format && bun run validate` for UI lint/format/type checks, which completed successfully for the UI package.
- Ran the repository parity gate `bun run validate:ci-parity`, which failed due to pre-existing `prettier --check src/` warnings in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts` that are unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199e8c9b8c8330971f15829fef973d)