### PR TITLE
fix(cliproxy): sanitize Codex quota labels

### DIFF
--- a/src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts
+++ b/src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts
@@ -382,6 +382,44 @@ describe('Codex Quota Fetcher', () => {
       expect(windows[0].featureLabel).toBe('Custom-Feature');
       expect(windows[0].usedPercent).toBe(50);
     });
+
+    it('should remove terminal control characters from additional limit labels', () => {
+      const response = {
+        additional_rate_limits: [
+          {
+            limit_name: '\u001b[2JGPT-5.3-Codex-Spark\u001b]52;c;payload\u0007',
+            rate_limit: {
+              primary_window: { used_percent: 25, reset_after_seconds: 3600 },
+            },
+          },
+        ],
+      };
+
+      const windows = buildCodexQuotaWindows(response);
+
+      expect(windows).toHaveLength(1);
+      expect(windows[0].featureLabel).toBe('GPT-5.3-Codex-Spark');
+      expect(windows[0].label).toBe('GPT-5.3-Codex-Spark (Primary)');
+    });
+
+    it('should bound additional limit labels before storing them', () => {
+      const response = {
+        additional_rate_limits: [
+          {
+            limit_name: `Feature-${'x'.repeat(120)}`,
+            rate_limit: {
+              primary_window: { used_percent: 25, reset_after_seconds: 3600 },
+            },
+          },
+        ],
+      };
+
+      const windows = buildCodexQuotaWindows(response);
+
+      expect(windows).toHaveLength(1);
+      expect(windows[0].featureLabel).toHaveLength(80);
+      expect(windows[0].label).toBe(`${windows[0].featureLabel} (Primary)`);
+    });
   });
 
   describe('buildCodexCoreUsageSummary', () => {

--- a/src/cliproxy/quota/quota-fetcher-codex.ts
+++ b/src/cliproxy/quota/quota-fetcher-codex.ts
@@ -11,6 +11,7 @@ import { getAuthDir } from '../config/config-generator';
 import { getAccount, getProviderAccounts, getPausedDir } from '../accounts/account-manager';
 import { sanitizeEmail, isTokenExpired } from '../auth/auth-utils';
 import type { CodexQuotaResult, CodexQuotaWindow, CodexCoreUsageSummary } from './quota-types';
+import { sanitizeCodexFeatureLabel } from './quota-label-sanitizer';
 import { extractCanonicalEmailFromAccountId } from '../accounts/email-account-identity';
 
 /** ChatGPT backend API base URL */
@@ -58,8 +59,8 @@ interface CodexRateLimitWindow {
  * Each entry surfaces its own primary/secondary windows under a feature-specific limit name.
  */
 interface CodexAdditionalRateLimit {
-  limit_name?: string;
-  limitName?: string;
+  limit_name?: unknown;
+  limitName?: unknown;
   metered_feature?: string;
   meteredFeature?: string;
   rate_limit?: CodexRateLimitWindow;
@@ -380,11 +381,7 @@ function buildCodexQuotaWindows(payload: CodexUsageResponse): CodexQuotaWindow[]
       const entryRateLimit = entry.rate_limit || entry.rateLimit;
       if (!entryRateLimit) continue;
 
-      const rawFeatureLabel = entry.limit_name ?? entry.limitName;
-      const featureLabel =
-        typeof rawFeatureLabel === 'string' && rawFeatureLabel.trim().length > 0
-          ? rawFeatureLabel.trim()
-          : 'Additional';
+      const featureLabel = sanitizeCodexFeatureLabel(entry.limit_name ?? entry.limitName);
       addWindow(
         `${featureLabel} (Primary)`,
         entryRateLimit.primary_window || entryRateLimit.primaryWindow,

--- a/src/cliproxy/quota/quota-label-sanitizer.ts
+++ b/src/cliproxy/quota/quota-label-sanitizer.ts
@@ -11,8 +11,8 @@ const TERMINAL_CONTROL_CHARS_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
  * labels must be constrained to safe, printable strings before they reach the
  * terminal.
  */
-export function sanitizeCodexFeatureLabel(value: unknown): string {
-  if (typeof value !== 'string') return CODEX_FEATURE_LABEL_FALLBACK;
+export function sanitizeCodexFeatureLabelOrNull(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
 
   const sanitized = value
     .replace(TERMINAL_ESCAPE_SEQUENCE_REGEX, '')
@@ -21,5 +21,9 @@ export function sanitizeCodexFeatureLabel(value: unknown): string {
     .slice(0, CODEX_FEATURE_LABEL_MAX_LENGTH)
     .trimEnd();
 
-  return sanitized.length > 0 ? sanitized : CODEX_FEATURE_LABEL_FALLBACK;
+  return sanitized.length > 0 ? sanitized : null;
+}
+
+export function sanitizeCodexFeatureLabel(value: unknown): string {
+  return sanitizeCodexFeatureLabelOrNull(value) ?? CODEX_FEATURE_LABEL_FALLBACK;
 }

--- a/src/cliproxy/quota/quota-label-sanitizer.ts
+++ b/src/cliproxy/quota/quota-label-sanitizer.ts
@@ -1,0 +1,25 @@
+const CODEX_FEATURE_LABEL_FALLBACK = 'Additional';
+const CODEX_FEATURE_LABEL_MAX_LENGTH = 80;
+const TERMINAL_ESCAPE_SEQUENCE_REGEX =
+  /\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)?|\u001b\[[0-?]*[ -/]*[@-~]/g;
+const TERMINAL_CONTROL_CHARS_REGEX = /[\u0000-\u001f\u007f-\u009f]/g;
+
+/**
+ * Sanitize upstream Codex feature labels before storing or rendering them.
+ *
+ * The quota API is not schema-validated at runtime, so additional-rate-limit
+ * labels must be constrained to safe, printable strings before they reach the
+ * terminal.
+ */
+export function sanitizeCodexFeatureLabel(value: unknown): string {
+  if (typeof value !== 'string') return CODEX_FEATURE_LABEL_FALLBACK;
+
+  const sanitized = value
+    .replace(TERMINAL_ESCAPE_SEQUENCE_REGEX, '')
+    .replace(TERMINAL_CONTROL_CHARS_REGEX, '')
+    .trim()
+    .slice(0, CODEX_FEATURE_LABEL_MAX_LENGTH)
+    .trimEnd();
+
+  return sanitized.length > 0 ? sanitized : CODEX_FEATURE_LABEL_FALLBACK;
+}

--- a/src/commands/cliproxy/quota-subcommand.ts
+++ b/src/commands/cliproxy/quota-subcommand.ts
@@ -18,7 +18,10 @@ import {
 } from '../../cliproxy/accounts/account-manager';
 import { fetchAllProviderQuotas } from '../../cliproxy/quota/quota-fetcher';
 import { fetchAllCodexQuotas } from '../../cliproxy/quota/quota-fetcher-codex';
-import { sanitizeCodexFeatureLabel } from '../../cliproxy/quota/quota-label-sanitizer';
+import {
+  sanitizeCodexFeatureLabel,
+  sanitizeCodexFeatureLabelOrNull,
+} from '../../cliproxy/quota/quota-label-sanitizer';
 import { fetchAllClaudeQuotas } from '../../cliproxy/quota/quota-fetcher-claude';
 import { pickMostRestrictiveClaudeWeeklyWindow } from '../../cliproxy/quota/quota-fetcher-claude-normalizer';
 import { fetchAllGeminiCliQuotas } from '../../cliproxy/quota/quota-fetcher-gemini-cli';
@@ -280,9 +283,12 @@ function inferCodeReviewCadence(
  * Strip a leading "GPT-X.Y-Codex-" prefix from a feature label and turn the
  * remainder into a Codex-prefixed display name. Other labels pass through unchanged.
  */
-function prettifyCodexFeatureLabel(featureLabel: unknown): string {
-  const trimmed = sanitizeCodexFeatureLabel(featureLabel);
-  if (!trimmed) return 'Additional';
+function prettifyCodexFeatureLabel(featureLabel: unknown, fallbackLabel?: unknown): string {
+  const trimmed =
+    sanitizeCodexFeatureLabelOrNull(featureLabel) ??
+    (fallbackLabel === undefined
+      ? sanitizeCodexFeatureLabel(featureLabel)
+      : sanitizeCodexFeatureLabel(fallbackLabel));
   const stripped = trimmed.replace(/^GPT-[\d.]+-Codex-/i, '');
   if (stripped !== trimmed && stripped.length > 0) {
     return `Codex ${stripped}`;
@@ -303,7 +309,7 @@ function getCodexWindowDisplayLabel(
   }
 
   if (window.category === 'additional') {
-    const pretty = prettifyCodexFeatureLabel(window.featureLabel ?? window.label);
+    const pretty = prettifyCodexFeatureLabel(window.featureLabel, window.label);
     if (window.cadence === '5h') return `${pretty} (5h)`;
     if (window.cadence === 'weekly') return `${pretty} (weekly)`;
     return pretty;

--- a/src/commands/cliproxy/quota-subcommand.ts
+++ b/src/commands/cliproxy/quota-subcommand.ts
@@ -18,6 +18,7 @@ import {
 } from '../../cliproxy/accounts/account-manager';
 import { fetchAllProviderQuotas } from '../../cliproxy/quota/quota-fetcher';
 import { fetchAllCodexQuotas } from '../../cliproxy/quota/quota-fetcher-codex';
+import { sanitizeCodexFeatureLabel } from '../../cliproxy/quota/quota-label-sanitizer';
 import { fetchAllClaudeQuotas } from '../../cliproxy/quota/quota-fetcher-claude';
 import { pickMostRestrictiveClaudeWeeklyWindow } from '../../cliproxy/quota/quota-fetcher-claude-normalizer';
 import { fetchAllGeminiCliQuotas } from '../../cliproxy/quota/quota-fetcher-gemini-cli';
@@ -279,8 +280,8 @@ function inferCodeReviewCadence(
  * Strip a leading "GPT-X.Y-Codex-" prefix from a feature label and turn the
  * remainder into a Codex-prefixed display name. Other labels pass through unchanged.
  */
-function prettifyCodexFeatureLabel(featureLabel: string): string {
-  const trimmed = featureLabel.trim();
+function prettifyCodexFeatureLabel(featureLabel: unknown): string {
+  const trimmed = sanitizeCodexFeatureLabel(featureLabel);
   if (!trimmed) return 'Additional';
   const stripped = trimmed.replace(/^GPT-[\d.]+-Codex-/i, '');
   if (stripped !== trimmed && stripped.length > 0) {
@@ -302,7 +303,7 @@ function getCodexWindowDisplayLabel(
   }
 
   if (window.category === 'additional') {
-    const pretty = prettifyCodexFeatureLabel(window.featureLabel || window.label || 'Additional');
+    const pretty = prettifyCodexFeatureLabel(window.featureLabel ?? window.label);
     if (window.cadence === '5h') return `${pretty} (5h)`;
     if (window.cadence === 'weekly') return `${pretty} (weekly)`;
     return pretty;
@@ -850,7 +851,9 @@ const QUOTA_PROVIDER_RUNTIME: Record<QuotaSupportedProvider, QuotaProviderRuntim
 };
 
 export const __testExports = {
+  getCodexWindowDisplayLabel,
   getQuotaFailureDisplayEntries,
+  prettifyCodexFeatureLabel,
   resolveDisplayedTier,
 };
 

--- a/tests/unit/commands/cliproxy-quota-subcommand.test.ts
+++ b/tests/unit/commands/cliproxy-quota-subcommand.test.ts
@@ -84,3 +84,35 @@ describe('cliproxy quota subcommand failure formatting', () => {
     expect(resolveDisplayedTier('pro', 'unknown')).toBe('pro');
   });
 });
+
+describe('cliproxy quota subcommand Codex label formatting', () => {
+  it('falls back for non-string cached Codex feature labels', async () => {
+    const { getCodexWindowDisplayLabel } = await loadQuotaCommandTestExports();
+
+    const label = getCodexWindowDisplayLabel({
+      label: 'ignored',
+      resetAfterSeconds: 3600,
+      category: 'additional',
+      cadence: '5h',
+      featureLabel: { unexpected: true },
+    } as never);
+
+    expect(label).toBe('Additional (5h)');
+  });
+
+  it('removes terminal control characters from cached Codex feature labels', async () => {
+    const { getCodexWindowDisplayLabel } = await loadQuotaCommandTestExports();
+
+    const label = getCodexWindowDisplayLabel({
+      label: 'ignored',
+      resetAfterSeconds: 3600,
+      category: 'additional',
+      cadence: 'weekly',
+      featureLabel: '\u001b[2JGPT-5.3-Codex-Spark\u001b]52;c;payload\u0007',
+    });
+
+    expect(label).toBe('Codex Spark (weekly)');
+    expect(label).not.toContain('\u001b');
+    expect(label).not.toContain('\u0007');
+  });
+});

--- a/tests/unit/commands/cliproxy-quota-subcommand.test.ts
+++ b/tests/unit/commands/cliproxy-quota-subcommand.test.ts
@@ -86,18 +86,31 @@ describe('cliproxy quota subcommand failure formatting', () => {
 });
 
 describe('cliproxy quota subcommand Codex label formatting', () => {
-  it('falls back for non-string cached Codex feature labels', async () => {
+  it('falls back to the cached window label for invalid Codex feature labels', async () => {
     const { getCodexWindowDisplayLabel } = await loadQuotaCommandTestExports();
 
-    const label = getCodexWindowDisplayLabel({
-      label: 'ignored',
-      resetAfterSeconds: 3600,
-      category: 'additional',
-      cadence: '5h',
-      featureLabel: { unexpected: true },
-    } as never);
+    const cases = [
+      { featureLabel: '', cadence: '5h', expected: 'Codex Spark (5h)' },
+      { featureLabel: '   ', cadence: 'weekly', expected: 'Codex Spark (weekly)' },
+      {
+        featureLabel: '\u001b[2J\u001b]52;c;payload\u0007',
+        cadence: '5h',
+        expected: 'Codex Spark (5h)',
+      },
+      { featureLabel: { unexpected: true }, cadence: '5h', expected: 'Codex Spark (5h)' },
+    ] as const;
 
-    expect(label).toBe('Additional (5h)');
+    for (const { featureLabel, cadence, expected } of cases) {
+      const label = getCodexWindowDisplayLabel({
+        label: 'GPT-5.3-Codex-Spark',
+        resetAfterSeconds: 3600,
+        category: 'additional',
+        cadence,
+        featureLabel,
+      } as never);
+
+      expect(label).toBe(expected);
+    }
   });
 
   it('removes terminal control characters from cached Codex feature labels', async () => {


### PR DESCRIPTION
### Motivation

- The Codex `additional_rate_limits` parser previously copied `limit_name`/`limitName` directly into displayed labels, which can be non-string or contain terminal control sequences and may crash the CLI or manipulate terminal output.
- Harden runtime handling so untrusted upstream quota labels cannot cause `TypeError` (e.g. calling `.trim()` on non-strings) or emit ANSI/OSC control sequences to the terminal.

### Description

- Add a shared sanitizer `sanitizeCodexFeatureLabel` that enforces string type, strips terminal escape/control sequences, trims and bounds label length, and falls back to `Additional` (`src/cliproxy/quota/quota-label-sanitizer.ts`).
- Treat `limit_name`/`limitName` as `unknown` in the Codex fetcher and call `sanitizeCodexFeatureLabel` before storing `featureLabel` and composing window labels (`src/cliproxy/quota/quota-fetcher-codex.ts`).
- Use the sanitizer in the quota display path by making `prettifyCodexFeatureLabel` accept `unknown` and sanitize legacy/cached `featureLabel` values before calling `.replace()` and printing to the terminal (`src/commands/cliproxy/quota-subcommand.ts`).
- Add regression tests covering non-string labels, control-sequence-containing labels, and overlong labels in both fetcher and display code paths (`src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts` and `tests/unit/commands/cliproxy-quota-subcommand.test.ts`).

### Testing

- Ran targeted unit tests: `bun test ./src/cliproxy/quota/__tests__/quota-fetcher-codex.test.ts tests/unit/commands/cliproxy-quota-subcommand.test.ts` and both test suites passed.
- Static checks: `bun run typecheck` and `bun run lint` completed successfully.
- Formatting check `bun run format:check` surfaced pre-existing formatting warnings in unrelated files and reported a non-zero exit (these are outside this change).
- Full fast test run (`bun run test:fast`) failed due to unrelated pre-existing test failures in other subsystems (Codex auth/dashboard state, account-route rollback mock, and browser status bootstrapping) and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199ffec9708330804d7bb5d54a4610)