### PR TITLE
fix: correct default Claude image model

### DIFF
--- a/src/config/schemas/proxy-server.ts
+++ b/src/config/schemas/proxy-server.ts
@@ -183,7 +183,7 @@ export const DEFAULT_IMAGE_ANALYSIS_CONFIG: ImageAnalysisConfig = {
     codex: 'gpt-5.1-codex-mini',
     kiro: 'kiro-claude-haiku-4-5',
     ghcp: 'claude-haiku-4.5',
-    claude: 'claude-haiku-4.5-20251001',
+    claude: 'claude-haiku-4-5-20251001',
     qwen: 'vision-model',
     iflow: 'qwen3-vl-plus',
     kimi: 'vision-model',

--- a/tests/unit/commands/config-image-analysis-command.test.ts
+++ b/tests/unit/commands/config-image-analysis-command.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
+import { DEFAULT_IMAGE_ANALYSIS_CONFIG } from '../../../src/config/schemas/proxy-server';
 
 // Create temp directory for test isolation
 let testDir: string;
@@ -213,26 +214,12 @@ image_analysis:
 
   describe('default configuration', () => {
     it('should have correct default values', () => {
-      // These are the expected defaults from unified-config-types.ts
-      const defaultConfig = {
-        enabled: true,
-        timeout: 60,
-        provider_models: {
-          agy: 'gemini-3-1-flash-preview',
-          gemini: 'gemini-3-flash-preview',
-          codex: 'gpt-5.1-codex-mini',
-          kiro: 'kiro-claude-haiku-4-5',
-          ghcp: 'claude-haiku-4.5',
-          claude: 'claude-haiku-4-5-20251001',
-          qwen: 'vision-model',
-          iflow: 'qwen3-vl-plus',
-          kimi: 'vision-model',
-        },
-      };
-
-      expect(defaultConfig.enabled).toBe(true);
-      expect(defaultConfig.timeout).toBe(60);
-      expect(Object.keys(defaultConfig.provider_models).length).toBe(9);
+      expect(DEFAULT_IMAGE_ANALYSIS_CONFIG.enabled).toBe(true);
+      expect(DEFAULT_IMAGE_ANALYSIS_CONFIG.timeout).toBe(60);
+      expect(DEFAULT_IMAGE_ANALYSIS_CONFIG.provider_models.claude).toBe(
+        'claude-haiku-4-5-20251001'
+      );
+      expect(Object.keys(DEFAULT_IMAGE_ANALYSIS_CONFIG.provider_models).length).toBe(9);
     });
   });
 


### PR DESCRIPTION
### Motivation
- A refactor accidentally changed the default Claude image-analysis model ID from the hyphenated `claude-haiku-4-5-20251001` (the cataloged/expected ID) to `claude-haiku-4.5-20251001`, which causes CLIProxy image/PDF analysis requests to fail for the default `claude` backend.

### Description
- Restore the hyphenated default model ID by changing `claude: 'claude-haiku-4.5-20251001'` to `claude: 'claude-haiku-4-5-20251001'` in `src/config/schemas/proxy-server.ts`.
- Update the image-analysis unit test to import and assert against the exported `DEFAULT_IMAGE_ANALYSIS_CONFIG` from `src/config/schemas/proxy-server.ts` so the default is validated directly in tests (`tests/unit/commands/config-image-analysis-command.test.ts`).

### Testing
- Ran `bunx prettier --write src/config/schemas/proxy-server.ts tests/unit/commands/config-image-analysis-command.test.ts` and formatting was applied to the touched files successfully.
- Ran `bun test tests/unit/commands/config-image-analysis-command.test.ts` and the test file passed (13 tests, 0 failures).
- Ran `bun run typecheck && bun run lint && bun run format:check`; `typecheck` and `lint` passed but `format:check` failed due to pre-existing formatting issues in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`, which are unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199e5f19188330ba9ac1bd61babc55)