### PR TITLE
fix: preserve Codex system prompt structure

### DIFF
--- a/src/cliproxy/proxy/__tests__/tool-sanitization-proxy-integration.test.ts
+++ b/src/cliproxy/proxy/__tests__/tool-sanitization-proxy-integration.test.ts
@@ -487,7 +487,7 @@ describe('ToolSanitizationProxy Integration', () => {
       }
     });
 
-    it('folds Codex system messages into the first user message before forwarding', async () => {
+    it('preserves Codex system fields and system-role messages before forwarding', async () => {
       const proxy = new ToolSanitizationProxy({
         upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
       });
@@ -508,45 +508,12 @@ describe('ToolSanitizationProxy Integration', () => {
         });
 
         const sentBody = lastRequest!.body as Record<string, unknown>;
-        const sentMessages = sentBody.messages as Array<Record<string, unknown>>;
 
-        expect(sentBody.system).toBeUndefined();
-        expect(sentMessages).toHaveLength(1);
-        expect(sentMessages[0].role).toBe('user');
-        expect(sentMessages[0].content).toEqual([
-          { type: 'text', text: 'Always be concise.\n\nUse JSON.' },
-          { type: 'text', text: 'hello' },
+        expect(sentBody.system).toEqual([{ type: 'text', text: 'Always be concise.' }]);
+        expect(sentBody.messages).toEqual([
+          { role: 'system', content: 'Use JSON.' },
+          { role: 'user', content: [{ type: 'text', text: 'hello' }] },
         ]);
-      } finally {
-        proxy.stop();
-      }
-    });
-
-    it('strips blank Codex system messages before forwarding', async () => {
-      const proxy = new ToolSanitizationProxy({
-        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
-      });
-      const port = await proxy.start();
-
-      try {
-        await fetch(`http://127.0.0.1:${port}/api/provider/codex/v1/messages`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            model: 'gpt-5.4',
-            system: '   ',
-            messages: [
-              { role: 'system', content: [{ type: 'text', text: '  ' }] },
-              { role: 'user', content: 'hello' },
-            ],
-          }),
-        });
-
-        const sentBody = lastRequest!.body as Record<string, unknown>;
-        const sentMessages = sentBody.messages as Array<Record<string, unknown>>;
-
-        expect(sentBody.system).toBeUndefined();
-        expect(sentMessages).toEqual([{ role: 'user', content: 'hello' }]);
       } finally {
         proxy.stop();
       }

--- a/src/cliproxy/proxy/tool-sanitization-proxy.ts
+++ b/src/cliproxy/proxy/tool-sanitization-proxy.ts
@@ -126,84 +126,6 @@ function applyCodexModelTuningAlias(body: Record<string, unknown>): Record<strin
   return tunedBody;
 }
 
-function extractSystemText(content: unknown): string {
-  if (typeof content === 'string') {
-    return content;
-  }
-
-  if (!Array.isArray(content)) {
-    return '';
-  }
-
-  return content
-    .filter((block): block is { type: unknown; text?: unknown } => isRecord(block))
-    .filter((block) => block.type === 'text' && typeof block.text === 'string')
-    .map((block) => block.text as string)
-    .join('\n\n');
-}
-
-function prependSystemTextToContent(content: unknown, systemText: string): unknown {
-  if (Array.isArray(content)) {
-    return [{ type: 'text', text: systemText }, ...content];
-  }
-  if (typeof content === 'string') {
-    return `${systemText}\n\n${content}`;
-  }
-  return systemText;
-}
-
-function foldCodexSystemMessages(body: Record<string, unknown>): Record<string, unknown> {
-  const systemTexts: string[] = [];
-  let removedSystem = false;
-  const nextBody = { ...body };
-
-  if (body.system !== undefined) {
-    removedSystem = true;
-    delete nextBody.system;
-    const systemText = extractSystemText(body.system).trim();
-    if (systemText) {
-      systemTexts.push(systemText);
-    }
-  }
-
-  const rawMessages = Array.isArray(body.messages) ? body.messages : [];
-  const messages = rawMessages.filter((message) => {
-    if (!isRecord(message) || message.role !== 'system') {
-      return true;
-    }
-    removedSystem = true;
-    const systemText = extractSystemText(message.content).trim();
-    if (systemText) {
-      systemTexts.push(systemText);
-    }
-    return false;
-  });
-
-  if (!removedSystem) {
-    return body;
-  }
-
-  if (systemTexts.length > 0) {
-    const systemPrefix = systemTexts.join('\n\n');
-    const firstUserIndex = messages.findIndex(
-      (message) => isRecord(message) && message.role === 'user'
-    );
-
-    if (firstUserIndex >= 0 && isRecord(messages[firstUserIndex])) {
-      const firstUserMessage = messages[firstUserIndex];
-      messages[firstUserIndex] = {
-        ...firstUserMessage,
-        content: prependSystemTextToContent(firstUserMessage.content, systemPrefix),
-      };
-    } else {
-      messages.unshift({ role: 'user', content: systemPrefix });
-    }
-  }
-
-  nextBody.messages = messages;
-  return nextBody;
-}
-
 function getUnsupportedToolFields(
   providerFromPath: string | null,
   model: string | undefined
@@ -467,8 +389,7 @@ export class ToolSanitizationProxy {
       }
 
       if (isRecord(modifiedBody) && isCodexRequest(providerFromPath, modifiedBody.model)) {
-        const tunedBody = applyCodexModelTuningAlias(modifiedBody);
-        modifiedBody = foldCodexSystemMessages(tunedBody);
+        modifiedBody = applyCodexModelTuningAlias(modifiedBody);
       }
 
       // Sanitize tools if present

--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -483,9 +483,8 @@ export async function reconcileExhaustedRotationAccounts(
     return [];
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();
@@ -593,9 +592,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;


### PR DESCRIPTION
### Motivation
- Fix a security/regression where Codex-routed requests folded privileged `system`/developer instructions into ordinary user content, weakening instruction boundaries and increasing prompt-injection risk. 
- Keep the intended Codex model tuning alias normalization while avoiding any rewrite that demotes or removes `system` messages. 

### Description
- Remove the Codex-specific system-message folding code and helper functions so top-level `system` fields and `role: 'system'` messages are forwarded unchanged. 
- Stop invoking the folding rewrite for Codex requests and only apply `applyCodexModelTuningAlias` for model tuning alias normalization. 
- Update the integration test to assert that Codex requests preserve `system` fields and `role: 'system'` messages instead of folding them into user content. 
- Apply small formatting adjustments where CI-parity Prettier drift was detected. 

### Testing
- Ran code style and linting: `bun run format` and `bun run lint:fix`, both completed and formatting drift was fixed. 
- Ran the targeted integration test `bun test ./src/cliproxy/proxy/__tests__/tool-sanitization-proxy-integration.test.ts -t "preserves Codex system"`, which passed. 
- Ran broader checks `bun run validate` and `bun run validate:ci-parity`; these exercised the full test matrix and surface unrelated pre-existing failures in other suites (not caused by this change), notably `web-server account-routes context normalization > rolls back inferred shared resource metadata when instance reconciliation fails` and `browser status > bootstraps the managed default browser profile dir before reporting attach readiness`, plus several settings-profile / browser / image-analysis / websearch launch tests in the CI-parity bucket.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dde7d5ec83308e5d169bd1940225)