### PR TITLE
fix(cliproxy): prefer explicit Codex free fallbacks

### DIFF
--- a/src/cliproxy/ai-providers/__tests__/codex-plan-compatibility.test.ts
+++ b/src/cliproxy/ai-providers/__tests__/codex-plan-compatibility.test.ts
@@ -78,6 +78,21 @@ describe('codex plan compatibility', () => {
     ).toBe('gpt-5.4-mini');
   });
 
+  it('prefers a rejected model explicit free-plan fallback over saved paid-only models', () => {
+    expect(
+      resolveRuntimeCodexFallbackModel({
+        requestedModel: 'gpt-5.3-codex-spark',
+        modelMap: {
+          defaultModel: 'gpt-5.3-codex',
+          opusModel: 'gpt-5.3-codex',
+          sonnetModel: 'gpt-5.3-codex',
+          haikuModel: 'gpt-5.3-codex-spark',
+        },
+        excludeModels: ['gpt-5.3-codex-spark'],
+      })
+    ).toBe('gpt-5.4-mini');
+  });
+
   it('tracks Codex thinking caps for current safe defaults, paid models, and legacy aliases', () => {
     expect(getModelMaxLevel('codex', 'gpt-5.5')).toBe('xhigh');
     expect(getModelMaxLevel('codex', 'gpt-5.4')).toBe('xhigh');

--- a/src/cliproxy/ai-providers/codex-plan-compatibility.ts
+++ b/src/cliproxy/ai-providers/codex-plan-compatibility.ts
@@ -114,8 +114,8 @@ export function resolveRuntimeCodexFallbackModel(options: {
     (options.excludeModels ?? []).map((model) => normalizeCodexModelId(model)).filter(Boolean)
   );
   const candidates = [
-    options.modelMap.defaultModel,
     getFreePlanFallbackCodexModel(requestedModel),
+    options.modelMap.defaultModel,
     options.modelMap.opusModel,
     options.modelMap.sonnetModel,
     options.modelMap.haikuModel,


### PR DESCRIPTION
### Motivation
- Preserve availability for verified free-plan Codex accounts by ensuring a requested model's explicit free-plan fallback is tried before any saved paid-only model defaults, preventing a paid-only saved default from being selected ahead of the intended free-safe fallback.

### Description
- Reorder fallback candidate resolution in `resolveRuntimeCodexFallbackModel` so `getFreePlanFallbackCodexModel(requestedModel)` is evaluated before `modelMap.defaultModel` in `src/cliproxy/ai-providers/codex-plan-compatibility.ts`.
- Add a regression test that asserts an explicit free-plan fallback is preferred over other saved paid-only models in `src/cliproxy/ai-providers/__tests__/codex-plan-compatibility.test.ts`.
- Keep the existing non-mutating reconcile behavior intact so saved settings remain preserved for free-plan accounts while runtime fallback ordering is corrected.

### Testing
- Ran the focused unit tests with `bun test ./src/cliproxy/ai-providers/__tests__/codex-plan-compatibility.test.ts ./src/cliproxy/ai-providers/__tests__/codex-plan-compatibility-reconcile.test.ts` and all tests in those files passed (`13 pass, 0 fail`).
- Ran `bun run typecheck`, `bun run lint`, and `bunx prettier --check` on the changed files and they succeeded for the modified files.
- Attempted full repo validation with `bun run validate`, which surfaced pre-existing unrelated failures (two unformatted files and unrelated failing tests), so repository-wide validation remains blocked by those unrelated issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a120f7b4833088e2d748a7c9a9a2)