### PR TITLE
fix: enforce tier lock during quota preflight

### DIFF
--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -658,8 +658,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
   // match the locked tier.  If it doesn't, route to a healthy account in the
   // locked tier instead.  Locks are per-provider: locking "agy" to "ultra"
   // does NOT constrain "claude", "codex", "gemini", or "ghcp".
-  // Graceful degradation: if no locked-tier account is available, fall through
-  // to the default (don't block the request entirely).
+  // This is intentionally strict: if no locked-tier account is available, do
+  // not fail open to a cross-tier default.
   const tierLock = getTierLockForProvider(quotaConfig.manual, provider);
   if (tierLock !== null && (defaultAccount.tier || 'unknown') !== tierLock) {
     const lockedTierAccount = await findHealthyAccount(provider, []);
@@ -673,7 +673,12 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
         reason: `Tier lock: selected ${tierLock} account`,
       };
     }
-    // No locked-tier account available — fall through and use default
+
+    return {
+      proceed: false,
+      accountId: '',
+      reason: `Tier lock: no healthy ${tierLock} account available`,
+    };
   }
 
   // Check if default is paused

--- a/tests/unit/cliproxy/quota-manager-tier-lock.test.ts
+++ b/tests/unit/cliproxy/quota-manager-tier-lock.test.ts
@@ -353,6 +353,49 @@ describe('quota-manager findHealthyAccount — tier_lock', () => {
   });
 
   // -------------------------------------------------------------------------
+  // preflightCheck must enforce the same strict tier lock as findHealthyAccount
+  // -------------------------------------------------------------------------
+
+  it('preflightCheck blocks a cross-tier default when no healthy locked-tier account exists', async () => {
+    writeMinimalConfig(tempHome, { agy: 'pro' });
+    _mockAccounts = [ULTRA_ACCOUNT, PRO_ACCOUNT];
+
+    const uid = `preflight-lock-pro-exhausted-${Date.now()}-${Math.random()}`;
+    const { preflightCheck, setCachedQuota } = await import(
+      `../../../src/cliproxy/quota/quota-manager?${uid}`
+    );
+
+    // Default is ultra, but agy is locked to pro. The only pro account is
+    // exhausted, so preflight must not fail open to the healthy ultra default.
+    setCachedQuota('agy', ULTRA_ACCOUNT.id, HEALTHY_QUOTA as never);
+    setCachedQuota('agy', PRO_ACCOUNT.id, EXHAUSTED_QUOTA as never);
+
+    const result = await preflightCheck('agy');
+    expect(result.proceed).toBe(false);
+    expect(result.accountId).not.toBe(ULTRA_ACCOUNT.id);
+    expect(result.reason).toBe('Tier lock: no healthy pro account available');
+  });
+
+  it('preflightCheck switches a cross-tier default to a healthy locked-tier account', async () => {
+    writeMinimalConfig(tempHome, { agy: 'pro' });
+    _mockAccounts = [ULTRA_ACCOUNT, PRO_ACCOUNT];
+
+    const uid = `preflight-lock-pro-healthy-${Date.now()}-${Math.random()}`;
+    const { preflightCheck, setCachedQuota } = await import(
+      `../../../src/cliproxy/quota/quota-manager?${uid}`
+    );
+
+    setCachedQuota('agy', ULTRA_ACCOUNT.id, HEALTHY_QUOTA as never);
+    setCachedQuota('agy', PRO_ACCOUNT.id, HEALTHY_QUOTA as never);
+
+    const result = await preflightCheck('agy');
+    expect(result.proceed).toBe(true);
+    expect(result.accountId).toBe(PRO_ACCOUNT.id);
+    expect(result.switchedFrom).toBe(ULTRA_ACCOUNT.id);
+    expect(result.reason).toBe('Tier lock: selected pro account');
+  });
+
+  // -------------------------------------------------------------------------
   // Baseline: no tier_lock — any available healthy account is returned.
   //
   // Same pattern: write null-lock and invalidate cache immediately before import.


### PR DESCRIPTION
### Motivation
- The per-provider `tier_lock` feature was inconsistently enforced: `findHealthyAccount` strictly filtered candidates by locked tier, but `preflightCheck` could fall back to a cross-tier default when no locked-tier account existed, creating a fail-open policy.

### Description
- Change `preflightCheck` in `src/cliproxy/quota/quota-manager.ts` to refuse to proceed (`proceed: false`) when a provider `tier_lock` is active and no healthy account exists in the locked tier, preventing silent cross-tier failover.
- Keep the existing behavior of switching to a healthy locked-tier account when one is available and honoring other fallback checks (`paused`, `cooldown`) as before.
- Add regression unit tests in `tests/unit/cliproxy/quota-manager-tier-lock.test.ts` to cover the fail-closed preflight case and the successful switch case.
- Apply a small formatting tweak to a dynamic import in `src/management/checks/image-analysis-check.ts` to satisfy repository formatting rules.

### Testing
- Ran `bun test tests/unit/cliproxy/quota-manager-tier-lock.test.ts`, and all tests in that file passed.
- Ran `bun run typecheck` (TS compiler) and it succeeded with no errors.
- Ran `bun run lint` and `bun run format:check`, and both checks passed after applying the formatting tweak.
- Attempted a broader `bun run validate` sequence; formatting/lint/typecheck steps completed, but the full `validate` run was interrupted by an unrelated environment-sensitive test failure/hang in the CI test bucket and was terminated (this did not affect the focused unit tests validating the fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ad0d06a88330add4f20e4ef405b8)