### PR TITLE
fix(codex): sanitize config override probes

### DIFF
--- a/src/targets/codex-detector.ts
+++ b/src/targets/codex-detector.ts
@@ -1,11 +1,19 @@
 import * as fs from 'fs';
 import * as childProcess from 'child_process';
 import { expandPath } from '../utils/helpers';
-import { escapeShellArg, getWindowsEscapedCommandShell } from '../utils/shell-executor';
+import {
+  escapeShellArg,
+  getWindowsEscapedCommandShell,
+  stripAnthropicEnv,
+  stripBrowserEnv,
+  stripCodexSessionEnv,
+} from '../utils/shell-executor';
 import type { TargetBinaryInfo } from './target-adapter';
 
 const CODEX_CONFIG_OVERRIDE_FEATURE = 'config-overrides';
 const CODEX_CONFIG_OVERRIDE_PROBE_ARGS = ['-c', 'model="gpt-5"', '--version'];
+const CCSXP_CLIPROXY_SHORTCUT_ENV = 'CCSXP_CLIPROXY_SHORTCUT';
+const CODEX_RUNTIME_ENV_KEY = 'CCS_CODEX_API_KEY';
 
 function buildWindowsCodexCandidates(matches: string[]): string[] {
   const shellCandidates = matches.filter((entry) => /\.(exe|cmd|bat|ps1)$/i.test(entry));
@@ -32,10 +40,21 @@ function buildWindowsCodexCandidates(matches: string[]): string[] {
   return [...new Set([...prioritized, ...bareCandidates])];
 }
 
+function buildCodexProbeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...stripBrowserEnv(stripCodexSessionEnv(stripAnthropicEnv(process.env))),
+  };
+  delete env[CCSXP_CLIPROXY_SHORTCUT_ENV];
+  delete env[CODEX_RUNTIME_ENV_KEY];
+  return env;
+}
+
 function runCodexProbe(codexPath: string, args: string[]): string | undefined {
   const isWindows = process.platform === 'win32';
   const isPowerShellScript = isWindows && /\.ps1$/i.test(codexPath);
   const needsShell = isWindows && /\.(cmd|bat)$/i.test(codexPath);
+
+  const env = buildCodexProbeEnv();
 
   try {
     if (isPowerShellScript) {
@@ -44,6 +63,7 @@ function runCodexProbe(codexPath: string, args: string[]): string | undefined {
         ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', codexPath, ...args],
         {
           encoding: 'utf8',
+          env,
           stdio: ['ignore', 'pipe', 'ignore'],
           timeout: 5000,
           windowsHide: true,
@@ -55,6 +75,7 @@ function runCodexProbe(codexPath: string, args: string[]): string | undefined {
       const cmdString = [codexPath, ...args].map(escapeShellArg).join(' ');
       const result = childProcess.spawnSync(cmdString, {
         encoding: 'utf8',
+        env,
         stdio: ['ignore', 'pipe', 'ignore'],
         timeout: 5000,
         windowsHide: true,
@@ -65,6 +86,7 @@ function runCodexProbe(codexPath: string, args: string[]): string | undefined {
 
     return childProcess.execFileSync(codexPath, args, {
       encoding: 'utf8',
+      env,
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 5000,
     });

--- a/tests/unit/targets/codex-detector.test.ts
+++ b/tests/unit/targets/codex-detector.test.ts
@@ -6,16 +6,29 @@ import * as path from 'path';
 
 import { detectCodexCli, getCodexBinaryInfo } from '../../../src/targets/codex-detector';
 
+const CCSXP_CLIPROXY_SHORTCUT_ENV = 'CCSXP_CLIPROXY_SHORTCUT';
+
 describe('codex-detector', () => {
   let tmpDir: string;
   let originalPath: string | undefined;
   let originalCodexPath: string | undefined;
+  let originalProbeEnv: Record<string, string | undefined>;
+  const probeEnvKeys = [
+    'ANTHROPIC_AUTH_TOKEN',
+    'ANTHROPIC_API_KEY',
+    'CCS_BROWSER_DEVTOOLS_URL',
+    'CODEX_THREAD_ID',
+    'CCS_CODEX_API_KEY',
+    CCSXP_CLIPROXY_SHORTCUT_ENV,
+    'CCS_SAFE_VALUE',
+  ];
   const originalPlatform = process.platform;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccs-codex-detector-test-'));
     originalPath = process.env.PATH;
     originalCodexPath = process.env.CCS_CODEX_PATH;
+    originalProbeEnv = Object.fromEntries(probeEnvKeys.map((key) => [key, process.env[key]]));
     process.env.PATH = '';
   });
 
@@ -27,6 +40,11 @@ describe('codex-detector', () => {
 
     if (originalCodexPath !== undefined) process.env.CCS_CODEX_PATH = originalCodexPath;
     else delete process.env.CCS_CODEX_PATH;
+
+    for (const key of probeEnvKeys) {
+      if (originalProbeEnv[key] !== undefined) process.env[key] = originalProbeEnv[key];
+      else delete process.env[key];
+    }
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
@@ -119,6 +137,39 @@ describe('codex-detector', () => {
     expect(detectCodexCli()).toBe(fakeCmdCodex);
 
     execSyncSpy.mockRestore();
+  });
+
+  it('runs Codex feature probes with the same sensitive env stripping used for Codex launches', () => {
+    const fakeCodex = path.join(tmpDir, 'codex');
+    fs.writeFileSync(fakeCodex, '');
+    process.env.CCS_CODEX_PATH = fakeCodex;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'secret-auth-token';
+    process.env.ANTHROPIC_API_KEY = 'secret-api-key';
+    process.env.CCS_BROWSER_DEVTOOLS_URL = 'ws://127.0.0.1:9222/devtools/browser/secret';
+    process.env.CODEX_THREAD_ID = 'thread-secret';
+    process.env.CCS_CODEX_API_KEY = 'runtime-secret';
+    process.env[CCSXP_CLIPROXY_SHORTCUT_ENV] = '1';
+    process.env.CCS_SAFE_VALUE = 'safe-value';
+
+    const execFileSyncSpy = spyOn(childProcess, 'execFileSync').mockImplementation(() => {
+      return 'codex-cli 0.119.0-alpha.1';
+    });
+
+    const info = getCodexBinaryInfo();
+
+    expect(info?.features).toContain('config-overrides');
+    const probeOptions = execFileSyncSpy.mock.calls
+      .map((call) => call[2] as { env?: NodeJS.ProcessEnv } | undefined)
+      .find((options) => options?.env);
+    expect(probeOptions?.env?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(probeOptions?.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(probeOptions?.env?.CCS_BROWSER_DEVTOOLS_URL).toBeUndefined();
+    expect(probeOptions?.env?.CODEX_THREAD_ID).toBeUndefined();
+    expect(probeOptions?.env?.CCS_CODEX_API_KEY).toBeUndefined();
+    expect(probeOptions?.env?.[CCSXP_CLIPROXY_SHORTCUT_ENV]).toBeUndefined();
+    expect(probeOptions?.env?.CCS_SAFE_VALUE).toBe('safe-value');
+
+    execFileSyncSpy.mockRestore();
   });
 
   it('falls back to a direct -c probe when help text omits the config flag', () => {


### PR DESCRIPTION
### Motivation

- Prevent sensitive environment variables from leaking to pre-launch Codex feature probes that previously inherited `process.env` and could expose tokens or browser DevTools URLs. 
- Ensure feature-detection probes run with the same sanitized environment that real Codex launches receive so compromised or malicious Codex binaries cannot read secrets during probing.

### Description

- Add `buildCodexProbeEnv()` and use `stripAnthropicEnv`, `stripBrowserEnv`, and `stripCodexSessionEnv` to construct a sanitized probe environment and remove `CCSXP_CLIPROXY_SHORTCUT` and `CCS_CODEX_API_KEY` before probing. 
- Pass the sanitized `env` into all probe execution paths in `runCodexProbe()` (PowerShell `execFileSync`, Windows shell `spawnSync`, and direct `execFileSync`).
- Add a unit test asserting probe subprocesses receive the sanitized env in `tests/unit/targets/codex-detector.test.ts` and preserve benign variables. 
- Apply minor Prettier formatting adjustments in two modules (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`) to satisfy style checks.

### Testing

- Ran `bun run format` and `bun run lint:fix` (succeeded). 
- Ran the modified unit tests: `bun test tests/unit/targets/codex-detector.test.ts` (9 tests, all passed). 
- Ran typecheck + lint + format checks (`bun run typecheck && bun run lint && bun run format:check`) (succeeded). 
- Ran repository validation: `bun run validate` and `bun run validate:ci-parity`; these reported unrelated existing test failures in broader suites (some fast and many settings/profile/browser tests) that are not caused by this change, while the new/modified unit tests for the Codex probe passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d853fc5483308b1ba7b75d0ef085)