### PR TITLE
fix(browser): preserve profile-bound DevTools discovery

### DIFF
--- a/src/cliproxy/executor/__tests__/browser-launch-setup.test.ts
+++ b/src/cliproxy/executor/__tests__/browser-launch-setup.test.ts
@@ -42,6 +42,7 @@ describe('resolveBrowserLaunchFlags — no browser flags', () => {
     }));
     mock.module('../../../config/config-loader-facade', () => ({
       getBrowserConfig: () => makeBrowserConfig(false),
+      hasExplicitClaudeBrowserDevtoolsPort: () => false,
       loadOrCreateUnifiedConfig: () => ({}),
       getThinkingConfig: () => ({}),
     }));
@@ -73,6 +74,7 @@ describe('resolveBrowserLaunchFlags — with browser-launch override', () => {
     }));
     mock.module('../../../config/config-loader-facade', () => ({
       getBrowserConfig: () => makeBrowserConfig(true, 'auto'),
+      hasExplicitClaudeBrowserDevtoolsPort: () => false,
       loadOrCreateUnifiedConfig: () => ({}),
       getThinkingConfig: () => ({}),
     }));
@@ -113,6 +115,7 @@ describe('resolveBrowserLaunchFlags — blocked override warning', () => {
     }));
     mock.module('../../../config/config-loader-facade', () => ({
       getBrowserConfig: () => makeBrowserConfig(false, 'never'),
+      hasExplicitClaudeBrowserDevtoolsPort: () => false,
       loadOrCreateUnifiedConfig: () => ({}),
       getThinkingConfig: () => ({}),
     }));
@@ -143,6 +146,7 @@ describe('resolveBrowserRuntime — attach disabled', () => {
     }));
     mock.module('../../../config/config-loader-facade', () => ({
       getBrowserConfig: () => makeBrowserConfig(false),
+      hasExplicitClaudeBrowserDevtoolsPort: () => false,
       loadOrCreateUnifiedConfig: () => ({}),
       getThinkingConfig: () => ({}),
     }));
@@ -173,6 +177,7 @@ describe('resolveBrowserRuntime — active runtime env', () => {
     }));
     mock.module('../../../config/config-loader-facade', () => ({
       getBrowserConfig: () => makeBrowserConfig(true, 'always'),
+      hasExplicitClaudeBrowserDevtoolsPort: () => false,
       loadOrCreateUnifiedConfig: () => ({}),
       getThinkingConfig: () => ({}),
     }));

--- a/src/cliproxy/executor/browser-launch-setup.ts
+++ b/src/cliproxy/executor/browser-launch-setup.ts
@@ -20,7 +20,10 @@ import {
   resolveOptionalBrowserAttachRuntime,
   syncBrowserMcpToConfigDir,
 } from '../../utils/browser';
