### PR TITLE
fix: avoid echoing invalid channel token values

### DIFF
--- a/src/commands/config-channels-command.ts
+++ b/src/commands/config-channels-command.ts
@@ -57,7 +57,7 @@ interface ChannelsCommandOptions {
   setTokenChannel?: OfficialChannelId;
   setTokenMissing: boolean;
   clearTokenInvalid?: string;
-  setTokenInvalid?: string;
+  setTokenInvalid: boolean;
   help: boolean;
 }
 
@@ -83,13 +83,13 @@ export function parseChannelsCommandArgs(args: string[]): ChannelsCommandOptions
   }
 
   let parsedSetTokenChannel: OfficialChannelId | undefined;
-  let setTokenInvalid: string | undefined;
+  let setTokenInvalid = false;
   if (setToken.found && !setToken.missingValue && setToken.value) {
     const channelId = setToken.value.trim().toLowerCase();
     if (isOfficialChannelId(channelId)) {
       parsedSetTokenChannel = channelId;
     } else {
-      setTokenInvalid = setToken.value;
+      setTokenInvalid = true;
     }
   }
 
@@ -378,11 +378,7 @@ export async function handleConfigChannelsCommand(args: string[]): Promise<void>
     return;
   }
   if (options.setTokenInvalid) {
-    console.error(
-      fail(
-        `Invalid --set-token value: ${options.setTokenInvalid} (use ${getOfficialChannelChoices()})`
-      )
-    );
+    console.error(fail(`Invalid --set-token value (use ${getOfficialChannelChoices()})`));
     process.exitCode = 1;
     return;
   }

--- a/src/commands/config-command-options.ts
+++ b/src/commands/config-command-options.ts
@@ -92,7 +92,7 @@ export function showConfigCommandHelp(): void {
   console.log('    --enable         Legacy alias: add Discord');
   console.log('    --disable        Legacy alias: remove Discord');
   console.log('    --unattended     Also add --dangerously-skip-permissions at runtime');
-  console.log('    --set-token <s>  Save channel token (telegram=<t> or discord=<t>)');
+  console.log('    --set-token <c>  Save channel token from channel env var');
   console.log('    --clear-token    Remove all saved channel tokens');
   console.log('    --clear-token <c> Remove one saved channel token');
   console.log(`                     ${getOfficialChannelsSupportMessage()}`);
@@ -136,7 +136,7 @@ export function showConfigCommandHelp(): void {
   console.log('  ccs config auth setup            Configure dashboard login');
   console.log('  ccs config channels              Show Official Channels status');
   console.log('  ccs config channels --set telegram,discord Enable Telegram + Discord');
-  console.log('  ccs config channels --set-token telegram=xxx Save TELEGRAM_BOT_TOKEN');
+  console.log('  TELEGRAM_BOT_TOKEN=xxx ccs config channels --set-token telegram Save token');
   console.log('  ccs config image-analysis        Show image settings');
   console.log('  ccs config image-analysis --enable Enable feature');
   console.log('  ccs config thinking              Show thinking settings');

--- a/tests/unit/commands/config-channels-command.test.ts
+++ b/tests/unit/commands/config-channels-command.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'bun:test';
-import { parseChannelsCommandArgs } from '../../../src/commands/config-channels-command';
+import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import {
+  handleConfigChannelsCommand,
+  parseChannelsCommandArgs,
+} from '../../../src/commands/config-channels-command';
+
+const originalExitCode = process.exitCode;
+
+afterEach(() => {
+  process.exitCode = originalExitCode ?? 0;
+});
 
 describe('config channels command parser', () => {
   it('parses selection, unattended mode, and token channel input', () => {
@@ -30,5 +39,35 @@ describe('config channels command parser', () => {
     expect(result.setTokenChannel).toBe('discord');
     expect(clearAll.clearTokenAll).toBe(true);
     expect(clearOne.clearTokenChannel).toBe('discord');
+  });
+
+  it('marks invalid set-token values without retaining secret-like input', () => {
+    const secretValue = 'telegram=SECRET_BOT_TOKEN_12345';
+    const result = parseChannelsCommandArgs(['--set-token', secretValue]);
+
+    expect(result.setTokenInvalid).toBe(true);
+    expect(JSON.stringify(result)).not.toContain(secretValue);
+    expect(JSON.stringify(result)).not.toContain('SECRET_BOT_TOKEN_12345');
+  });
+});
+
+describe('config channels command handler', () => {
+  it('does not echo invalid set-token values to stderr', async () => {
+    const secretValue = 'telegram=SECRET_BOT_TOKEN_12345';
+    const errors: string[] = [];
+    const errorSpy = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      errors.push(args.map(String).join(' '));
+    });
+
+    try {
+      await handleConfigChannelsCommand(['--set-token', secretValue]);
+    } finally {
+      errorSpy.mockRestore();
+    }
+
+    expect(process.exitCode).toBe(1);
+    expect(errors.join('\n')).toContain('Invalid --set-token value');
+    expect(errors.join('\n')).not.toContain(secretValue);
+    expect(errors.join('\n')).not.toContain('SECRET_BOT_TOKEN_12345');
   });
 });


### PR DESCRIPTION
### Motivation

- Prevent leaking token-bearing deprecated `--set-token` argv values into stderr/logs by stopping the parser from retaining raw invalid input and by avoiding echoing it in error messages.

### Description

- Stop storing raw `--set-token` values for invalid inputs and instead mark invalid `--set-token` as a boolean in `parseChannelsCommandArgs` to avoid retaining secrets in memory (`src/commands/config-channels-command.ts`).
- Print a generic validation message for invalid `--set-token` invocations instead of interpolating the user-supplied value into stderr (`src/commands/config-channels-command.ts`).
- Update top-level config help to show the environment-variable-based token flow instead of the deprecated token-in-argv example (`src/commands/config-command-options.ts`).
- Add parser and handler regression tests to ensure invalid token-like `--set-token` values are not retained or emitted (`tests/unit/commands/config-channels-command.test.ts`).
- Apply small formatter-friendly edits to a few dynamic-import lines to satisfy lint/format checks (`src/cliproxy/quota/quota-manager.ts`, `src/management/checks/image-analysis-check.ts`).

### Testing

- Ran the new and updated unit tests: `bun test tests/unit/commands/config-channels-command.test.ts` (4 tests passed).
- Built the project and validated the runtime reproduction that previously leaked secrets by running the packaged CLI and invoking `config channels --set-token telegram=SECRET_BOT_TOKEN_12345`; the process exited with code `1` and stderr contained only the generic `Invalid --set-token value` message with no token or `telegram=SECRET` substrings (build + runtime check completed successfully).
- Performed `bun run typecheck`, `bun run lint`, `bun run format:check`, and `bun run build` locally; these steps succeeded but `bun run validate` / `bun run validate:ci-parity` reported unrelated existing test failures in other suites (not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dd3d66c083309e6b4da246eeda6d)