### PR TITLE
fix: harden macOS bar launch descriptor

### DIFF
--- a/macos-bar/Sources/CCSBarApp/BarServerLauncher.swift
+++ b/macos-bar/Sources/CCSBarApp/BarServerLauncher.swift
@@ -1,4 +1,9 @@
 import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
 import CCSBarCore
 
 /// Reads `~/.ccs/bar/launch.json` and spawns the CCS bar server detached,
@@ -36,10 +41,80 @@ struct BarServerLauncher: Sendable {
 
   private func loadDescriptor() -> BarLaunchDescriptor? {
     let path = BarLaunchDescriptor.defaultPath(home: home)
-    guard FileManager.default.fileExists(atPath: path),
-      let data = FileManager.default.contents(atPath: path)
+    guard isSafeDescriptorFile(path),
+      let data = FileManager.default.contents(atPath: path),
+      let descriptor = try? JSONDecoder().decode(BarLaunchDescriptor.self, from: data),
+      isSafeDescriptor(descriptor)
     else { return nil }
-    return try? JSONDecoder().decode(BarLaunchDescriptor.self, from: data)
+    return descriptor
+  }
+
+  /// Treat launch.json as untrusted because it lives under a user-writable CCS
+  /// directory. Refuse symlinks, files not owned by the current user, and files
+  /// writable by group/other before decoding executable details.
+  private func isSafeDescriptorFile(_ path: String) -> Bool {
+    let fm = FileManager.default
+    guard fm.fileExists(atPath: path) else { return false }
+
+    guard let linkValues = try? URL(fileURLWithPath: path).resourceValues(forKeys: [.isSymbolicLinkKey]),
+      linkValues.isSymbolicLink != true,
+      let attrs = try? fm.attributesOfItem(atPath: path),
+      (attrs[.type] as? FileAttributeType) == .typeRegular,
+      let owner = attrs[.ownerAccountID] as? NSNumber,
+      owner.uint32Value == getuid(),
+      let permissions = attrs[.posixPermissions] as? NSNumber
+    else { return false }
+
+    // Disallow group/other write bits. User-writable is expected so CCS can refresh it.
+    return (permissions.uint16Value & 0o022) == 0
+  }
+
+  /// Validate the descriptor schema and constrain it to the expected CCS bar
+  /// server command shape: runtime absolute path + absolute entry point +
+  /// exactly "bar serve". This blocks shell descriptors such as
+  /// /bin/sh -c attacker-command while preserving the installed launch path.
+  private func isSafeDescriptor(_ descriptor: BarLaunchDescriptor) -> Bool {
+    guard descriptor.schema == 1, descriptor.args.count == 3 else { return false }
+    guard descriptor.args[1] == "bar", descriptor.args[2] == "serve" else { return false }
+    guard isAbsolutePath(descriptor.runtime), isAbsolutePath(descriptor.args[0]) else { return false }
+    guard descriptor.home == home else { return false }
+    if let ccsHome = descriptor.ccsHome, !ccsHome.isEmpty, !isAbsolutePath(ccsHome) {
+      return false
+    }
+
+    let runtimeName = URL(fileURLWithPath: descriptor.runtime).lastPathComponent.lowercased()
+    let allowedRuntimes: Set<String> = ["node", "nodejs", "bun"]
+    guard allowedRuntimes.contains(runtimeName) else { return false }
+    guard FileManager.default.isExecutableFile(atPath: descriptor.runtime) else { return false }
+
+    let entry = descriptor.args[0]
+    let entryName = URL(fileURLWithPath: entry).lastPathComponent.lowercased()
+    guard entryName == "ccs.js" || entryName == "ccs.ts" else { return false }
+    guard isSafeEntrypointFile(entry), !isUnderCcsDir(entry) else { return false }
+
+    return true
+  }
+
+  private func isSafeEntrypointFile(_ path: String) -> Bool {
+    guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+      (attrs[.type] as? FileAttributeType) == .typeRegular,
+      let permissions = attrs[.posixPermissions] as? NSNumber
+    else { return false }
+
+    return (permissions.uint16Value & 0o022) == 0
+  }
+
+  private func isUnderCcsDir(_ path: String) -> Bool {
+    let ccsPath = URL(fileURLWithPath: home)
+      .appendingPathComponent(".ccs")
+      .standardizedFileURL
+      .path
+    let targetPath = URL(fileURLWithPath: path).standardizedFileURL.path
+    return targetPath == ccsPath || targetPath.hasPrefix(ccsPath + "/")
+  }
+
+  private func isAbsolutePath(_ path: String) -> Bool {
+    path.hasPrefix("/")
   }
 
   // MARK: - Spawn from descriptor

--- a/src/web-server/routes/route-helpers.ts
+++ b/src/web-server/routes/route-helpers.ts
@@ -437,6 +437,18 @@ export function validateFilePath(filePath: string): {
     if (pathSegments.includes('.git') || pathSegments.includes('node_modules')) {
       return { valid: false, readonly: false, error: 'Access to this path is not allowed' };
     }
+
+    // launch.json is an executable descriptor consumed by the native macOS bar.
+    // It must only be written by trusted bar install/launch code paths, not the
+    // generic dashboard file API.
+    if (
+      pathSegments.length === 2 &&
+      pathSegments[0] === 'bar' &&
+      pathSegments[1] === 'launch.json'
+    ) {
+      return { valid: false, readonly: false, error: 'Access to this path is not allowed' };
+    }
+
     return { valid: true, readonly: false };
   }
 

--- a/tests/unit/web-server/route-helpers.test.ts
+++ b/tests/unit/web-server/route-helpers.test.ts
@@ -42,6 +42,22 @@ describe('validateFilePath', () => {
     expect(result.readonly).toBe(false);
   });
 
+  test('rejects writes to the macOS bar launch descriptor', () => {
+    const filePath = path.join(tempDir, '.ccs', 'bar', 'launch.json');
+    const result = validateFilePath(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(result.readonly).toBe(false);
+  });
+
+  test('still allows other writes inside the bar directory', () => {
+    const filePath = path.join(tempDir, '.ccs', 'bar', 'serve.log');
+    const result = validateFilePath(filePath);
+
+    expect(result.valid).toBe(true);
+    expect(result.readonly).toBe(false);
+  });
+
   test('rejects sibling paths that only share ~/.ccs prefix', () => {
     const bypassPath = path.join(tempDir, '.ccs-evil', 'config.yaml');
     const result = validateFilePath(bypassPath);


### PR DESCRIPTION
### Motivation
- Prevent arbitrary command execution via the macOS bar's `~/.ccs/bar/launch.json` descriptor by treating the file as untrusted. 
- Ensure the native launcher only runs a constrained, expected CCS server command shape instead of any runtime/args recorded in a user-writable file. 
- Prevent the dashboard's generic file API from planting executable launch descriptors under `~/.ccs`.

### Description
- Add conservative on-disk checks in `BarServerLauncher.loadDescriptor()` to refuse symlinks, non-regular files, files not owned by the current user, and files with group/other write bits before decoding. (`macos-bar/Sources/CCSBarApp/BarServerLauncher.swift`)
- Add descriptor schema and command-shape validation that requires `schema == 1`, `args.length == 3`, exact `"bar","serve"` tail args, absolute runtime/entry paths, only allow known runtime binaries (`node`, `nodejs`, `bun`), require the runtime be executable, restrict entrypoint basename to `ccs.js`/`ccs.ts`, and forbid entrypoints under the user `~/.ccs` tree. (`BarServerLauncher.swift`)
- Keep existing spawn logic but only invoke it when the descriptor passes the new safety checks. (`BarServerLauncher.swift`)
- Block the generic dashboard file-path validator from allowing writes to `bar/launch.json` so the generic `PUT /api/file` cannot write the executable descriptor. (`src/web-server/routes/route-helpers.ts`)
- Add a unit test asserting the `bar/launch.json` path is rejected by `validateFilePath`. (`tests/unit/web-server/route-helpers.test.ts`)
- Small portability addition to import `Darwin`/`Glibc` depending on OS in the Swift launcher file. (`BarServerLauncher.swift`)

### Testing
- Ran `bun test tests/unit/web-server/route-helpers.test.ts` and the file-path tests passed (6/6).
- Ran `bun run typecheck` (`tsc --noEmit`) and `bun run lint`, both succeeded.
- Ran `bun run format:check` which reported pre-existing formatting issues in unrelated files (`src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`), causing the format check to fail; the new code changes themselves were formatted with project tooling.
- Attempted `swift build` for `macos-bar`, which fails on this Linux CI environment due to missing Apple `SwiftUI` (environment limitation), not due to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a309b057ce08330a9c6ade25f97fef8)