### PR TITLE
fix: validate usage profile query type

### DIFF
--- a/src/web-server/usage/profile-filter.ts
+++ b/src/web-server/usage/profile-filter.ts
@@ -9,8 +9,13 @@ export interface ProfileScopedUsageData {
 
 const PROFILE_NAME_REGEX = /^[A-Za-z0-9._-]+$/;
 
-export function normalizeProfileQuery(profile?: string): string | undefined {
-  const value = profile?.trim();
+export function normalizeProfileQuery(profile?: unknown): string | undefined {
+  if (profile === undefined) return undefined;
+  if (typeof profile !== 'string') {
+    throw new Error('Invalid profile filter');
+  }
+
+  const value = profile.trim();
   if (!value || value === 'all') return undefined;
   if (!PROFILE_NAME_REGEX.test(value)) {
     throw new Error('Invalid profile filter');

--- a/tests/unit/web-server/usage-handlers-semantics.test.ts
+++ b/tests/unit/web-server/usage-handlers-semantics.test.ts
@@ -83,11 +83,7 @@ function writeAssistantEntriesToDir(baseClaudeDir: string, entries: AssistantFix
       },
     });
 
-    fs.writeFileSync(
-      path.join(projectDir, `${entry.sessionId}.jsonl`),
-      `${line}\n`,
-      'utf-8'
-    );
+    fs.writeFileSync(path.join(projectDir, `${entry.sessionId}.jsonl`), `${line}\n`, 'utf-8');
   }
 }
 
@@ -222,7 +218,10 @@ describe('usage handlers semantics', () => {
       res as never
     );
 
-    const payload = res.payload as { success: boolean; data: Array<{ hour: string; requests: number }> };
+    const payload = res.payload as {
+      success: boolean;
+      data: Array<{ hour: string; requests: number }>;
+    };
     const targetHour = payload.data.find((row) => row.hour === '2026-03-02 10:00');
 
     expect(targetHour?.requests).toBe(3);
@@ -413,6 +412,19 @@ describe('usage handlers semantics', () => {
         sessions: [expect.objectContaining({ sessionId: 'session-default' })],
       },
     });
+  });
+
+  it('rejects non-string profile filters as validation errors', async () => {
+    for (const profile of [['work', 'default'], { name: 'work' }]) {
+      const res = createMockResponse();
+      await handlers.handleSummary({ query: { profile } } as never, res as never);
+
+      expect(res.statusCode).toBe(400);
+      expect(res.payload).toMatchObject({
+        success: false,
+        error: 'Invalid profile filter',
+      });
+    }
   });
 
   it('rejects reversed date ranges before computing summary totals', async () => {


### PR DESCRIPTION
### Motivation
- The profile normalizer assumed `req.query.profile` was always a string and called `trim()`, which throws for array/object query values and made malformed requests return 500 instead of a 400 validation error.
- Make input handling robust so non-string profile query values are rejected as validation errors and keep the API response semantics consistent.

### Description
- Change `normalizeProfileQuery` to accept `profile?: unknown`, return early for `undefined`, and throw `Invalid profile filter` when the runtime value is not a `string` before calling `trim()` in `src/web-server/usage/profile-filter.ts`.
- Add a unit test that exercises non-string `profile` query payloads via the summary handler and asserts a 400 validation response in `tests/unit/web-server/usage-handlers-semantics.test.ts`.
- Apply Prettier formatting fixes to files that blocked the pre-commit/style checks, including `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`.

### Testing
- Ran the targeted unit tests: `bun test tests/unit/web-server/usage-handlers-semantics.test.ts`, which passed (all assertions in that file succeeded).
- Ran formatting checks: `prettier --check` on the modified files, which passed after applying `prettier --write`.
- Ran `tsc --noEmit` (typecheck) and `eslint` (lint), both of which succeeded against the modified code.
- Ran the full `bun run validate` flow which surfaced two unrelated existing failures in other test suites; those unrelated failures were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a15873a8833093dd5ecf7cb4da6b)