### PR TITLE
fix(bar): distinguish native Codex subscription rows

### DIFF
--- a/macos-bar/Sources/CCSBarApp/BarMenuView.swift
+++ b/macos-bar/Sources/CCSBarApp/BarMenuView.swift
@@ -401,7 +401,7 @@ struct BarRowView: View {
   /// A native first-party subscription (Claude Code / Codex) — drives the
   /// distinct "subscription" badge + indigo provider chip.
   private var isNativeSubscription: Bool {
-    BarFormatting.isNativeSubscription(provider: row.provider)
+    BarFormatting.isNativeSubscription(row)
   }
 
   var body: some View {

--- a/macos-bar/Sources/CCSBarCheck/main.swift
+++ b/macos-bar/Sources/CCSBarCheck/main.swift
@@ -906,13 +906,19 @@ check(
   BarFormatting.providerLabel("codex") == "Codex", "native: providerLabel maps codex -> 'Codex'")
 check(BarFormatting.providerLabel("agy") == "agy", "native: providerLabel passes CLIProxy keys through")
 check(
-  BarFormatting.isNativeSubscription(provider: "claude-code"),
+  BarFormatting.isNativeSubscription(
+    BarSummaryRow(accountId: "claude-code", provider: "claude-code")),
   "native: claude-code is a native subscription")
 check(
-  BarFormatting.isNativeSubscription(provider: "codex"), "native: codex is a native subscription")
+  BarFormatting.isNativeSubscription(BarSummaryRow(accountId: "codex", provider: "codex")),
+  "native: codex is a native subscription")
 check(
-  !BarFormatting.isNativeSubscription(provider: "agy"),
+  !BarFormatting.isNativeSubscription(BarSummaryRow(accountId: "agy-a", provider: "agy")),
   "native: agy (CLIProxy pool) is NOT a native subscription")
+check(
+  !BarFormatting.isNativeSubscription(
+    BarSummaryRow(accountId: "pool-codex-oauth-1", provider: "codex")),
+  "native: codex CLIProxy pool row is NOT a native subscription")
 
 // (N6) Grouping: a mixed list splits into native subscriptions (top) and pool
 //      accounts, preserving backend order within each group.
@@ -922,17 +928,19 @@ do {
     BarSummaryRow(
       accountId: "claude-code", provider: "claude-code", quotaPercentage: 40, quotaStatus: "ok"),
     BarSummaryRow(accountId: "pool-b", provider: "ghcp", quotaStatus: "unsupported"),
+    BarSummaryRow(
+      accountId: "pool-codex-oauth-1", provider: "codex", quotaPercentage: 65, quotaStatus: "ok"),
     BarSummaryRow(accountId: "codex", provider: "codex", quotaPercentage: 52, quotaStatus: "ok"),
   ]
   let parts = BarFormatting.partitionSubscriptions(mixed)
   check(parts.subscriptions.count == 2, "native: partition pulls 2 subscriptions")
-  check(parts.pool.count == 2, "native: partition leaves 2 pool accounts")
+  check(parts.pool.count == 3, "native: partition leaves 3 pool accounts")
   check(
     parts.subscriptions.map { $0.provider } == ["claude-code", "codex"],
     "native: subscriptions keep backend order (claude-code, codex)")
   check(
-    parts.pool.map { $0.provider } == ["agy", "ghcp"],
-    "native: pool keeps backend order (agy, ghcp)")
+    parts.pool.map { $0.id } == ["agy:pool-a", "ghcp:pool-b", "codex:pool-codex-oauth-1"],
+    "native: pool keeps backend order and retains CLIProxy codex row")
 }
 
 // (N7) Pool-only list does NOT get split (single "Accounts" header path): both

--- a/macos-bar/Sources/CCSBarCore/BarFormatting.swift
+++ b/macos-bar/Sources/CCSBarCore/BarFormatting.swift
@@ -165,8 +165,9 @@ public enum BarFormatting {
   /// Code or Codex plan) rather than a CLIProxy-managed OAuth pool account. Drives
   /// the "Subscriptions" grouping + badge so a user reads "this is MY plan quota",
   /// not one of the rotating pool credentials.
-  public static func isNativeSubscription(provider: String) -> Bool {
-    provider == "claude-code" || provider == "codex"
+  public static func isNativeSubscription(_ row: BarSummaryRow) -> Bool {
+    (row.provider == "claude-code" && row.accountId == "claude-code")
+      || (row.provider == "codex" && row.accountId == "codex")
   }
 
   /// Friendly product label for a provider key. Native subscription keys read as
@@ -189,7 +190,7 @@ public enum BarFormatting {
     var subs: [BarSummaryRow] = []
     var pool: [BarSummaryRow] = []
     for row in rows {
-      if isNativeSubscription(provider: row.provider) {
+      if isNativeSubscription(row) {
         subs.append(row)
       } else {
         pool.append(row)


### PR DESCRIPTION
### Motivation
- Prevent CLIProxy-managed Codex pool accounts from being misclassified and badged as the user’s native Codex subscription by making the classifier unambiguous. 
- Preserve the intended trust distinction in the macOS bar UI so only true native rows drive the "Subscriptions" grouping, badge, and indigo chip styling.

### Description
- Change the native-subscription classifier to be row-aware by making `isNativeSubscription` accept a `BarSummaryRow` and require both `provider` and `accountId` to match the native contract (`claude-code:claude-code` and `codex:codex`). (file: `macos-bar/Sources/CCSBarCore/BarFormatting.swift`)
- Update `partitionSubscriptions` and UI call sites to use the new row-aware `isNativeSubscription` so partitioning and badging remain driven by the corrected classifier. (files: `macos-bar/Sources/CCSBarCore/BarFormatting.swift`, `macos-bar/Sources/CCSBarApp/BarMenuView.swift`)
- Extend the local test harness (`ccs-bar-check`) to cover the regression by asserting that a CLIProxy-shaped Codex row remains in the pool group while the true native Codex row classifies as a subscription. (file: `macos-bar/Sources/CCSBarCheck/main.swift`)

### Testing
- Ran TypeScript checks (`tsc --noEmit`) and `eslint` auto-fix as part of the commit hooks, which completed successfully in this environment. 
- Ran `git diff --check` to validate whitespace/patch issues with no failures. 
- Attempted to run the Swift harness via `swift run ccs-bar-check`, but execution was blocked in this Linux container due to the unavailable macOS `SwiftUI` module, so the Swift UI build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ad0d41c4833084e92860a022a142)