### PR TITLE
fix: stop ccsxp model alias parsing at option terminator

### DIFF
--- a/src/targets/codex-adapter.ts
+++ b/src/targets/codex-adapter.ts
@@ -143,6 +143,10 @@ function normalizeCcsxpCodexModelFlagAliases(args: string[]): {
 
   for (let index = 0; index < normalizedArgs.length; index += 1) {
     const arg = normalizedArgs[index];
+    if (arg === '--') {
+      break;
+    }
+
     if (arg === '-m' || arg === '--model') {
       const nextValue = normalizedArgs[index + 1];
       if (typeof nextValue === 'string') {

--- a/tests/unit/targets/codex-runtime-integration.test.ts
+++ b/tests/unit/targets/codex-runtime-integration.test.ts
@@ -848,6 +848,32 @@ process.exit(0);
     ]);
   });
 
+  it('preserves ccsxp positional model-like arguments after the option terminator', () => {
+    if (process.platform === 'win32') return;
+
+    const result = runCcsxpAlias(['--', '--', '-m', 'gpt-5.5-high-fast', 'prompt text'], {
+      ...process.env,
+      CI: '1',
+      NO_COLOR: '1',
+      HOME: tmpHome,
+      CCS_HOME: tmpHome,
+      CCS_CODEX_PATH: fakeCodexPath,
+      CCS_TEST_CODEX_ARGS_OUT: codexArgsLogPath,
+      CCS_TEST_CODEX_ENV_OUT: codexEnvLogPath,
+    });
+
+    expect(result.status).toBe(0);
+    const codexCalls = readLoggedCodexCalls(codexArgsLogPath);
+    expect(codexCalls.at(-1)).toEqual([
+      '--config',
+      'model_provider="cliproxy"',
+      '--',
+      '-m',
+      'gpt-5.5-high-fast',
+      'prompt text',
+    ]);
+  });
+
   it('normalizes ccsxp native low Codex tuning aliases in config.toml', () => {
     if (process.platform === 'win32') return;
 
@@ -1137,7 +1163,9 @@ supports_websockets = false
     });
 
     expect(result.status).toBe(0);
-    expect(result.stderr).not.toContain('Codex CLI does not support Claude account-based profiles.');
+    expect(result.stderr).not.toContain(
+      'Codex CLI does not support Claude account-based profiles.'
+    );
     expect(readLoggedCodexCalls(codexArgsLogPath)).toEqual([['fix failing tests']]);
     expect(readLoggedCodexEnv(codexEnvLogPath)).toEqual([
       {


### PR DESCRIPTION
### Motivation
- The ccsxp Codex model-alias normalizer was scanning all argv tokens and rewrote `-m/--model` forms even after the POSIX option terminator `--`, causing positional prompt text that looks like flags to be normalized into model/config overrides.

### Description
- Stop parsing when the POSIX terminator is encountered by adding an early `if (arg === '--') { break; }` in `normalizeCcsxpCodexModelFlagAliases` (`src/targets/codex-adapter.ts`).
- Add a regression test `preserves ccsxp positional model-like arguments after the option terminator` to `tests/unit/targets/codex-runtime-integration.test.ts` to ensure positional model-like args after `--` are preserved.
- Run Prettier formatting fixes on two unrelated files so repository style checks and the pre-commit hook pass (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`).

### Testing
- Ran `env -u CODEX_HOME bun test tests/unit/targets/codex-runtime-integration.test.ts` and the test file passed, including the new regression test.
- Ran style/lint checks with `bun run format:check` and `bun run lint` and formatting issues were resolved so `format:check` now passes.
- Ran full `env -u CODEX_HOME bun run validate` which still reports two unrelated existing unit-test failures in other test suites (`web-server account-routes context normalization` and `browser status`), so those pre-existing failures remain unchanged by this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199e5e88708330a420c783d14fece1)