### PR TITLE
fix(bar): avoid blocking on lower-priority probes

### DIFF
--- a/src/commands/bar/bar-server-probe.ts
+++ b/src/commands/bar/bar-server-probe.ts
@@ -34,9 +34,9 @@ export function resolveBarPort(ccsDir: string): number | null {
  *
  * Both IPv4 (127.0.0.1) and IPv6 (::1) loopback addresses are probed for each
  * port. All probes are fired concurrently so worst-case latency is ~1.5 s
- * (one timeout) rather than N × 1.5 s sequentially. Priority selection is
- * applied after all results are in: the bar.json port is preferred over the
- * defaults, and within a port 127.0.0.1 is preferred over [::1].
+ * (one timeout) rather than N × 1.5 s sequentially. Results are awaited in
+ * priority order so a lower-priority slow or streaming response cannot block
+ * returning an already-known higher-priority hit.
  */
 export async function defaultFindRunningServer(ccsDir: string): Promise<DashboardInfo | null> {
   const { request } = await import('undici');
@@ -48,7 +48,22 @@ export async function defaultFindRunningServer(ccsDir: string): Promise<Dashboar
         headersTimeout: 1500,
         bodyTimeout: 1500,
       });
-      await body.text();
+
+      // The summary endpoint only needs the status code for liveness. Do not
+      // buffer the response body: a non-CCS loopback service can stream forever
+      // and keep discovery from returning a higher-priority hit. Release the
+      // response as soon as headers arrive.
+      try {
+        if (typeof body.resume === 'function') {
+          body.resume();
+        } else if (typeof body.destroy === 'function') {
+          body.destroy();
+        }
+      } catch {
+        // Closing the response is a best-effort cleanup; liveness depends only
+        // on the status code already received.
+      }
+
       return { ok: statusCode === 200 };
     } catch {
       return { ok: false };
@@ -65,10 +80,10 @@ export async function defaultFindRunningServer(ccsDir: string): Promise<Dashboar
     { port, baseUrl: `http://[::1]:${port}`, url: `http://[::1]:${port}/api/bar/summary` },
   ]);
 
-  const results = await Promise.all(probeTargets.map((t) => probe(t.url)));
+  const probes = probeTargets.map((t) => probe(t.url));
 
   for (let i = 0; i < probeTargets.length; i++) {
-    if (results[i].ok) {
+    if ((await probes[i]).ok) {
       const { port, baseUrl } = probeTargets[i];
       return { port, baseUrl };
     }

--- a/tests/unit/commands/bar-command.test.ts
+++ b/tests/unit/commands/bar-command.test.ts
@@ -3026,3 +3026,60 @@ describe('bar install: silent-decline fix — hint on user decline (review findi
     expect(allOutput).not.toMatch(/Run `ccs bar` to launch later/i);
   });
 });
+
+describe('defaultFindRunningServer: streaming lower-priority probes', () => {
+  it('returns a higher-priority hit without waiting for lower-priority response bodies', async () => {
+    const ccsDir = path.join(tempHome, '.ccs');
+    fs.mkdirSync(ccsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(ccsDir, 'bar.json'),
+      JSON.stringify({ port: 41235, baseUrl: 'http://127.0.0.1:41235', authMode: 'loopback' })
+    );
+
+    let highPriorityBodyDestroyed = false;
+    let lowerPriorityProbeStarted = false;
+
+    mock.module('undici', () => ({
+      request: (url: string) => {
+        if (url === 'http://127.0.0.1:41235/api/bar/summary') {
+          return Promise.resolve({
+            statusCode: 200,
+            body: {
+              destroy: () => {
+                highPriorityBodyDestroyed = true;
+              },
+            },
+          });
+        }
+
+        if (url === 'http://127.0.0.1:3000/api/bar/summary') {
+          lowerPriorityProbeStarted = true;
+          return new Promise(() => {
+            // Simulate a lower-priority service that never finishes responding.
+          });
+        }
+
+        return Promise.resolve({
+          statusCode: 404,
+          body: { destroy: () => {} },
+        });
+      },
+    }));
+
+    moduleSeq++;
+    const { defaultFindRunningServer } = (await import(
+      `../../../src/commands/bar/bar-server-probe?test=${Date.now()}-${moduleSeq}`
+    )) as {
+      defaultFindRunningServer: (ccsDir: string) => Promise<{ port: number; baseUrl: string } | null>;
+    };
+
+    const result = await Promise.race([
+      defaultFindRunningServer(ccsDir),
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 250)),
+    ]);
+
+    expect(result).toEqual({ port: 41235, baseUrl: 'http://127.0.0.1:41235' });
+    expect(highPriorityBodyDestroyed).toBe(true);
+    expect(lowerPriorityProbeStarted).toBe(true);
+  });
+});


### PR DESCRIPTION
### Motivation
- The concurrent probe implementation previously awaited every probe and drained response bodies with `body.text()`, allowing a lower-priority streaming or stalled loopback service to block discovery and delay returning a valid higher-priority server. 
- The change aims to preserve concurrent probing for performance while ensuring a known higher-priority success can be returned promptly and without fully buffering reply bodies.

### Description
- Stop buffering probe bodies with `body.text()` and instead release the response body as soon as headers arrive by calling `body.resume()` or `body.destroy()` when available, since liveness only requires the status code. 
- Keep probes started concurrently but await probe results in priority order by mapping to started promises and checking them sequentially so a lower-priority slow probe cannot block returning an earlier high-priority hit. 
- Add a regression unit test that mocks a never-ending lower-priority probe and verifies the higher-priority `bar.json` port is returned promptly. 

### Testing
- Ran static type checks with `bun run typecheck`, which succeeded. 
- Ran the targeted unit regression with `bun test tests/unit/commands/bar-command.test.ts -t 'streaming lower-priority probes' --timeout 10000`, and the new test passed. 
- Ran the full `tests/unit/commands/bar-command.test.ts` suite where the changes cause the new regression test and the rest of the file to pass, but one pre-existing IPv6-only integration-style test (`detects a real HTTP server responding 200 on /api/bar/summary bound to ::1 only`) still fails in this environment, so the file shows `105 pass / 1 fail` under the local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ad0d154c83309e28fa87b54c286e)