### PR TITLE
fix(cursor): redact daemon token from dashboard start

### DIFF
--- a/src/web-server/routes/cursor-routes.ts
+++ b/src/web-server/routes/cursor-routes.ts
@@ -234,7 +234,9 @@ router.post('/daemon/start', async (_req: Request, res: Response): Promise<void>
       port: cursorConfig.port,
       ghost_mode: cursorConfig.ghost_mode,
     });
-    res.json(result);
+    const { daemonToken: _redactedDaemonToken, ...publicResult } = result;
+    void _redactedDaemonToken;
+    res.json(publicResult);
   } catch (error) {
     res.status(500).json({ error: (error as Error).message });
   }

--- a/tests/unit/web-server/cursor-routes.test.ts
+++ b/tests/unit/web-server/cursor-routes.test.ts
@@ -52,9 +52,11 @@ let checkAuthStatus: () => {
   };
 };
 let getTokenStoragePath: () => string;
-let getDaemonStartPreconditionError: (
-  input: { enabled: boolean; authenticated: boolean; tokenExpired?: boolean }
-) => { status: number; error: string } | null;
+let getDaemonStartPreconditionError: (input: {
+  enabled: boolean;
+  authenticated: boolean;
+  tokenExpired?: boolean;
+}) => { status: number; error: string } | null;
 let getAutoDetectFailureStatus: (
   reason?:
     | 'db_not_found'
@@ -65,13 +67,15 @@ let getAutoDetectFailureStatus: (
     | 'invalid_token_format'
 ) => number;
 
-function seedCursorConfig(overrides: {
-  enabled?: boolean;
-  port?: number;
-  auto_start?: boolean;
-  ghost_mode?: boolean;
-  model?: string;
-} = {}): void {
+function seedCursorConfig(
+  overrides: {
+    enabled?: boolean;
+    port?: number;
+    auto_start?: boolean;
+    ghost_mode?: boolean;
+    model?: string;
+  } = {}
+): void {
   const config = loadOrCreateUnifiedConfig();
   config.cursor = {
     enabled: overrides.enabled ?? true,
@@ -329,7 +333,10 @@ describe('Cursor Routes Logic', () => {
       try {
         const dbPath = getTokenStoragePath();
         fs.mkdirSync(path.dirname(dbPath), { recursive: true });
-        execFileSync('sqlite3', [dbPath, 'CREATE TABLE IF NOT EXISTS itemTable (key TEXT PRIMARY KEY, value TEXT);']);
+        execFileSync('sqlite3', [
+          dbPath,
+          'CREATE TABLE IF NOT EXISTS itemTable (key TEXT PRIMARY KEY, value TEXT);',
+        ]);
         execFileSync('sqlite3', [
           dbPath,
           `INSERT OR REPLACE INTO itemTable (key, value) VALUES ('cursorAuth/accessToken', '${token}');`,
@@ -471,27 +478,28 @@ describe('Cursor Routes Logic', () => {
       expect(json.error).toContain('expired');
     });
 
-    it(
-      'POST /api/cursor/daemon/start starts daemon and /daemon/stop stops it',
-      async () => {
-        const port = 15000 + Math.floor(Math.random() * 20000);
-        seedCursorConfig({ enabled: true, port });
-        seedCredentials(false);
+    it('POST /api/cursor/daemon/start starts daemon and /daemon/stop stops it', async () => {
+      const port = 15000 + Math.floor(Math.random() * 20000);
+      seedCursorConfig({ enabled: true, port });
+      seedCredentials(false);
 
-        const startRes = await fetch(`${baseUrl}/api/cursor/daemon/start`, { method: 'POST' });
-        expect(startRes.status).toBe(200);
+      const startRes = await fetch(`${baseUrl}/api/cursor/daemon/start`, { method: 'POST' });
+      expect(startRes.status).toBe(200);
 
-        const startJson = (await startRes.json()) as { success?: boolean; pid?: number };
-        expect(startJson.success).toBe(true);
-        expect(typeof startJson.pid).toBe('number');
+      const startJson = (await startRes.json()) as {
+        success?: boolean;
+        pid?: number;
+        daemonToken?: string;
+      };
+      expect(startJson.success).toBe(true);
+      expect(typeof startJson.pid).toBe('number');
+      expect(startJson.daemonToken).toBeUndefined();
 
-        const stopRes = await fetch(`${baseUrl}/api/cursor/daemon/stop`, { method: 'POST' });
-        expect(stopRes.status).toBe(200);
-        const stopJson = (await stopRes.json()) as { success?: boolean };
-        expect(stopJson.success).toBe(true);
-      },
-      35000
-    );
+      const stopRes = await fetch(`${baseUrl}/api/cursor/daemon/stop`, { method: 'POST' });
+      expect(stopRes.status).toBe(200);
+      const stopJson = (await stopRes.json()) as { success?: boolean };
+      expect(stopJson.success).toBe(true);
+    }, 35000);
 
     it('POST /api/cursor/daemon/stop returns success when daemon is not running', async () => {
       const res = await fetch(`${baseUrl}/api/cursor/daemon/stop`, { method: 'POST' });


### PR DESCRIPTION
### Motivation
- Prevent leaking the Cursor daemon bearer secret via the dashboard `/api/cursor/daemon/start` response while keeping the endpoint usable for startup probing.

### Description
- Redact `daemonToken` from the result returned by `startDaemon()` when the dashboard route serializes the result in `src/web-server/routes/cursor-routes.ts` so the API no longer exposes the live bearer token.
- Update the unit test `tests/unit/web-server/cursor-routes.test.ts` to assert the daemon is started but that `daemonToken` is not present in the public JSON response.
- Apply Prettier/formatting cleanup to a couple of touched files (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`) to satisfy project formatting checks.

### Testing
- Ran targeted tests: `bun test tests/unit/web-server/cursor-routes.test.ts` and `bun test tests/integration/cursor-daemon-lifecycle.test.ts`, and both relevant suites passed locally for the modified route and integration scenarios.
- Ran formatting and linting commands (`prettier --write`, `eslint --fix`) to normalize touched files and remove style drift; those changes were committed.
- Attempts to run full `bun run validate` / `validate:ci-parity` in this environment surfaced unrelated existing test failures and an invalid `/root/.ccs/config.yaml` in the container, so broader CI parity checks were not fully green here but are unrelated to the token-redaction change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dde771b083308ba0853380c5f5b1)