### PR TITLE
fix: honor default target for Claude passthrough

### DIFF
--- a/src/dispatcher/profile-resolver.ts
+++ b/src/dispatcher/profile-resolver.ts
@@ -99,11 +99,15 @@ function usesImplicitDefaultProfile(cleanArgs: string[]): boolean {
  * and only reached on the profile-not-found path, so a real configured profile
  * of the same name always wins.
  */
-export function isBareClaudeSubcommandPassthrough(profile: string, args: string[]): boolean {
+export function isBareClaudeSubcommandPassthrough(
+  profile: string,
+  args: string[],
+  profileConfig?: Parameters<typeof resolveTargetType>[1]
+): boolean {
   if (profile === 'default') return false;
   if (getClaudeSubcommandName([profile]) === null) return false;
   try {
-    return resolveTargetType(args) === 'claude';
+    return resolveTargetType(args, profileConfig) === 'claude';
   } catch {
     return false;
   }
@@ -158,10 +162,19 @@ export async function resolveProfileAndTarget(
   } catch (profileError) {
     // Bare Claude subcommand passthrough: forward `ccs agents`, `ccs mcp`, ...
     // through the default profile instead of failing as an unknown profile.
-    if (isBareClaudeSubcommandPassthrough(profile, args)) {
-      remainingArgs = [profile, ...remainingArgs];
-      profile = 'default';
-      profileInfo = detector.detectProfileType(profile);
+    if (profile !== 'default' && getClaudeSubcommandName([profile]) !== null) {
+      const defaultProfileInfo = detector.detectProfileType('default');
+      const defaultProfileConfig = defaultProfileInfo.target
+        ? { target: defaultProfileInfo.target }
+        : undefined;
+
+      if (isBareClaudeSubcommandPassthrough(profile, args, defaultProfileConfig)) {
+        remainingArgs = [profile, ...remainingArgs];
+        profile = 'default';
+        profileInfo = defaultProfileInfo;
+      } else {
+        throw profileError;
+      }
     } else {
       throw profileError;
     }

--- a/tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts
+++ b/tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts
@@ -42,4 +42,25 @@ describe('isBareClaudeSubcommandPassthrough', () => {
     );
     expect(isBareClaudeSubcommandPassthrough('mcp', ['mcp', '--target', 'codex'])).toBe(false);
   });
+
+  it('does not reroute through a default profile configured for a non-claude target', () => {
+    expect(
+      isBareClaudeSubcommandPassthrough('setup-token', ['setup-token', 'sk-secret'], {
+        target: 'droid',
+      })
+    ).toBe(false);
+    expect(isBareClaudeSubcommandPassthrough('agents', ['agents'], { target: 'codex' })).toBe(
+      false
+    );
+  });
+
+  it('allows explicit claude target selection to override a non-claude default profile target', () => {
+    expect(
+      isBareClaudeSubcommandPassthrough(
+        'setup-token',
+        ['setup-token', 'sk-secret', '--target', 'claude'],
+        { target: 'droid' }
+      )
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent bare Claude-only subcommands (e.g. `agents`, `setup-token`) from being rerouted through a non-`claude` default profile (which could send secret argv to Droid/Codex). 
- Ensure the passthrough predicate uses the effective target derived from the default profile's persisted config rather than assuming `claude` by default.

### Description

- Thread the default profile's effective target into the passthrough gate by extending `isBareClaudeSubcommandPassthrough` to accept an optional `profileConfig` and pass it to `resolveTargetType` so the predicate respects persisted profile targets. 
- On profile-not-found, resolve the `default` profile first and only reroute when `isBareClaudeSubcommandPassthrough` still resolves to `claude` using the default profile's `target` (avoids re-routing into Droid/Codex). 
- Add regression tests in `tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts` that assert non-reroute when the default profile target is non-`claude` and that `--target claude` can override a non-`claude` default. 
- Apply small Prettier formatting fixes to a couple of touched files (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`).

### Testing

- Ran `bun test tests/unit/dispatcher/profile-resolver-subcommand-passthrough.test.ts` and the new/updated tests passed. 
- Ran `bun run format` and `bun run lint:fix` to normalize formatting and lint issues and both completed successfully. 
- Ran `bun run validate` which surfaced unrelated, pre-existing test failures (`web-server account-routes` and `browser status` suites) not introduced by this change. 
- Ran `bun run validate:ci-parity` which also failed due to unrelated existing settings-profile launch test buckets rather than the passthrough logic changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dc9c716c83309a6b4c59a8a08250)