### PR TITLE
fix(cliproxy/executor): isolate parser exit-code checks to avoid ambient `process.exitCode` early returns

### DIFF
--- a/src/cliproxy/executor/__tests__/arg-parser.test.ts
+++ b/src/cliproxy/executor/__tests__/arg-parser.test.ts
@@ -17,6 +17,7 @@ import {
   filterCcsFlags,
   parseExecutorFlags,
   validateFlagCombinations,
+  withIsolatedFailureExitCode,
   type ParsedExecutorFlags,
 } from '../arg-parser';
 import type { UnifiedConfig } from '../../../config/unified-config-types';
@@ -154,6 +155,58 @@ describe('CCS_FLAGS and filterCcsFlags', () => {
   it('filterCcsFlags strips --1m= and --no-1m= inline forms', () => {
     expect(filterCcsFlags(['--1m=true'])).toEqual([]);
     expect(filterCcsFlags(['--no-1m=true'])).toEqual([]);
+  });
+});
+
+// ── withIsolatedFailureExitCode ─────────────────────────────────────────────────
+
+describe('withIsolatedFailureExitCode', () => {
+  let originalExitCode: number | undefined;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode as number | undefined;
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode ?? 0;
+    errorSpy.mockRestore();
+  });
+
+  function makeCtx(provider = 'gemini', compositeProviders: string[] = []) {
+    return { provider, compositeProviders, unifiedConfig: makeEmptyUnifiedConfig() };
+  }
+
+  it('does not report ambient exitCode=1 as a fresh parser failure', () => {
+    process.exitCode = 1;
+
+    const { result, failed } = withIsolatedFailureExitCode(() =>
+      parseExecutorFlags(['--accounts'], makeCtx())
+    );
+
+    expect(failed).toBe(false);
+    expect(result.showAccounts).toBe(true);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('reports a fresh validation failure even when exitCode was already 1', () => {
+    const parsedFlags = parseExecutorFlags(
+      ['--gitlab-url', 'https://gitlab.example.com'],
+      makeCtx()
+    );
+    process.exitCode = 1;
+
+    const { failed } = withIsolatedFailureExitCode(() =>
+      validateFlagCombinations(parsedFlags, { provider: 'gemini', compositeProviders: [] }, [
+        '--gitlab-url',
+        'https://gitlab.example.com',
+      ])
+    );
+
+    expect(failed).toBe(true);
+    expect(process.exitCode).toBe(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('--gitlab-url'));
   });
 });
 

--- a/src/cliproxy/executor/arg-parser.ts
+++ b/src/cliproxy/executor/arg-parser.ts
@@ -179,6 +179,36 @@ export interface ParsedExecutorFlags {
 }
 
 /**
+ * Run a parser/validator step with a fresh exitCode sentinel.
+ *
+ * The parser and validator preserve legacy behavior by setting
+ * process.exitCode=1 for recoverable flag errors. Because process.exitCode is
+ * process-global state, callers must not treat an ambient stale value as a new
+ * parser failure. This helper temporarily clears the sentinel, reports whether
+ * this operation set it to 1, and restores the previous value when no new
+ * failure occurred.
+ */
+export function withIsolatedFailureExitCode<T>(operation: () => T): {
+  result: T;
+  failed: boolean;
+} {
+  const previousExitCode = process.exitCode;
+  process.exitCode = 0;
+
+  let failed = false;
+  let result!: T;
+  try {
+    result = operation();
+    failed = process.exitCode === 1;
+    return { result, failed };
+  } finally {
+    if (!failed) {
+      process.exitCode = previousExitCode ?? 0;
+    }
+  }
+}
+
+/**
  * Parse all CCS executor flags from args.
  *
  * Exits with code 1 (process.exitCode = 1 + return) on invalid flag values.

--- a/src/cliproxy/executor/index.ts
+++ b/src/cliproxy/executor/index.ts
@@ -62,7 +62,12 @@ import {
   resolveRuntimeThinkingOverride,
 } from './thinking-override-resolver';
 import { shouldStartHttpsTunnel } from './https-tunnel-policy';
-import { filterCcsFlags, parseExecutorFlags, validateFlagCombinations } from './arg-parser';
+import {
+  filterCcsFlags,
+  parseExecutorFlags,
+  validateFlagCombinations,
+  withIsolatedFailureExitCode,
+} from './arg-parser';
 import { resolveExecutorProxy } from './proxy-resolver';
 import { buildProxyChain } from './proxy-chain-builder';
 import { warnBrokenModels } from './model-warnings';
@@ -153,16 +158,20 @@ export async function execClaudeWithCLIProxy(
   let sessionId: string | undefined;
 
   // 2. Parse all CCS executor flags (extracted to arg-parser.ts)
-  const parsedFlags = parseExecutorFlags(argsWithoutProxy, {
-    provider,
-    compositeProviders,
-    unifiedConfig,
-  });
-  if (process.exitCode === 1) return;
+  const { result: parsedFlags, failed: parseFailed } = withIsolatedFailureExitCode(() =>
+    parseExecutorFlags(argsWithoutProxy, {
+      provider,
+      compositeProviders,
+      unifiedConfig,
+    })
+  );
+  if (parseFailed) return;
 
   // Validate cross-flag combinations (exits with code 1 on violation)
-  validateFlagCombinations(parsedFlags, { provider, compositeProviders }, argsWithoutProxy);
-  if (process.exitCode === 1) return;
+  const { failed: validationFailed } = withIsolatedFailureExitCode(() =>
+    validateFlagCombinations(parsedFlags, { provider, compositeProviders }, argsWithoutProxy)
+  );
+  if (validationFailed) return;
 
   const {
     forceConfig,


### PR DESCRIPTION
### Motivation

- Parsing/validation previously inferred failure by checking global `process.exitCode === 1`, which allowed a pre-existing ambient `process.exitCode = 1` to cause valid executor runs to return early. 
- The refactor extracted flag parsing into `arg-parser.ts` but preserved the global-exit check semantics, introducing an availability/logic regression for embedded or reused processes. 

### Description

- Add `withIsolatedFailureExitCode` to `src/cliproxy/executor/arg-parser.ts` to run a parse/validation step against a fresh exit-code sentinel and report whether the step set `process.exitCode = 1` while restoring ambient state on success. 
- Use the helper in `execClaudeWithCLIProxy` (`src/cliproxy/executor/index.ts`) to call `parseExecutorFlags` and `validateFlagCombinations` without treating stale global `process.exitCode` as a fresh failure. 
- Add regression tests to `src/cliproxy/executor/__tests__/arg-parser.test.ts` that verify ambient `process.exitCode = 1` does not cause a valid parse to be considered failed and that fresh validation failures are still detected. 
- Run formatting updates on a few files flagged by Prettier to satisfy project style checks. 

### Testing

- Ran the focused unit tests: `bun test ./src/cliproxy/executor/__tests__/arg-parser.test.ts` and all cases passed. 
- Ran typecheck and lint: `bun run typecheck && bun run lint` and formatting check: `bun run format:check`, all succeeded. 
- Ran broader validation commands `bun run validate` and `bun run validate:ci-parity`; these invoked the full test suite and build and reported failures unrelated to this change in existing flaky/integration suites (notably several settings-profile / browser / image-analysis suites), so the targeted changes remain covered by the focused unit tests that passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199cf872a48330822bee0cc5f67620)