### PR TITLE
test: restrict claudecode CCS_HOME cleanup

### DIFF
--- a/tests/unit/utils/claudecode-env-stripping.test.ts
+++ b/tests/unit/utils/claudecode-env-stripping.test.ts
@@ -145,8 +145,16 @@ function registerChildProcessMock(): void {
   }));
 }
 
+const tempCcsHomes = new Set<string>();
+
+function createTempCcsHome(prefix: string): string {
+  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempCcsHomes.add(tempHome);
+  return tempHome;
+}
+
 function writeConfigWithAutoUpdatePreference(enabled: boolean): void {
-  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-auto-update-pref-'));
+  const tempHome = createTempCcsHome('ccs-auto-update-pref-');
   process.env.CCS_HOME = tempHome;
   const ccsDir = path.join(tempHome, '.ccs');
   fs.mkdirSync(ccsDir, { recursive: true });
@@ -158,7 +166,7 @@ preferences:
 }
 
 function writeConfigWithWebSearchSettings(yamlBody: string): void {
-  const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-websearch-env-'));
+  const tempHome = createTempCcsHome('ccs-websearch-env-');
   process.env.CCS_HOME = tempHome;
   const ccsDir = path.join(tempHome, '.ccs');
   fs.mkdirSync(ccsDir, { recursive: true });
@@ -225,10 +233,8 @@ describe('CLAUDECODE environment stripping', () => {
   });
 
   afterEach(async () => {
-    const tempCcsHome = process.env.CCS_HOME?.startsWith(os.tmpdir())
-      ? process.env.CCS_HOME
-      : undefined;
-    if (tempCcsHome) {
+    const tempCcsHome = process.env.CCS_HOME;
+    if (tempCcsHome && tempCcsHomes.has(tempCcsHome)) {
       await stopOpenAICompatProxy();
     }
 
@@ -277,9 +283,10 @@ describe('CLAUDECODE environment stripping', () => {
       }
     }
 
-    if (tempCcsHome) {
-      fs.rmSync(tempCcsHome, { recursive: true, force: true });
+    for (const tempHome of tempCcsHomes) {
+      fs.rmSync(tempHome, { recursive: true, force: true });
     }
+    tempCcsHomes.clear();
   });
 
   it('stripClaudeCodeEnv removes CLAUDECODE case-insensitively', () => {


### PR DESCRIPTION
### Motivation
- Tests in `tests/unit/utils/claudecode-env-stripping.test.ts` were treating any `CCS_HOME` that started with `os.tmpdir()` as disposable which could delete a caller-provided `CCS_HOME` under the system temp directory. 
- The intent is to only remove directories created by this test file to avoid destructive cleanup of unrelated developer/CI state.

### Description
- Added a `tempCcsHomes` tracking `Set<string>` and a helper `createTempCcsHome(prefix: string)` which records `mkdtemp`-created directories before assigning `process.env.CCS_HOME`.
- Updated `writeConfigWithAutoUpdatePreference` and `writeConfigWithWebSearchSettings` to use the new `createTempCcsHome` helper.
- Restricted `stopOpenAICompatProxy()` and recursive `fs.rmSync` cleanup to only operate on tracked temp homes and then clear the tracking set after removal.
- All changes are confined to `tests/unit/utils/claudecode-env-stripping.test.ts` and preserve existing test behavior while preventing accidental removal of external `CCS_HOME` paths.

### Testing
- Ran `bun test tests/unit/utils/claudecode-env-stripping.test.ts --timeout 30000` and all tests in that file passed.
- Verified the destructive PoC case with `CCS_TEST_DISABLE_GLOBAL_BOOTSTRAP=1 CCS_HOME=/tmp/ccs-destructive-cleanup-poc-fixed bun test ...` and confirmed the external marker file remained present after the test run.
- Ran `bunx prettier --check tests/unit/utils/claudecode-env-stripping.test.ts` which succeeded for the modified test file.
- `bun run validate` and `bun run validate:ci-parity` failed due to unrelated Prettier formatting issues in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199c8fe39883308d55642aa9393fc2)