### PR TITLE
fix(management): skip broken shared plugin entries

### DIFF
--- a/src/management/shared-manager.ts
+++ b/src/management/shared-manager.ts
@@ -354,7 +354,19 @@ class SharedManager {
       }
 
       const entryPath = path.join(sharedPluginsPath, entry.name);
-      const stats = fs.statSync(entryPath);
+      let stats: fs.Stats;
+      try {
+        stats = fs.statSync(entryPath);
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        console.log(
+          warn(
+            `Skipping plugins/${entry.name}: unable to inspect shared plugin entry${code ? ` (${code})` : ''}`
+          )
+        );
+        continue;
+      }
+
       items.set(entry.name, {
         name: entry.name,
         type: stats.isDirectory() ? 'directory' : 'file',

--- a/tests/unit/shared-manager.test.ts
+++ b/tests/unit/shared-manager.test.ts
@@ -307,6 +307,31 @@ describe('SharedManager', () => {
   });
 
   describe('marketplace registry ownership', () => {
+    it('skips unstatable shared plugin entries during instance linking', () => {
+      const manager = new SharedManager();
+      const instancePath = instanceDir('work');
+      const sharedPluginsPath = path.join(claudeDir(), 'plugins');
+      const logSpy = spyOn(console, 'log').mockImplementation(() => {});
+
+      fs.mkdirSync(instancePath, { recursive: true });
+      fs.mkdirSync(sharedPluginsPath, { recursive: true });
+      fs.symlinkSync(
+        path.join(sharedPluginsPath, 'missing-plugin'),
+        path.join(sharedPluginsPath, 'broken-plugin'),
+        'dir'
+      );
+
+      expect(() => manager.linkSharedDirectories(instancePath)).not.toThrow();
+      expect(fs.existsSync(path.join(instancePath, 'plugins', 'broken-plugin'))).toBe(false);
+      expect(
+        logSpy.mock.calls.some(([message]) =>
+          String(message).includes(
+            'Skipping plugins/broken-plugin: unable to inspect shared plugin entry'
+          )
+        )
+      ).toBe(true);
+    });
+
     it('writes global and instance registries with different authoritative install locations', () => {
       const globalRegistryPath = path.join(claudeDir(), 'plugins', 'known_marketplaces.json');
       ensureMarketplacePayload(claudeDir());


### PR DESCRIPTION
### Motivation
- Instance setup could abort when enumerating entries under the shared `plugins` directory because `fs.statSync` follows symlinks and threw for dangling or otherwise unstatable entries.
- The change makes instance linking robust to broken plugin symlinks by skipping entries that cannot be inspected instead of propagating the exception.

### Description
- Wrap `fs.statSync` in `src/management/shared-manager.ts` with a `try/catch` and log a `warn` message then `continue` to skip unstatable entries when enumerating shared plugins.
- Add a unit test `tests/unit/shared-manager.test.ts` that creates a dangling plugin symlink and verifies `linkSharedDirectories()` does not throw and does not materialize the broken entry.
- Changes are limited to `src/management/shared-manager.ts` and `tests/unit/shared-manager.test.ts` and preserve existing behavior when entries are inspectable.

### Testing
- Ran `bunx prettier --write src/management/shared-manager.ts tests/unit/shared-manager.test.ts` and formatting was applied to the modified files.
- Ran `bun test tests/unit/shared-manager.test.ts` and the suite passed (`21 pass, 0 fail`).
- Ran `bunx eslint src/management/shared-manager.ts` and `bun run typecheck` against the codebase and they completed for the changed files without introducing type or lint failures.
- Attempted full `bun run validate`, which surfaced unrelated pre-existing issues: two unrelated unit tests failed (`web-server account-routes context normalization > rolls back inferred shared resource metadata when instance reconciliation fails` and `browser status > bootstraps the managed default browser profile dir before reporting attach readiness`) and `format:check` reported pre-existing formatting warnings in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199ff6b3fc8330915ca686aea70be6)