### PR TITLE
fix: correct claude image analysis default model

### DIFF
--- a/src/config/schemas/proxy-server.ts
+++ b/src/config/schemas/proxy-server.ts
@@ -183,7 +183,7 @@ export const DEFAULT_IMAGE_ANALYSIS_CONFIG: ImageAnalysisConfig = {
     codex: 'gpt-5.1-codex-mini',
     kiro: 'kiro-claude-haiku-4-5',
     ghcp: 'claude-haiku-4.5',
-    claude: 'claude-haiku-4.5-20251001',
+    claude: 'claude-haiku-4-5-20251001',
     qwen: 'vision-model',
     iflow: 'qwen3-vl-plus',
     kimi: 'vision-model',

--- a/tests/unit/utils/hooks/image-analysis-backend-resolver.test.ts
+++ b/tests/unit/utils/hooks/image-analysis-backend-resolver.test.ts
@@ -3,12 +3,20 @@ import {
   DEFAULT_IMAGE_ANALYSIS_CONFIG,
   type ImageAnalysisConfig,
 } from '../../../../src/config/unified-config-types';
+import { findModel } from '../../../../src/cliproxy/model-catalog';
 import {
   canonicalizeImageAnalysisConfig,
   resolveImageAnalysisStatus,
 } from '../../../../src/utils/hooks/image-analysis-backend-resolver';
 
 describe('image-analysis-backend-resolver', () => {
+  it('uses a catalog-backed Claude image analysis default model', () => {
+    const defaultModel = DEFAULT_IMAGE_ANALYSIS_CONFIG.provider_models.claude;
+
+    expect(defaultModel).toBe('claude-haiku-4-5-20251001');
+    expect(findModel('claude', defaultModel)?.id).toBe(defaultModel);
+  });
+
   it('canonicalizes provider aliases in config', () => {
     const config = canonicalizeImageAnalysisConfig({
       enabled: true,


### PR DESCRIPTION
### Motivation
- A refactor introduced a typo in the default Claude image-analysis model id causing the runtime to send an unknown model id for Claude image-analysis requests.
- The default must match the model catalog entry so new or repaired configs continue to work for the Claude backend.

### Description
- Correct the default Claude image-analysis model identifier from `claude-haiku-4.5-20251001` to the catalog-backed `claude-haiku-4-5-20251001` in `src/config/schemas/proxy-server.ts`.
- Add a regression unit test that asserts the default model value and that it resolves via the model catalog in `tests/unit/utils/hooks/image-analysis-backend-resolver.test.ts`.
- Apply small formatter-driven cleanup to two dynamic import lines in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts` produced by the repo format/lint pass.

### Testing
- Ran `bun run format` and `bun run lint:fix` successfully to apply formatting and lint fixes.
- Ran the focused unit test with `bun test tests/unit/utils/hooks/image-analysis-backend-resolver.test.ts` and it passed (all cases in that file passed).
- Ran `bun run typecheck && bun run lint && bun run format:check` which succeeded locally; full `bun run validate` and `bun run validate:ci-parity` were attempted but failed due to unrelated, pre-existing test failures in other suites (Codex/dashboard/browser areas) in this environment and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199cf1f2ac8330adf1da96d5aea575)