### PR TITLE
test(accounts): fix stale account-visual-groups free-tier expectations

### DIFF
--- a/ui/tests/unit/ui/lib/account-visual-groups.test.ts
+++ b/ui/tests/unit/ui/lib/account-visual-groups.test.ts
@@ -29,17 +29,14 @@ describe('buildAccountVisualGroups', () => {
     ]);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0]?.variants?.map((variant) => variant.audience)).toEqual([
-      'business',
-      'personal',
-    ]);
+    expect(groups[0]?.variants?.map((variant) => variant.audience)).toEqual(['business', 'free']);
     expect(groups[0]?.variants?.map((variant) => variant.inlineLabel)).toEqual([
       'Business · Workspace 04a0f049',
-      'Personal · Free',
+      'Free',
     ]);
     expect(groups[0]?.variants?.map((variant) => variant.compactDetailLabel)).toEqual([
       '04a0f049',
-      'Free',
+      null,
     ]);
     expect(groups[0]?.memberIds).toEqual([
       'kaidu.kd@gmail.com#04a0f049-team',
@@ -47,7 +44,7 @@ describe('buildAccountVisualGroups', () => {
     ]);
   });
 
-  it('keeps multiple personal codex plans distinct inside the same grouped card', () => {
+  it('keeps personal and free codex plans distinct inside the same grouped card', () => {
     const groups = buildAccountVisualGroups([
       makeAccount({
         id: 'kaidu.kd@gmail.com#plus',
@@ -61,8 +58,8 @@ describe('buildAccountVisualGroups', () => {
 
     expect(groups).toHaveLength(1);
     expect(groups[0]?.variants?.map((variant) => variant.inlineLabel)).toEqual([
-      'Personal · Free',
       'Personal · Plus',
+      'Free',
     ]);
   });
 });


### PR DESCRIPTION
## Problem

`ui/tests/unit/ui/lib/account-visual-groups.test.ts` fails on `dev`. Commit `72ea1fc9` ("fix(accounts): simplify codex free tier badges") added a `free` audience to `AUDIENCE_ORDER` in `account-visual-groups.ts` but did not update the test, leaving two assertions pinned to the old `personal` / `Personal · Free` output.

## Fix

Realign the two stale assertions to the current source output:
- free-tier codex variant → audience `free` (was `personal`)
- inline label `Free` (was `Personal · Free`)
- compact detail label `null` (was `Free`)
- rename the second test to reflect personal + free distinction

## Validation

- [x] `vitest run account-visual-groups.test.ts` — 2 pass (was 2 fail on dev)
- [x] `prettier --check` clean

## Notes

The same realignment also appears inside PR #1457; this standalone fix decouples the broken-test repair from that feature PR so `dev` goes green regardless of #1457's timing. Identical final content → clean merge.
