### PR TITLE
fix(cliproxy): preserve manual quota pauses

### DIFF
--- a/src/cliproxy/accounts/__tests__/account-safety-quota-exhaustion.test.ts
+++ b/src/cliproxy/accounts/__tests__/account-safety-quota-exhaustion.test.ts
@@ -21,6 +21,7 @@ import {
   restoreExpiredQuotaPauses,
 } from '../../accounts/account-safety';
 import { sanitizeEmail } from '../../auth/auth-utils';
+import { pauseAccount } from '../registry';
 
 // Setup test isolation
 let tmpDir: string;
@@ -1226,6 +1227,65 @@ describe('Quota Exhaustion Handlers', () => {
       expect(resumed).toBe(1);
       expect(getAccount('agy', 'cooldown@gmail.com')?.paused).not.toBe(true);
       expect(fs.existsSync(path.join(tmpDir, '.ccs', 'cliproxy', 'quota-paused.json'))).toBe(false);
+    });
+
+    it('does not auto-resume when a user manually re-pauses a quota-paused account', async () => {
+      writeRegistry({
+        agy: {
+          default: 'cooldown@gmail.com',
+          accounts: {
+            'cooldown@gmail.com': {
+              email: 'cooldown@gmail.com',
+              tokenFile: 'agy-cooldown.json',
+            },
+          },
+        },
+      });
+      writeAuthToken('agy-cooldown.json', {
+        type: 'agy',
+        email: 'cooldown@gmail.com',
+        access_token: 'token',
+      });
+
+      const now = Date.now();
+      expect(pauseAccountForQuotaCooldown('agy', 'cooldown@gmail.com', 5, now)).toBe(true);
+
+      const registryPath = path.join(tmpDir, '.ccs', 'cliproxy', 'accounts.json');
+      const quotaPausedPath = path.join(tmpDir, '.ccs', 'cliproxy', 'quota-paused.json');
+      const originalPausedAt = '2026-01-01T00:00:00.000Z';
+      const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8')) as {
+        providers: {
+          agy: {
+            accounts: Record<string, { paused?: boolean; pausedAt?: string }>;
+          };
+        };
+      };
+      const quotaPaused = JSON.parse(fs.readFileSync(quotaPausedPath, 'utf8')) as {
+        entries: Array<{ pausedAt: string }>;
+      };
+      registry.providers.agy.accounts['cooldown@gmail.com'].pausedAt = originalPausedAt;
+      quotaPaused.entries[0].pausedAt = originalPausedAt;
+      fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+      fs.writeFileSync(quotaPausedPath, JSON.stringify(quotaPaused, null, 2));
+
+      expect(pauseAccount('agy', 'cooldown@gmail.com')).toBe(true);
+
+      const refreshedRegistry = JSON.parse(
+        fs.readFileSync(registryPath, 'utf8')
+      ) as typeof registry;
+      expect(refreshedRegistry.providers.agy.accounts['cooldown@gmail.com'].pausedAt).not.toBe(
+        originalPausedAt
+      );
+
+      const resumed = restoreExpiredQuotaPauses(now + 6 * 60 * 1000);
+      const { getAccount } = await import('../account-manager');
+
+      expect(resumed).toBe(0);
+      expect(getAccount('agy', 'cooldown@gmail.com')?.paused).toBe(true);
+      expect(
+        fs.existsSync(path.join(tmpDir, '.ccs', 'cliproxy', 'auth-paused', 'agy-cooldown.json'))
+      ).toBe(true);
+      expect(fs.existsSync(quotaPausedPath)).toBe(false);
     });
 
     it('does not auto-resume quota-paused accounts when pausedAt metadata is missing', async () => {

--- a/src/cliproxy/accounts/registry.ts
+++ b/src/cliproxy/accounts/registry.ts
@@ -660,6 +660,10 @@ export function pauseAccount(provider: CLIProxyProvider, accountId: string): boo
 
     const accountMeta = providerAccounts.accounts[accountId];
     if (accountMeta.paused) {
+      // Treat an explicit pause request for an already paused account as a fresh
+      // manual decision. This changes the pause metadata so quota cooldown
+      // restore cannot later mistake the pause for its original auto-pause.
+      accountMeta.pausedAt = new Date().toISOString();
       return true;
     }
 

--- a/src/commands/cliproxy/quota-subcommand.ts
+++ b/src/commands/cliproxy/quota-subcommand.ts
@@ -1056,8 +1056,13 @@ export async function handlePauseAccount(args: string[]): Promise<void> {
   }
 
   if (account.paused) {
+    const refreshed = pauseAccount(provider, account.id);
+    const refreshedAccount = refreshed ? findAccountByQuery(provider, account.id) : account;
     console.log(warn(`Account already paused: ${formatCliAccountLabel(account)}`));
-    console.log(info(`Paused at: ${account.pausedAt || 'unknown'}`));
+    if (refreshed) {
+      console.log(info('Manual pause refreshed; account will stay out of quota rotation'));
+    }
+    console.log(info(`Paused at: ${refreshedAccount?.pausedAt || account.pausedAt || 'unknown'}`));
     return;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent CCS from auto-resuming an account that a user later manually re-paused while a quota-created cooldown entry still existed.

### Description
- Refresh `pausedAt` when `pauseAccount()` is invoked on an already-paused account so manual re-pause updates metadata and cannot be mistaken for the original quota pause (`src/cliproxy/accounts/registry.ts`).
- When CLI `ccs cliproxy pause` sees an already-paused account, call `pauseAccount()` to refresh metadata and report the refreshed pause time to the user (`src/commands/cliproxy/quota-subcommand.ts`).
- Add a regression test that exercises manual re-pause of a quota-paused account and asserts that `restoreExpiredQuotaPauses()` does not auto-resume it (`src/cliproxy/accounts/__tests__/account-safety-quota-exhaustion.test.ts`).
- Apply minor Prettier-driven formatting adjustments to dynamic import lines to satisfy the repo formatting checks (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`).

### Testing
- Ran formatting with `bun run format` and lint autofix with `bun run lint:fix`, both succeeded.
- Unit test: `bun test ./src/cliproxy/accounts/__tests__/account-safety-quota-exhaustion.test.ts` passed and includes the new regression test that verifies manual re-pause prevents auto-resume.
- Typecheck/lint/format-check via `bun run typecheck && bun run lint && bun run format:check` passed.
- Full validation `env -u CODEX_HOME bun run validate` ran but `test:fast` reported two pre-existing/env-sensitive unrelated failures (`web-server account-routes context normalization` and `browser status`), so the remaining failures are not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199b8913a4833084291490e914efe5)