### PR TITLE
fix: restrict local runtime readiness probes

### DIFF
--- a/src/web-server/routes/profile-routes.ts
+++ b/src/web-server/routes/profile-routes.ts
@@ -6,6 +6,7 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { requireLocalAccessWhenAuthDisabled } from '../middleware/auth-middleware';
 import { isReservedName, RESERVED_PROFILE_NAMES } from '../../config/reserved-names';
 import {
   createApiProfile,
@@ -29,6 +30,9 @@ import { isCLIProxyProvider } from '../../cliproxy/provider-capabilities';
 import { isAnthropicDirectProfile, updateSettingsFile, parseTarget } from './route-helpers';
 
 const router = Router();
+
+const LOCAL_RUNTIME_READINESS_LOCAL_ACCESS_ERROR =
+  'Local runtime readiness requires localhost access when dashboard auth is disabled.';
 
 function isDenylistError(message: string | undefined): boolean {
   return typeof message === 'string' && message.toLowerCase().includes('denylist');
@@ -87,7 +91,11 @@ router.get('/cliproxy-bridge/providers', (_req: Request, res: Response): void =>
   }
 });
 
-router.get('/local-runtime-readiness', async (_req: Request, res: Response): Promise<void> => {
+router.get('/local-runtime-readiness', async (req: Request, res: Response): Promise<void> => {
+  if (!requireLocalAccessWhenAuthDisabled(req, res, LOCAL_RUNTIME_READINESS_LOCAL_ACCESS_ERROR)) {
+    return;
+  }
+
   try {
     res.json({ runtimes: await getLocalRuntimeReadiness() });
   } catch (error) {

--- a/tests/unit/web-server/profile-routes-local-runtime-readiness.test.ts
+++ b/tests/unit/web-server/profile-routes-local-runtime-readiness.test.ts
@@ -6,11 +6,20 @@ import profileRoutes from '../../../src/web-server/routes/profile-routes';
 describe('profile-routes local runtime readiness', () => {
   let server: Server;
   let baseUrl = '';
+  let forcedRemoteAddress = '127.0.0.1';
+  let originalDashboardAuthEnabled: string | undefined;
   const originalFetch = globalThis.fetch;
 
   beforeAll(async () => {
     const app = express();
     app.use(express.json());
+    app.use((req, _res, next) => {
+      Object.defineProperty(req.socket, 'remoteAddress', {
+        value: forcedRemoteAddress,
+        configurable: true,
+      });
+      next();
+    });
     app.use('/api/profiles', profileRoutes);
 
     await new Promise<void>((resolve, reject) => {
@@ -36,6 +45,10 @@ describe('profile-routes local runtime readiness', () => {
   });
 
   beforeEach(() => {
+    originalDashboardAuthEnabled = process.env.CCS_DASHBOARD_AUTH_ENABLED;
+    process.env.CCS_DASHBOARD_AUTH_ENABLED = 'false';
+    forcedRemoteAddress = '127.0.0.1';
+
     globalThis.fetch = (async (input: RequestInfo | URL) => {
       const url = String(input);
 
@@ -73,6 +86,12 @@ describe('profile-routes local runtime readiness', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+
+    if (originalDashboardAuthEnabled !== undefined) {
+      process.env.CCS_DASHBOARD_AUTH_ENABLED = originalDashboardAuthEnabled;
+    } else {
+      delete process.env.CCS_DASHBOARD_AUTH_ENABLED;
+    }
   });
 
   it('reports local runtimes as ready when their endpoints respond with models', async () => {
@@ -101,6 +120,30 @@ describe('profile-routes local runtime readiness', () => {
         status: 'ready',
       })
     );
+  });
+
+  it('blocks remote readiness probes when dashboard auth is disabled', async () => {
+    let probeCount = 0;
+    forcedRemoteAddress = '10.10.0.24';
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith(baseUrl)) {
+        return originalFetch(input);
+      }
+      probeCount += 1;
+      return new Response(JSON.stringify({ models: [{ name: 'gemma4:e4b' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }) as typeof fetch;
+
+    const response = await fetch(`${baseUrl}/api/profiles/local-runtime-readiness`);
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: 'Local runtime readiness requires localhost access when dashboard auth is disabled.',
+    });
+    expect(probeCount).toBe(0);
   });
 
   it('reports setup guidance when local endpoints are unavailable', async () => {


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated remote callers from triggering server-side loopback probes for hard-coded local runtimes when the dashboard is network-reachable with dashboard auth disabled.
- Enforce the established local-only access policy for endpoints that perform sensitive loopback checks before any fetches occur.

### Description
- Require local access for the `GET /api/profiles/local-runtime-readiness` route by calling `requireLocalAccessWhenAuthDisabled` and returning `403` when the guard rejects the request.
- Add the `LOCAL_RUNTIME_READINESS_LOCAL_ACCESS_ERROR` constant for a consistent error message returned when the guard blocks access.
- Add a unit regression test `tests/unit/web-server/profile-routes-local-runtime-readiness.test.ts` that simulates a non-loopback client and asserts the readiness probe is blocked and no loopback fetches are performed.
- Run repository formatting which adjusted some import wrapping style in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts` to satisfy Prettier.

### Testing
- Ran the focused unit test: `bun test tests/unit/web-server/profile-routes-local-runtime-readiness.test.ts`, which passed (3 passed, 0 failed).
- Verified typecheck and lint/format checks with `bun run typecheck && bun run lint && bun run format:check`, which passed locally for the modified files.
- Ran broader validation steps (`bun run validate` / `bun run validate:ci-parity`), which exercised the full test suite; these revealed unrelated pre-existing failures in other test buckets (account-routes context normalization and browser status targets), not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199ff4a9888330a8c386b5e1ac11ab)