### PR TITLE
fix: tolerate null retryable check

### DIFF
--- a/src/utils/__tests__/retry-strategy.test.ts
+++ b/src/utils/__tests__/retry-strategy.test.ts
@@ -25,6 +25,26 @@ describe('withRetry', () => {
     expect(fn).toHaveBeenCalledTimes(3);
   });
 
+  it('uses the default retryability check when retryableCheck is null at runtime', async () => {
+    let attempt = 0;
+    const fn = mock(() => {
+      attempt++;
+      if (attempt < 2) {
+        return Promise.reject(new RetryableError('transient failure'));
+      }
+      return Promise.resolve('ok');
+    });
+
+    const result = await withRetry(fn, {
+      maxRetries: 3,
+      baseDelayMs: 1,
+      retryableCheck: null,
+    } as unknown as RetryOptions);
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
   it('throws after max retries exhausted', async () => {
     const fn = mock(() => Promise.reject(new RetryableError('always fails')));
     await expect(withRetry(fn, { maxRetries: 2, baseDelayMs: 1 })).rejects.toThrow('always fails');

--- a/src/utils/retry-strategy.ts
+++ b/src/utils/retry-strategy.ts
@@ -99,7 +99,7 @@ export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions):
     throw new Error('withRetry: baseDelayMs must be >= 0');
   }
 
-  const isRetryable = retryableCheck;
+  const isRetryable = retryableCheck ?? defaultRetryableCheck;
   let lastError: unknown;
 
   for (let attempt = 0; attempt <= maxRetries; attempt++) {


### PR DESCRIPTION
### Motivation
- A recent change removed the nullish fallback for `retryableCheck`, causing a runtime `TypeError` when an untyped caller passed `retryableCheck: null` and the retry logic tried to invoke it. 
- The intent is to make `withRetry` robust to runtime inputs (undefined or null) and preserve the previous tolerant behavior.

### Description
- Restore the nullish fallback in `withRetry` so `isRetryable` is set with `retryableCheck ?? defaultRetryableCheck` in `src/utils/retry-strategy.ts`. 
- Add a regression test covering `retryableCheck: null` in `src/utils/__tests__/retry-strategy.test.ts` to ensure the default retryability check is used for null values. 
- Commit created with message `fix: tolerate null retryable check` updating the two files above.

### Testing
- Ran `bun test ./src/utils/__tests__/retry-strategy.test.ts`, which executed 20 tests and all passed. 
- Ran `prettier --check` on the modified files (`src/utils/retry-strategy.ts` and `src/utils/__tests__/retry-strategy.test.ts`) and they passed formatting checks. 
- Ran `bun run validate`; it failed due to unrelated Prettier formatting warnings in existing files `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`, which are outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199fe290448330a35b6824b4e54b69)