### PR TITLE
fix(bar): tolerate duplicate rows in alert pruning

### DIFF
--- a/macos-bar/Sources/CCSBarCheck/main.swift
+++ b/macos-bar/Sources/CCSBarCheck/main.swift
@@ -758,6 +758,35 @@ do {
   check(t1.firedKeys.isEmpty, "prune collapses stale-bucket + absent-account keys (bounded)")
 }
 
+// (H) Duplicate account ids from a malformed summary must not crash pruning.
+do {
+  let rows = [
+    BarSummaryRow(
+      accountId: "dup@example.com", provider: "agy", quotaPercentage: 5, quotaStatus: "ok",
+      nextReset: "2026-07-01T00:00:00Z"),
+    BarSummaryRow(
+      accountId: "dup@example.com", provider: "agy", quotaPercentage: 4, quotaStatus: "ok",
+      nextReset: "2026-08-01T00:00:00Z"),
+  ]
+  let prior: Set<String> = [
+    "quotaRemainingBelow|agy:dup@example.com|2026-07-01T00:00:00Z|L10",
+    "quotaRemainingBelow|agy:dup@example.com|2026-08-01T00:00:00Z|L10",
+    "quotaRemainingBelow|agy:dup@example.com|2026-09-01T00:00:00Z|L10",
+  ]
+  let ev = BarAlertEngine.evaluate(
+    rows: rows, analytics: nil, prefs: BarAlertPrefs(quotaLevels: [10]), priorFiredKeys: prior,
+    now: engineNow, calendar: utc)
+  check(
+    ev.firedKeys.contains("quotaRemainingBelow|agy:dup@example.com|2026-07-01T00:00:00Z|L10"),
+    "duplicate ids: prune keeps first present reset bucket")
+  check(
+    ev.firedKeys.contains("quotaRemainingBelow|agy:dup@example.com|2026-08-01T00:00:00Z|L10"),
+    "duplicate ids: prune keeps second present reset bucket")
+  check(
+    !ev.firedKeys.contains("quotaRemainingBelow|agy:dup@example.com|2026-09-01T00:00:00Z|L10"),
+    "duplicate ids: prune drops absent reset bucket")
+}
+
 // (H) Deterministic order: shuffled rows produce notifs in stable id order.
 do {
   let rows = [

--- a/macos-bar/Sources/CCSBarCore/BarAlertEngine.swift
+++ b/macos-bar/Sources/CCSBarCore/BarAlertEngine.swift
@@ -251,8 +251,9 @@ public enum BarAlertEngine {
     // PRUNE — keep the fired set bounded so it can't grow without limit across
     // day/month/reset rollovers or account churn.
     let presentIds = Set(rows.map { $0.id })
-    let presentResetBuckets: [String: String] = Dictionary(
-      uniqueKeysWithValues: rows.map { ($0.id, $0.nextReset ?? "noreset") })
+    let presentResetBuckets: [String: Set<String>] = rows.reduce(into: [:]) { buckets, row in
+      buckets[row.id, default: []].insert(row.nextReset ?? "noreset")
+    }
     fired = fired.filter { key in
       let parts = key.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
       guard let kind = parts.first else { return false }
@@ -266,7 +267,7 @@ public enum BarAlertEngine {
         // parts: [kind, accountId, bucket, "L<level>"]; bucket must equal the
         // account's CURRENT nextReset and the account must still be present.
         guard parts.count >= 3, presentIds.contains(parts[1]) else { return false }
-        return presentResetBuckets[parts[1]] == parts[2]
+        return presentResetBuckets[parts[1]]?.contains(parts[2]) == true
       case BarAlertKind.reauthNeeded.rawValue, BarAlertKind.accountCooldownOrPaused.rawValue:
         // parts: [kind, accountId, "on"]; keep only for still-present accounts.
         return parts.count >= 2 && presentIds.contains(parts[1])


### PR DESCRIPTION
### Motivation
- A malformed or malicious `/api/bar/summary` payload containing duplicate provider/account rows could trigger `Dictionary(uniqueKeysWithValues:)` to fatal-error during alert pruning, crashing the menu-bar alert evaluation that runs on every refresh.

### Description
- Replace the fragile `Dictionary(uniqueKeysWithValues:)` construction with a `Dictionary<String, Set<String>>` built via `rows.reduce(into:)` so each row id maps to a set of observed `nextReset` buckets and duplicate ids are tolerated.
- Update the pruning check to use membership `presentResetBuckets[id]?.contains(bucket) == true` instead of equality against a single bucket value.
- Add a regression check in the `ccs-bar-check` harness that supplies duplicate rows with multiple reset buckets and asserts pruning keeps present buckets and drops absent buckets without crashing.

### Testing
- Compiled and ran a targeted harness with `swiftc` that links `BarSummary.swift`, `BarAnalytics.swift`, `BarFormatting.swift`, `BarQuotaGauge.swift`, and `BarAlertEngine.swift` plus the duplicate-row test, and the harness reported success.
- Attempting to run the full test target with `swift run ccs-bar-check` in this Linux container failed because `SwiftUI` is unavailable on non-macOS, so the platform-specific suite could not be executed here.
- `git diff --check` passed and pre-commit hooks flagged unrelated Prettier warnings in TypeScript files that are not part of these macOS bar changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ad0db70c8330b6faf9c131218b36)