### PR TITLE
fix(ui): preserve Gemini tier fallback without entitlement

### DIFF
--- a/ui/src/components/shared/quota-tooltip-content.tsx
+++ b/ui/src/components/shared/quota-tooltip-content.tsx
@@ -378,7 +378,8 @@ export function QuotaTooltipContent({ quota, resetTime }: QuotaTooltipContentPro
   if (isGeminiQuotaResult(quota)) {
     const hasBucketResetTime = quota.buckets.some((bucket) => !!bucket.resetTime);
     const hasEntitlementTier =
-      !!quota.entitlement?.rawTierLabel || quota.entitlement?.normalizedTier !== 'unknown';
+      !!quota.entitlement?.rawTierLabel ||
+      (!!quota.entitlement && quota.entitlement.normalizedTier !== 'unknown');
     const distinctTokenTypes = Array.from(
       new Set(
         quota.buckets

--- a/ui/tests/unit/ui/components/shared/quota-tooltip-content.test.tsx
+++ b/ui/tests/unit/ui/components/shared/quota-tooltip-content.test.tsx
@@ -83,6 +83,20 @@ describe('QuotaTooltipContent', () => {
     expect(screen.getByText(expectedReset)).toBeInTheDocument();
   });
 
+  it('renders the Gemini tier label when entitlement evidence is absent', () => {
+    const quota = createGeminiQuotaResult({
+      entitlement: undefined,
+      tierLabel: 'Legacy Pro',
+      tierId: null,
+      creditBalance: null,
+    });
+
+    render(<QuotaTooltipContent quota={quota} resetTime={null} />);
+
+    expect(screen.getByText('Tier')).toBeInTheDocument();
+    expect(screen.getByText('Legacy Pro')).toBeInTheDocument();
+  });
+
   it('falls back to the shared reset indicator when Gemini buckets omit reset timestamps', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-29T00:00:00Z'));


### PR DESCRIPTION
### Motivation
- Fix a UI correctness bug where a missing optional `entitlement` object caused the Gemini tooltip to treat an entitlement tier as present and suppressed the legacy `tierLabel` fallback.

### Description
- Tighten the entitlement check in `ui/src/components/shared/quota-tooltip-content.tsx` so `normalizedTier` is only compared when `quota.entitlement` exists.
- Add a regression unit test `ui/tests/unit/ui/components/shared/quota-tooltip-content.test.tsx` that verifies the Gemini `tierLabel` is rendered when `entitlement` is `undefined` and a legacy tier label is present.
- Changes touch `ui/src/components/shared/quota-tooltip-content.tsx` and the corresponding unit test file.

### Testing
- Ran the targeted component tests with `cd ui && bun run test:run tests/unit/ui/components/shared/quota-tooltip-content.test.tsx --reporter=verbose`, and all tests in that file passed (4 tests passed).
- Ran UI validation with `cd ui && bun run validate`, which completed successfully for the UI package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a15e9f7c8330a38ff94a3d166226)