### PR TITLE
fix: avoid relative completion backend execution

### DIFF
--- a/scripts/completion/ccs.bash
+++ b/scripts/completion/ccs.bash
@@ -22,18 +22,6 @@ __ccs_completion_run() {
   local current="$1"
   shift || true
 
-  local script_dir repo_root repo_cli
-  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-  repo_root="$(cd "${script_dir}/../.." && pwd)"
-  repo_cli="${repo_root}/dist/ccs.js"
-  if [[ ! -f "${repo_cli}" ]]; then
-    repo_cli="${repo_root}/bin/ccs.js"
-  fi
-  if [[ -f "${repo_cli}" ]]; then
-    node "${repo_cli}" __complete --shell bash --current "${current}" -- "$@" 2>/dev/null
-    return 0
-  fi
-
   if command -v ccs >/dev/null 2>&1; then
     ccs __complete --shell bash --current "${current}" -- "$@" 2>/dev/null
   fi

--- a/scripts/completion/ccs.fish
+++ b/scripts/completion/ccs.fish
@@ -11,17 +11,6 @@ function __fish_ccs_complete
         set -e tokens_before_current[-1]
     end
 
-    set -l script_file (status filename)
-    set -l repo_root (realpath (dirname $script_file)/../.. 2>/dev/null)
-    set -l repo_cli "$repo_root/dist/ccs.js"
-    if not test -f "$repo_cli"
-        set repo_cli "$repo_root/bin/ccs.js"
-    end
-    if test -f "$repo_cli"
-        node "$repo_cli" __complete --shell fish --current "$current" -- $tokens_before_current 2>/dev/null
-        return
-    end
-
     if command -sq ccs
         ccs __complete --shell fish --current "$current" -- $tokens_before_current 2>/dev/null
     end

--- a/scripts/completion/ccs.ps1
+++ b/scripts/completion/ccs.ps1
@@ -6,16 +6,6 @@ function Invoke-CcsCompletionBackend {
         [string[]]$TokensBeforeCurrent
     )
 
-    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
-    $repoCli = Join-Path $repoRoot 'dist\ccs.js'
-    if (-not (Test-Path $repoCli)) {
-        $repoCli = Join-Path $repoRoot 'bin\ccs.js'
-    }
-    if (Test-Path $repoCli) {
-        & node $repoCli __complete --shell powershell --current $CurrentWord -- @TokensBeforeCurrent 2>$null
-        return
-    }
-
     if (Get-Command ccs -ErrorAction SilentlyContinue) {
         & ccs __complete --shell powershell --current $CurrentWord -- @TokensBeforeCurrent 2>$null
     }

--- a/scripts/completion/ccs.zsh
+++ b/scripts/completion/ccs.zsh
@@ -22,19 +22,6 @@ __ccs_completion_run() {
   local current="$1"
   shift || true
 
-  local script_path script_dir repo_root repo_cli
-  script_path="${(%):-%N}"
-  script_dir="${script_path:A:h}"
-  repo_root="${script_dir:h:h}"
-  repo_cli="${repo_root}/dist/ccs.js"
-  if [[ ! -f "${repo_cli}" ]]; then
-    repo_cli="${repo_root}/bin/ccs.js"
-  fi
-  if [[ -f "${repo_cli}" ]]; then
-    node "${repo_cli}" __complete --shell zsh --current "${current}" -- "$@" 2>/dev/null
-    return 0
-  fi
-
   if (( $+commands[ccs] )); then
     ccs __complete --shell zsh --current "${current}" -- "$@" 2>/dev/null
   fi

--- a/tests/unit/commands/shell-completion-command.test.ts
+++ b/tests/unit/commands/shell-completion-command.test.ts
@@ -143,6 +143,27 @@ describe('shell-completion command', () => {
     );
   });
 
+  it('completion adapters only delegate to the ccs command on PATH', () => {
+    const completionScripts = [
+      '../../../scripts/completion/ccs.bash',
+      '../../../scripts/completion/ccs.zsh',
+      '../../../scripts/completion/ccs.fish',
+      '../../../scripts/completion/ccs.ps1',
+    ];
+
+    for (const scriptPath of completionScripts) {
+      const script = readFileSync(join(import.meta.dir, scriptPath), 'utf8');
+
+      expect(script).not.toContain('../..');
+      expect(script).not.toContain('repo_root');
+      expect(script).not.toContain('repoRoot');
+      expect(script).not.toContain('repo_cli');
+      expect(script).not.toContain('repoCli');
+      expect(script).not.toContain('node ');
+      expect(script).not.toContain('& node');
+    }
+  });
+
   it('fish completion strips a duplicated partial token before delegating to __complete', () => {
     const fishScript = readFileSync(
       join(import.meta.dir, '../../../scripts/completion/ccs.fish'),


### PR DESCRIPTION
### Motivation
- Shell completion adapters were walking up from the installed completion script and executing `dist/ccs.js`/`bin/ccs.js` with `node`, which lets a planted home-directory file (e.g. `~/bin/ccs.js`) run during tab completion when the completion scripts are copied into user config directories.

### Description
- Remove the repo-relative `dist/ccs.js` / `bin/ccs.js` lookup and execution from the Bash, Zsh, Fish, and PowerShell completion adapters so they only delegate to the `ccs` command resolved from the user `PATH` (`scripts/completion/ccs.bash`, `ccs.zsh`, `ccs.fish`, `ccs.ps1`).
- Add a regression assertion to `tests/unit/commands/shell-completion-command.test.ts` that verifies completion scripts no longer contain `../..`, `repo_root`/`repoCli` variables, or direct `node` execution.
- Apply Prettier formatting adjustments to two TypeScript files to satisfy the repository formatting checks (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`).

### Testing
- Ran formatting and lint fixes with `bun run format` and `bun run lint:fix`, and updated the test file with `bunx prettier --write tests/unit/commands/shell-completion-command.test.ts`, all of which completed successfully. 
- Executed the targeted unit test with `bun test tests/unit/commands/shell-completion-command.test.ts`, which passed (all assertions in that file passed). 
- Performed a Bash PoC under an isolated `$HOME` to confirm a planted `~/bin/ccs.js` is no longer executed and the PATH `ccs` fallback is used (PoC invoked via the sourced completion script and verified no `PWNED` artifact was written and `legit-suggestion` came from PATH `ccs`).
- Ran broader validations (`bun run validate` and `bun run validate:ci-parity`); these commands surfaced pre-existing, unrelated test failures (not caused by the completion script changes) in `web-server account-routes context normalization` and `browser-status` suites as documented in the CI output, so the change itself did not break the completion coverage tests but the full-validate gate remains red due to unrelated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199e8a3628833081fd1fe0b6fd094f)