### PR TITLE
fix(browser): handle DevTools close endpoint response

### DIFF
--- a/lib/mcp/ccs-browser-server.cjs
+++ b/lib/mcp/ccs-browser-server.cjs
@@ -1230,11 +1230,16 @@ function getTools() {
   ];
 }
 
-async function fetchJson(url, options = undefined) {
+async function fetchOk(url, options = undefined) {
   const response = await fetch(url, options);
   if (!response.ok) {
     throw new Error(`HTTP ${response.status} for ${url}`);
   }
+  return response;
+}
+
+async function fetchJson(url, options = undefined) {
+  const response = await fetchOk(url, options);
   return await response.json();
 }
 
@@ -5193,7 +5198,7 @@ async function handleClosePage(toolArgs) {
     activeRecordingSession = null;
   }
 
-  await fetchJson(`${getHttpUrl()}/json/close/${encodeURIComponent(page.id)}`);
+  await fetchOk(`${getHttpUrl()}/json/close/${encodeURIComponent(page.id)}`, { method: 'PUT' });
   const interceptSession = interceptSessionsByPageId.get(page.id);
   if (interceptSession) {
     closeSocket(interceptSession.ws);

--- a/tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts
+++ b/tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts
@@ -433,6 +433,45 @@ describe('ccs-browser MCP server - session and interception', () => {
     expect(listText).not.toContain('Docs');
   });
 
+  it('closes a page when Chrome DevTools requires PUT and returns text', async () => {
+    const responses = await runMcpRequests(
+      [
+        { id: 'page-1', title: 'Home', currentUrl: 'https://example.com/' },
+        { id: 'page-2', title: 'Docs', currentUrl: 'https://example.com/docs' },
+      ],
+      [
+        {
+          jsonrpc: '2.0',
+          id: 8331,
+          method: 'tools/call',
+          params: { name: 'browser_select_page', arguments: { pageIndex: 1 } },
+        },
+        {
+          jsonrpc: '2.0',
+          id: 8332,
+          method: 'tools/call',
+          params: { name: 'browser_close_page', arguments: {} },
+        },
+        {
+          jsonrpc: '2.0',
+          id: 8333,
+          method: 'tools/call',
+          params: { name: 'browser_get_session_info', arguments: {} },
+        },
+      ],
+      { requirePutForClosePage: true, closePageRespondsWithText: true }
+    );
+
+    const closeText = getResponseText(responses.find((message) => message.id === 8332));
+    expect(closeText).toContain('status: closed');
+    expect(closeText).toContain('selectedPageId: page-1');
+
+    const listText = getResponseText(responses.find((message) => message.id === 8333));
+    expect(listText).toContain('0. Home');
+    expect(listText).toContain('selected: true');
+    expect(listText).not.toContain('Docs');
+  });
+
   it('keeps the selected page when closing a different page', async () => {
     const responses = await runMcpRequests(
       [

--- a/tests/unit/hooks/browser-mcp-test-harness.ts
+++ b/tests/unit/hooks/browser-mcp-test-harness.ts
@@ -350,6 +350,8 @@ type RunMcpRequestsOptions = {
   childEnv?: NodeJS.ProcessEnv;
   responseTimeoutMs?: number;
   requirePutForNewPage?: boolean;
+  requirePutForClosePage?: boolean;
+  closePageRespondsWithText?: boolean;
 };
 
 function encodeMessage(message: unknown): string {
@@ -746,6 +748,12 @@ function createMockBrowser(pagesInput: MockPageState[]) {
         }
 
         if (req.url?.startsWith('/json/close/')) {
+          if (options.requirePutForClosePage && req.method !== 'PUT') {
+            res.writeHead(405, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'method not allowed' }));
+            return;
+          }
+
           const targetId = decodeURIComponent(req.url.slice('/json/close/'.length));
           const entry = Array.from(pageStates.entries()).find(([, page]) => page.id === targetId);
           if (!entry) {
@@ -754,6 +762,11 @@ function createMockBrowser(pagesInput: MockPageState[]) {
             return;
           }
           pageStates.delete(entry[0]);
+          if (options.closePageRespondsWithText) {
+            res.writeHead(200, { 'Content-Type': 'text/plain' });
+            res.end('Target is closing');
+            return;
+          }
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ id: targetId }));
           return;


### PR DESCRIPTION
### Motivation
- Chrome DevTools `/json/close` can require an unsafe verb (PUT) and often returns plain text rather than JSON, which caused `fetchJson()` to either use the wrong method or throw when parsing a non-JSON success body and left `selectedPageId` stale.

### Description
- Added a `fetchOk(url, options)` helper that validates HTTP success without forcing JSON parsing and left `fetchJson()` to reuse `fetchOk` for JSON endpoints.
- Updated the browser close flow to call `/json/close/<targetId>` with `PUT` via `fetchOk()` so the close response is not parsed as JSON and page-selection reconciliation always runs.
- Extended the test harness to simulate DevTools close endpoints that require `PUT` and optionally return plain text, and added a regression test verifying closing a selected page works with those behaviors.
- Changes touch `lib/mcp/ccs-browser-server.cjs`, `tests/unit/hooks/browser-mcp-test-harness.ts`, and `tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts`.

### Testing
- Ran `bunx prettier --write lib/mcp/ccs-browser-server.cjs tests/unit/hooks/browser-mcp-test-harness.ts tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts` and formatting succeeded.
- Ran the focused unit test file with `bun test tests/unit/hooks/browser-mcp-session-and-intercepts.test.ts` and all tests in that suite passed (`47 pass`, `0 fail`).
- Ran `bun run format` and `bun run lint:fix` successfully for the touched files.
- Ran `bun run validate`, which failed `prettier --check src/` due to unrelated existing formatting issues in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts` (these are pre-existing and not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a17787108330a4687480850915e2)