### PR TITLE
fix: avoid quadratic cliproxy usage hydration

### DIFF
--- a/src/web-server/usage/cliproxy-usage-transformer.ts
+++ b/src/web-server/usage/cliproxy-usage-transformer.ts
@@ -243,15 +243,19 @@ function hydrateProviderlessHistoryDetails(
   existing: CliproxyUsageHistoryDetail[],
   incoming: CliproxyUsageHistoryDetail[]
 ): CliproxyUsageHistoryDetail[] {
+  if (!existing.some((detail) => !detail.provider)) return existing;
+
   const incomingByProviderlessSignature = new Map<string, CliproxyUsageHistoryDetail[]>();
   for (const detail of incoming) {
     if (!detail.provider) continue;
 
     const signature = createProviderlessHistorySignature(detail);
-    incomingByProviderlessSignature.set(signature, [
-      ...(incomingByProviderlessSignature.get(signature) ?? []),
-      detail,
-    ]);
+    const matches = incomingByProviderlessSignature.get(signature);
+    if (matches) {
+      matches.push(detail);
+    } else {
+      incomingByProviderlessSignature.set(signature, [detail]);
+    }
   }
 
   return existing.map((detail) => {


### PR DESCRIPTION
### Motivation

- The providerless-history hydration pass in `hydrateProviderlessHistoryDetails` used array spread to accumulate incoming details per signature, producing O(n^2) work for duplicate signatures and enabling a CPU/memory DoS when a remote CLIProxy returns many duplicate records.
- The change aims to make hydration linear in the number of incoming details while preserving existing merge behavior and only doing the hydration work when it can actually affect persisted snapshots.

### Description

- Short-circuit `hydrateProviderlessHistoryDetails` to return early when `existing` has no providerless records to hydrate, avoiding unnecessary pre-indexing of `incoming` details.
- Replace repeated array-spread accumulation with an in-place `push()` accumulation into a `Map<string, CliproxyUsageHistoryDetail[]>` so duplicate-heavy inputs are handled in linear time.
- No API or merge semantics were changed; `mergeCliproxyUsageHistoryDetails` still calls the hydration helper and retains the same downstream deduplication and counting logic.

### Testing

- Ran the focused unit tests for the transformer with `bun test tests/unit/web-server/cliproxy-usage-transformer.test.ts` and all tests in that file passed.
- Ran type checks and linting with `bun run typecheck && bun run lint`, which succeeded.
- Confirmed formatting with `bunx prettier --check src/web-server/usage/cliproxy-usage-transformer.ts`, which succeeded.
- Ran `bun run validate` which surfaced unrelated repository issues (existing Prettier warnings in other files and two unrelated failing tests in `browser-status` and `account-routes-context`), so the broader validation run did not fully succeed but the changes in this PR did not cause those failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28d7a973908330a6388b44197f6b7d)