### PR TITLE
fix(proxy): load pid-only profile daemon state

### DIFF
--- a/src/proxy/proxy-daemon.ts
+++ b/src/proxy/proxy-daemon.ts
@@ -285,7 +285,7 @@ function getOpenAICompatProxyStateForProfile(profileName: string): OpenAICompatP
     };
   }
 
-  return { pid: null, session: null, source: 'profile' };
+  return { pid: getOpenAICompatProxyPid(profileName), session: null, source: 'profile' };
 }
 
 export async function listOpenAICompatProxyStatuses(): Promise<OpenAICompatProxyStatus[]> {

--- a/tests/integration/proxy/daemon-lifecycle.test.ts
+++ b/tests/integration/proxy/daemon-lifecycle.test.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import getPort from 'get-port';
 import {
   getOpenAICompatProxyStatus,
+  isOpenAICompatProxyRunning,
   listOpenAICompatProxyStatuses,
   startOpenAICompatProxy,
   stopOpenAICompatProxy,
@@ -918,6 +919,62 @@ describe('openai proxy daemon lifecycle', () => {
     expect(secondStart.alreadyRunning).not.toBe(true);
     expect(secondStart.authToken).not.toBe('stale-token-a');
   });
+
+  it('stops pid-only profile daemons instead of only deleting their state', async () => {
+    const port = await getPort();
+    const settingsPath = path.join(tempDir, 'pid-only-stop.settings.json');
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+          ANTHROPIC_AUTH_TOKEN: 'sk-pid-only-stop',
+          ANTHROPIC_MODEL: 'gpt-4.1',
+        },
+      }),
+      'utf8'
+    );
+
+    const profile = resolveOpenAICompatProfileConfig('pid-only-stop', settingsPath, {
+      ANTHROPIC_BASE_URL: 'https://api.openai.com/v1',
+      ANTHROPIC_AUTH_TOKEN: 'sk-pid-only-stop',
+      ANTHROPIC_MODEL: 'gpt-4.1',
+    });
+    if (!profile) {
+      throw new Error('Expected pid-only-stop OpenAI-compatible profile');
+    }
+
+    const started = await startOpenAICompatProxy(profile, { port });
+    expect(started.success).toBe(true);
+    expect(started.pid).toBeDefined();
+
+    const pid = started.pid;
+    if (!pid) {
+      throw new Error('Expected pid-only-stop daemon pid');
+    }
+
+    try {
+      fs.unlinkSync(getOpenAICompatProxySessionPath('pid-only-stop'));
+
+      const statuses = await listOpenAICompatProxyStatuses();
+      expect(statuses).toContainEqual({
+        running: false,
+        profileName: 'pid-only-stop',
+        pid,
+      });
+
+      const stopped = await stopOpenAICompatProxy();
+      expect(stopped.success).toBe(true);
+      expect(fs.existsSync(getOpenAICompatProxyPidPath('pid-only-stop'))).toBe(false);
+      expect(await isOpenAICompatProxyRunning(port, 'pid-only-stop')).toBe(false);
+    } finally {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // Already stopped.
+      }
+    }
+  }, 35000);
 
   it('replaces pid-only proxy state before starting a new daemon', async () => {
     const firstPort = await getPort();


### PR DESCRIPTION
### Motivation
- Profiles discovered from `.daemon.pid` files must surface their PID even when the `.session.json` file is missing so stop/replacement flows can verify and terminate live daemons instead of deleting the only PID tracking file.

### Description
- Change `getOpenAICompatProxyStateForProfile` to return `pid: getOpenAICompatProxyPid(profileName)` when no session is present so pid-only profiles expose their PID for status/stop logic.
- Add an integration regression test that starts a daemon, removes only its session file, verifies the pid-only status is discovered, runs `stopOpenAICompatProxy()` and asserts the daemon is stopped and its pid file removed.

### Testing
- Ran `bun test tests/integration/proxy/daemon-lifecycle.test.ts --test-name-pattern 'pid-only'` and the new pid-only stop integration test passed.
- Ran `bun test tests/unit/proxy/proxy-daemon-state.test.ts tests/integration/proxy/daemon-lifecycle.test.ts --test-name-pattern 'pid-only|listOpenAICompatProxyProfileNames'` and the targeted unit+integration checks passed.
- Ran `bunx prettier --check src/proxy/proxy-daemon.ts tests/integration/proxy/daemon-lifecycle.test.ts` which passed for the modified files, and ran typecheck and lint which passed; full `bun run validate` / `bun run validate:ci-parity` surfaced unrelated pre-existing formatting and test failures outside this change (format-check warnings in other files and unrelated failing suites) that were not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199eb0d5dc8330875c65252e47bc5a)