-import { getBrowserConfig } from '../../config/config-loader-facade';
+import {
+  getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
+} from '../../config/config-loader-facade';
 
 export interface BrowserLaunchSetupResult {
   /** CLI override flag if --browser-launch / --no-browser-launch was passed */
@@ -57,7 +60,9 @@ export function resolveBrowserLaunchFlags(argsWithoutProxy: string[]): {
   }
 
   const browserConfig = getBrowserConfig();
-  const browserAttachConfig = getEffectiveClaudeBrowserAttachConfig(browserConfig);
+  const browserAttachConfig = getEffectiveClaudeBrowserAttachConfig(browserConfig, process.env, {
+    hasExplicitDevtoolsPort: hasExplicitClaudeBrowserDevtoolsPort(),
+  });
   const claudeBrowserExposure = resolveBrowserExposure(
     {
       enabled: browserAttachConfig.enabled,
@@ -85,7 +90,9 @@ export async function resolveBrowserRuntime(
   inheritedClaudeConfigDir: string | undefined
 ): Promise<Pick<BrowserLaunchSetupResult, 'browserRuntimeEnv'>> {
   const browserConfig = getBrowserConfig();
-  const browserAttachConfig = getEffectiveClaudeBrowserAttachConfig(browserConfig);
+  const browserAttachConfig = getEffectiveClaudeBrowserAttachConfig(browserConfig, process.env, {
+    hasExplicitDevtoolsPort: hasExplicitClaudeBrowserDevtoolsPort(),
+  });
   const claudeBrowserExposure = resolveBrowserExposure(
     {
       enabled: browserAttachConfig.enabled,

--- a/src/config/config-loader-facade.ts
+++ b/src/config/config-loader-facade.ts
@@ -41,6 +41,7 @@ export {
   isDashboardAuthEnabled,
   getDashboardAuthConfig,
   getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
   getImageAnalysisConfig,
   getLoggingConfig,
   getCursorConfig,

--- a/src/config/loader/config-getters.ts
+++ b/src/config/loader/config-getters.ts
@@ -53,6 +53,13 @@ function getConfig(): import('../unified-config-types').UnifiedConfig {
   return loader.loadOrCreateUnifiedConfig();
 }
 
+function getPersistedConfig(): import('../unified-config-types').UnifiedConfig | null {
+  const loader = require('../unified-config-loader') as {
+    loadUnifiedConfig: () => import('../unified-config-types').UnifiedConfig | null;
+  };
+  return loader.loadUnifiedConfig();
+}
+
 // ---------------------------------------------------------------------------
 // GeminiWebSearchInfo interface
 // ---------------------------------------------------------------------------
@@ -305,6 +312,22 @@ export function getDashboardAuthConfig(): DashboardAuthConfig {
 export function getBrowserConfig(): BrowserConfig {
   const config = getConfig();
   return canonicalizeBrowserConfig(config.browser);
+}
+
+/**
+ * Return whether the persisted browser config explicitly defines
+ * claude.devtools_port. Canonicalized BrowserConfig values always contain a
+ * default port, so config-backed browser attach callers must use this raw
+ * persisted shape to decide whether the port should bypass profile discovery.
+ */
+export function hasExplicitClaudeBrowserDevtoolsPort(): boolean {
+  const claude = getPersistedConfig()?.browser?.claude;
+  if (!claude || !Object.prototype.hasOwnProperty.call(claude, 'devtools_port')) {
+    return false;
+  }
+
+  const port = claude.devtools_port;
+  return Number.isFinite(port) && Math.floor(port as number) === port && port >= 1 && port <= 65535;
 }
 
 /**

--- a/src/config/unified-config-loader.ts
+++ b/src/config/unified-config-loader.ts
@@ -102,6 +102,7 @@ export {
   isDashboardAuthEnabled,
   getDashboardAuthConfig,
   getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
   getImageAnalysisConfig,
   getLoggingConfig,
   getCursorConfig,

--- a/src/dispatcher/profile-resolver.ts
+++ b/src/dispatcher/profile-resolver.ts
@@ -18,7 +18,10 @@ import { loadSettings } from '../config/config-loader-facade';
 import { expandPath } from '../utils/helpers';
 import { fail, info, warn } from '../utils/ui';
 import { ErrorManager } from '../utils/error-manager';
-import { getBrowserConfig } from '../config/config-loader-facade';
+import {
+  getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
+} from '../config/config-loader-facade';
 import {
   getEffectiveClaudeBrowserAttachConfig,
   resolveBrowserExposure,
@@ -278,7 +281,11 @@ export async function resolveProfileAndTarget(
   const targetBinaryInfo: TargetBinaryInfo | null = targetAdapter?.detectBinary() ?? null;
   const browserConfig = getBrowserConfig();
   const claudeAttachConfig =
-    resolvedTarget === 'claude' ? getEffectiveClaudeBrowserAttachConfig(browserConfig) : undefined;
+    resolvedTarget === 'claude'
+      ? getEffectiveClaudeBrowserAttachConfig(browserConfig, process.env, {
+          hasExplicitDevtoolsPort: hasExplicitClaudeBrowserDevtoolsPort(),
+        })
+      : undefined;
   const codexRuntimeConfigOverrides = resolveCodexRuntimeConfigOverrides(
     resolvedTarget,
     browserLaunchOverride

--- a/src/utils/browser/browser-settings.ts
+++ b/src/utils/browser/browser-settings.ts
@@ -225,12 +225,13 @@ export function getBrowserAttachOverride(env: NodeJS.ProcessEnv = process.env): 
 
 export function getEffectiveClaudeBrowserAttachConfig(
   config: BrowserConfig,
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  options: { hasExplicitDevtoolsPort?: boolean } = {}
 ): EffectiveClaudeBrowserAttachConfig {
   const override = getBrowserAttachOverride(env);
   const configUserDataDir =
     resolveBrowserUserDataDir(config.claude.user_data_dir) ?? getRecommendedBrowserUserDataDir();
-  const configHasExplicitPort = config.claude.devtools_port !== undefined;
+  const configHasExplicitPort = options.hasExplicitDevtoolsPort ?? true;
   const configPort = normalizeDevtoolsPort(config.claude.devtools_port);
   const configEvalMode = config.claude.eval_mode ?? 'readonly';
   const envEvalMode = parseBrowserEvalMode(env.CCS_BROWSER_EVAL_MODE);

--- a/src/utils/browser/browser-setup.ts
+++ b/src/utils/browser/browser-setup.ts
@@ -8,7 +8,11 @@ import {
   getRecommendedBrowserUserDataDir,
   isManagedClaudeBrowserAttachConfig,
 } from './browser-settings';
-import { getBrowserConfig, mutateConfig } from '../../config/config-loader-facade';
+import {
+  getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
+  mutateConfig,
+} from '../../config/config-loader-facade';
 
 export interface BrowserSetupResult {
   configUpdated: boolean;
@@ -41,7 +45,9 @@ export async function runBrowserSetup(
   const initialConfig = deps.getBrowserConfig();
   const configUpdated = persistBrowserSetupConfig(deps, initialConfig);
   const persistedConfig = deps.getBrowserConfig();
-  const effectiveConfig = getEffectiveClaudeBrowserAttachConfig(persistedConfig);
+  const effectiveConfig = getEffectiveClaudeBrowserAttachConfig(persistedConfig, process.env, {
+    hasExplicitDevtoolsPort: hasExplicitClaudeBrowserDevtoolsPort(),
+  });
   const createdUserDataDir = isManagedClaudeBrowserAttachConfig(effectiveConfig)
     ? ensureManagedBrowserUserDataDir(effectiveConfig).createdProfileDir
     : false;

--- a/src/utils/browser/browser-status.ts
+++ b/src/utils/browser/browser-status.ts
@@ -19,7 +19,11 @@ import {
   getEffectiveClaudeBrowserAttachConfig,
   getRecommendedBrowserUserDataDir,
 } from './browser-settings';
-import { getBrowserConfig, loadUnifiedConfig } from '../../config/config-loader-facade';
+import {
+  getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
+  loadUnifiedConfig,
+} from '../../config/config-loader-facade';
 
 export interface ClaudeBrowserStatus {
   enabled: boolean;
@@ -124,9 +128,12 @@ export function getUserFacingBrowserConfig(): BrowserConfig {
 }
 
 async function buildClaudeBrowserStatus(
-  browserConfig = getUserFacingBrowserConfig()
+  browserConfig = getUserFacingBrowserConfig(),
+  hasExplicitDevtoolsPort = hasExplicitClaudeBrowserDevtoolsPort()
 ): Promise<ClaudeBrowserStatus> {
-  const effective = getEffectiveClaudeBrowserAttachConfig(browserConfig);
+  const effective = getEffectiveClaudeBrowserAttachConfig(browserConfig, process.env, {
+    hasExplicitDevtoolsPort,
+  });
   const launchCommands = buildBrowserLaunchCommands(effective.userDataDir, effective.devtoolsPort);
   const base: Omit<ClaudeBrowserStatus, 'state' | 'title' | 'detail' | 'nextStep'> = {
     enabled: effective.enabled,

--- a/tests/unit/utils/browser/browser-status.test.ts
+++ b/tests/unit/utils/browser/browser-status.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   getBrowserConfig,
+  hasExplicitClaudeBrowserDevtoolsPort,
   mutateUnifiedConfig,
   saveUnifiedConfig,
 } from '../../../../src/config/unified-config-loader';
@@ -168,11 +169,11 @@ describe('browser status', () => {
       };
     });
 
-    const runtimeSpy = spyOn(chromeReuse, 'resolveBrowserRuntimeEnv').mockRejectedValue(
-      new Error(
+    const runtimeSpy = spyOn(chromeReuse, 'resolveBrowserRuntimeEnv').mockImplementation(() => {
+      throw new Error(
         `Chrome reuse metadata not found: ${join(tempHome, '.ccs', 'browser', 'chrome-user-data', 'DevToolsActivePort')}`
-      )
-    );
+      );
+    });
     const codexSpy = spyOn(codexDetector, 'getCodexBinaryInfo').mockReturnValue({
       path: '/usr/local/bin/codex',
       needsShell: false,
@@ -422,7 +423,51 @@ describe('browser status', () => {
     }
   });
 
-  it('always forwards an explicit port for config-backed browser attach sessions', async () => {
+  it('preserves profile-bound port discovery when config omits DevTools port', async () => {
+    const config = createEmptyUnifiedConfig();
+    config.browser = {
+      claude: {
+        enabled: true,
+        policy: 'auto',
+        user_data_dir: '/tmp/config-browser',
+      } as typeof config.browser.claude,
+      codex: {
+        enabled: true,
+        policy: 'auto',
+      } as typeof config.browser.codex,
+    };
+    saveUnifiedConfig(config);
+
+    expect(hasExplicitClaudeBrowserDevtoolsPort()).toBe(false);
+
+    const runtimeSpy = spyOn(chromeReuse, 'resolveBrowserRuntimeEnv').mockResolvedValue({
+      CCS_BROWSER_USER_DATA_DIR: '/tmp/config-browser',
+      CCS_BROWSER_DEVTOOLS_HOST: '127.0.0.1',
+      CCS_BROWSER_DEVTOOLS_PORT: '9333',
+      CCS_BROWSER_DEVTOOLS_HTTP_URL: 'http://127.0.0.1:9333',
+      CCS_BROWSER_DEVTOOLS_WS_URL: 'ws://127.0.0.1/devtools/browser/config',
+    });
+    const codexSpy = spyOn(codexDetector, 'getCodexBinaryInfo').mockReturnValue({
+      path: '/usr/local/bin/codex',
+      needsShell: false,
+      version: 'codex-cli 0.120.0',
+      features: ['config-overrides'],
+    });
+
+    try {
+      await getBrowserStatus();
+
+      expect(runtimeSpy.mock.calls[0]?.[0]).toEqual({
+        profileDir: '/tmp/config-browser',
+        devtoolsPort: undefined,
+      });
+    } finally {
+      runtimeSpy.mockRestore();
+      codexSpy.mockRestore();
+    }
+  });
+
+  it('forwards an explicit port for config-backed browser attach sessions', async () => {
     mutateUnifiedConfig((config) => {
       config.browser = {
         claude: {
@@ -437,6 +482,8 @@ describe('browser status', () => {
         },
       };
     });
+
+    expect(hasExplicitClaudeBrowserDevtoolsPort()).toBe(true);
 
     const runtimeSpy = spyOn(chromeReuse, 'resolveBrowserRuntimeEnv').mockResolvedValue({
       CCS_BROWSER_USER_DATA_DIR: '/tmp/config-browser',


### PR DESCRIPTION
### Motivation
- Fix a logic/security regression where canonicalized browser defaults made `claude.devtools_port` look user-explicit, causing CCS to bypass profile-bound `DevToolsActivePort` discovery and potentially attach to an unrelated localhost DevTools endpoint.
- Ensure omitted config ports continue to trigger profile-bound discovery while preserving explicit env or persisted-port behavior.

### Description
- Add `hasExplicitClaudeBrowserDevtoolsPort()` that inspects the persisted unified config (not the canonicalized view) to detect whether `claude.devtools_port` was explicitly set. (`src/config/loader/config-getters.ts`, re-exported via `src/config/unified-config-loader.ts` and `src/config/config-loader-facade.ts`).
- Extend `getEffectiveClaudeBrowserAttachConfig()` to accept an explicit-port signal and use it to set `hasExplicitDevtoolsPort` instead of relying on canonicalized defaults. (`src/utils/browser/browser-settings.ts`).
- Thread the persisted explicit-port signal through status/setup/launcher/dispatcher code paths so runtime discovery only gets an explicit port when the user actually configured one: updates to `browser-status`, `browser-setup`, `cliproxy/executor/browser-launch-setup`, and `dispatcher/profile-resolver` call sites. (`src/utils/browser/browser-status.ts`, `src/utils/browser/browser-setup.ts`, `src/cliproxy/executor/browser-launch-setup.ts`, `src/dispatcher/profile-resolver.ts`).
- Add/adjust unit tests to cover omitted vs explicit DevTools port behavior and preserve existing explicit-port forwarding semantics. (`tests/unit/utils/browser/browser-status.test.ts`).
- Apply Prettier formatting fixes to files touched by the change so repository formatting checks pass. (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`).

### Testing
- Ran `bun run typecheck` and `bun run lint` with no errors reported. (passed)
- Ran Prettier checks with `bunx prettier --check ...` on affected files and fixed formatting where required. (passed)
- Ran unit tests `bun test tests/unit/utils/browser/browser-status.test.ts tests/unit/utils/browser/browser-setup.test.ts` and verified the new and existing browser tests pass. (passed)
- Ran `bun run validate` (full validate/test:fast); typecheck/lint/format checks passed but `test:fast` surfaced an unrelated existing failing test `web-server account-routes context normalization > rolls back inferred shared resource metadata when instance reconciliation fails`, so the validate script reported failure that is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dd3d8fd483309ce6e5b71d69e2e1)