### PR TITLE
fix(ui): guard invalid log detail timestamps

### DIFF
--- a/ui/src/components/logs/logs-detail-panel.tsx
+++ b/ui/src/components/logs/logs-detail-panel.tsx
@@ -9,6 +9,7 @@ import { LogLevelBadge } from './log-level-badge';
 import { LogsEmpty } from './logs-empty';
 import {
   formatJson,
+  formatLogTimestampIso,
   getDisplayLatency,
   getDisplayModule,
   getDisplayRequestId,
@@ -34,7 +35,7 @@ interface OverviewRow {
 function buildOverviewRows(entry: LogsEntry, sourceLabel?: string): OverviewRow[] {
   // Use shared accessors so this panel and the list row never diverge.
   return [
-    { label: 'Time', value: new Date(entry.timestamp).toISOString(), mono: true },
+    { label: 'Time', value: formatLogTimestampIso(entry.timestamp), mono: true },
     { label: 'Level', value: entry.level },
     { label: 'Module', value: getDisplayModule(entry, sourceLabel) },
     { label: 'Stage', value: getDisplayStage(entry) },

--- a/ui/src/components/logs/utils.ts
+++ b/ui/src/components/logs/utils.ts
@@ -21,6 +21,19 @@ export function formatLogTimestamp(timestamp: string | null | undefined) {
   }).format(date);
 }
 
+export function formatLogTimestampIso(timestamp: string | null | undefined) {
+  if (!timestamp) {
+    return 'No activity yet';
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return timestamp;
+  }
+
+  return date.toISOString();
+}
+
 export function formatRelativeLogTime(timestamp: string | null | undefined) {
   if (!timestamp) {
     return 'No activity yet';

--- a/ui/tests/unit/ui/components/logs-detail-panel.test.tsx
+++ b/ui/tests/unit/ui/components/logs-detail-panel.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@tests/setup/test-utils';
+import { describe, expect, it } from 'vitest';
+import { LogsDetailPanel } from '@/components/logs/logs-detail-panel';
+import type { LogsEntry } from '@/lib/api-client';
+
+function buildEntry(overrides: Partial<LogsEntry> = {}): LogsEntry {
+  return {
+    id: 'entry-1',
+    timestamp: '2026-04-07T11:00:00.000Z',
+    level: 'info',
+    source: 'dashboard',
+    event: 'logs.bootstrap',
+    message: 'Dashboard log entry',
+    processId: 25582,
+    runId: 'run-1',
+    ...overrides,
+  };
+}
+
+describe('LogsDetailPanel', () => {
+  it('falls back to the raw timestamp when the selected log entry has an invalid timestamp', () => {
+    render(<LogsDetailPanel entry={buildEntry({ timestamp: 'not-a-date' })} />);
+
+    expect(screen.getByText('not-a-date')).toBeInTheDocument();
+    expect(screen.getByTitle('not-a-date')).toHaveTextContent('not-a-date');
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent the logs detail panel from throwing `RangeError` when a malformed `timestamp` reaches the UI by avoiding direct `new Date(...).toISOString()` calls during render.

### Description
- Add `formatLogTimestampIso()` in `ui/src/components/logs/utils.ts` which validates `new Date(timestamp)` and returns `date.toISOString()` or falls back to the raw `timestamp` for invalid dates.
- Replace the direct `new Date(entry.timestamp).toISOString()` usage with `formatLogTimestampIso(entry.timestamp)` in `ui/src/components/logs/logs-detail-panel.tsx`'s overview rows.
- Add a unit test at `ui/tests/unit/ui/components/logs-detail-panel.test.tsx` verifying the detail panel falls back to the raw timestamp when given an invalid timestamp.

### Testing
- Ran the new UI unit test with `cd ui && bun run test:run tests/unit/ui/components/logs-detail-panel.test.tsx` and it passed.
- Ran UI formatting and validation with `cd ui && bun run format && bun run validate` and those checks passed for the UI changes.
- A full-root `validate` run was attempted (`bun run validate`) but failed due to unrelated pre-existing repo issues outside this patch; those failures are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199fe7b400833096416bd9c59c630a)