### PR TITLE
fix(ci): add always-reporting CI Gate so fork PRs stop deadlocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,37 @@ jobs:
 
       - name: Assert compose parity (compose.yaml vs docker-compose.integrated.yml)
         run: bash tests/docker/compose-parity.sh
+
+  # Single always-reporting status that branch protection requires.
+  #
+  # The validate/build/test jobs are gated to trusted author associations so
+  # untrusted fork code never executes on the self-hosted runners. A job skipped
+  # by a job-level `if` reports no status, so requiring those job names directly
+  # leaves fork PRs stuck on "Expected - waiting for status to be reported"
+  # forever. Requiring this gate instead keeps the contract satisfiable:
+  #   - trusted PR: gate is green only if every gated job actually succeeded
+  #   - fork PR:    gated jobs skip, gate reports green so the PR is mergeable
+  #                 (fork code is still reviewed by a maintainer before merge)
+  #
+  # No checkout here: the gate only inspects upstream job results, so it runs no
+  # third-party code and is safe on the self-hosted runner.
+  ci-gate:
+    if: always()
+    needs: [validate, build, test]
+    runs-on: [self-hosted, linux, x64]
+    name: CI Gate
+    steps:
+      - name: Verify gated jobs did not fail
+        env:
+          VALIDATE: ${{ needs.validate.result }}
+          BUILD: ${{ needs.build.result }}
+          TEST: ${{ needs.test.result }}
+        run: |
+          echo "validate=$VALIDATE build=$BUILD test=$TEST"
+          for result in "$VALIDATE" "$BUILD" "$TEST"; do
+            if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
+              echo "[X] A required CI job did not pass (result: $result)"
+              exit 1
+            fi
+          done
+          echo "[OK] CI gate satisfied (success or skipped-for-fork)"


### PR DESCRIPTION
## Problem

External-contributor (fork) PRs get stuck with required checks showing
`Expected — Waiting for status to be reported` and can never merge.

Closes #1461

## Root Cause

Every job in `ci.yml` is gated:

```yaml
if: contains(["COLLABORATOR","MEMBER","OWNER"], github.event.pull_request.author_association)
```

That gate is correct — CI runs on self-hosted runners and untrusted fork code
must not execute there. But fork authors are `CONTRIBUTOR`/`NONE`, so all jobs
**skip**, and a job skipped by a job-level `if` reports **no status**. Branch
protection requires the job names `typecheck`/`lint`/`format`/`build`/`test`
directly, so the required checks wait forever for statuses that never arrive →
permanent merge deadlock.

## Fix

Add one always-reporting `CI Gate` job:

- `if: always()`, `needs: [validate, build, test]`
- runs on `[self-hosted, linux, x64]` with **no checkout** — it only inspects
  upstream job results, so it executes no third-party/fork code (keeps fork code
  off home infra; no cloud runner introduced)
- fails only if a gated job actually `failure`/`cancelled`; passes when they
  succeed (trusted PR) or skip (fork PR)

Result:
- trusted PR → gate green only if validate+build+test all pass (quality
  preserved)
- fork PR → gated jobs skip, gate green, PR mergeable after maintainer review

## Required follow-up (not in this PR — it's a GitHub setting)

After this lands and `CI Gate` reports once, update **branch protection** on
`dev` and `main`: required status checks → replace
`typecheck, lint, format, build, test` with `CI Gate`.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `CI Gate` job (always-reporting required-check shim) |

## Validation

- [x] YAML parses; gate job has correct `needs`/`if`/`runs-on` and no checkout
- [ ] Branch-protection contexts updated to require `CI Gate` (manual, post-merge)
