### PR TITLE
fix(bar): anchor menu panel to top and stop full-screen sizing

### DIFF
--- a/macos-bar/Sources/CCSBarApp/BarMenuView.swift
+++ b/macos-bar/Sources/CCSBarApp/BarMenuView.swift
@@ -51,8 +51,12 @@ struct BarMenuView: View {
   /// Content shorter than the cap renders FULLY with no scroll bar.
   /// Content taller than the cap scrolls.
   private var scrollAreaHeight: CGFloat {
-    guard contentHeight > 0 else { return screenCap }
-    return min(contentHeight, screenCap)
+    let cap = screenCap
+    // Before the first measurement, use a modest default so the popover is never
+    // sized to the full screen (which macOS then centers). Once the content is
+    // measured, use its height, capped.
+    guard contentHeight > 0 else { return min(cap, 560) }
+    return min(contentHeight, cap)
   }
 
   var body: some View {
@@ -132,7 +136,7 @@ struct BarMenuView: View {
         // Content shorter than the cap renders FULLY (no empty space, no clip).
         // Content taller scrolls. contentHeight starts at 0 so we show screenCap
         // until the first preference fires.
-        .frame(height: scrollAreaHeight)
+        .frame(height: scrollAreaHeight, alignment: .top)
         .onPreferenceChange(ContentHeightKey.self) { measured in
           // Only grow, never shrink — prevents a feedback loop where a smaller
           // frame triggers a re-layout that reports an even smaller height.


### PR DESCRIPTION
Follow-up to #1528. The new content-measured height had a regression: the panel could render at nearly full screen height with its content vertically centered.

## Root cause
`scrollAreaHeight` returned `screenCap` (visible screen height minus 120) whenever `contentHeight` was still 0 (before/if the measurement reports), and the ScrollView `.frame(height:)` had no alignment. So an unmeasured panel got a near-full-screen frame and the shorter content was centered in it; macOS then centered the oversized window. That produced the full-screen, middled popover.

## Fix
- Default the scroll-area height to a modest value (`min(screenCap, 560)`) until the content is measured, instead of `screenCap`.
- Pin the frame to `.top` alignment so content is never vertically centered.

Net: the popover anchors under the menu bar and sizes to its content, scrolling only on genuine overflow.

## Validation
- Swift builds (swiftly 6.3.2); `ccs-bar-check` passes.
- Ran the patched build locally and confirmed the popover anchors top-right and sizes to content (no full-screen centering).
- Shipping as the v1.6.1 `ccs-bar-latest` asset so installed apps pick it up.

Docs-only-adjacent; this is a Swift app change. Merge via web UI.