### PR TITLE
fix(proxy): forward stream_options.include_usage to OpenAI-compatible upstreams

### DIFF
--- a/src/proxy/transformers/request-transformer.ts
+++ b/src/proxy/transformers/request-transformer.ts
@@ -101,6 +101,9 @@ interface OpenAIMessage {
 export interface ProxyOpenAIRequest {
   model?: string;
   stream: boolean;
+  stream_options?: {
+    include_usage: boolean;
+  };
   reasoning_effort?: string;
   reasoning?: {
     enabled: boolean;
@@ -728,6 +731,16 @@ export class ProxyRequestTransformer {
           ? source.model.trim()
           : undefined,
       stream: source.stream === true,
+      // Ask the upstream provider to emit a final SSE chunk with token usage.
+      // OpenAI-compatible endpoints (and most proxies that follow the spec,
+      // including LiteLLM) only include `usage` in the streamed response when
+      // `stream_options.include_usage` is set on the request. Without this
+      // flag the proxy's stream parser still writes Anthropic-shaped events
+      // with `usage: { input_tokens: 0, output_tokens: 0 }`, so Claude Code's
+      // status line and the session log show 0 tokens even though the call
+      // was billed. See:
+      // https://platform.openai.com/docs/api-reference/chat-streaming
+      ...(source.stream === true ? { stream_options: { include_usage: true } } : {}),
       messages: coalesceMessages(allMessages),
       max_tokens: asNumber(source.max_tokens),
       temperature: asNumber(source.temperature),

--- a/tests/unit/proxy/transformers/request-transformer.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer.test.ts
@@ -115,4 +115,36 @@ describe('ProxyRequestTransformer', () => {
     expect(result.stop).toEqual(['A']);
     expect(result.metadata).toBeUndefined();
   });
+
+  it('sets stream_options.include_usage for streaming requests so upstreams return token usage', () => {
+    const transformer = new ProxyRequestTransformer();
+    const result = transformer.transform({
+      stream: true,
+      messages: [{ role: 'user', content: 'ping' }],
+    });
+
+    expect(result.stream).toBe(true);
+    expect(result.stream_options).toEqual({ include_usage: true });
+  });
+
+  it('omits stream_options for non-streaming requests', () => {
+    const transformer = new ProxyRequestTransformer();
+    const result = transformer.transform({
+      stream: false,
+      messages: [{ role: 'user', content: 'ping' }],
+    });
+
+    expect(result.stream).toBe(false);
+    expect(result.stream_options).toBeUndefined();
+  });
+
+  it('omits stream_options when the upstream flag is absent', () => {
+    const transformer = new ProxyRequestTransformer();
+    const result = transformer.transform({
+      messages: [{ role: 'user', content: 'ping' }],
+    });
+
+    expect(result.stream).toBe(false);
+    expect(result.stream_options).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Claude Code's status line and the session log showed **0 tokens** for every streaming response routed through the OpenAI-compatible proxy, even though the upstream call was billed.

Root cause: the proxy's Anthropic→OpenAI request transformer did not set `stream_options: { include_usage: true }` on the upstream call. Without that flag, OpenAI-compatible providers (LiteLLM, OpenRouter, local llama.cpp, etc.) omit the final SSE chunk that carries `usage.prompt_tokens` / `usage.completion_tokens`.

The proxy's stream parser (`dist/proxy/transformers/sse-stream-transformer.js`) was already wired to forward that chunk into an Anthropic-shaped `message_delta` event with `usage.input_tokens` / `usage.output_tokens` — it just never received the data.

This PR makes the request transformer set `stream_options: { include_usage: true }` whenever the incoming Anthropic request is streamed. Non-streamed requests are untouched (they already get a complete `usage` block in the JSON response).

## Reproduction

```bash
# 1. Start proxy for any generic-chat-completion-api profile
ccs proxy start <profile>

# 2. Watch the streaming SSE response for the message_delta event
curl -N -X POST http://127.0.0.1:43532/v1/messages \
  -H 'Content-Type: application/json' \
  -H 'anthropic-version: 2023-06-01' \
  -H 'x-api-key: $TOKEN' \
  -H 'Authorization: Bearer $TOKEN' \
  -d '{"model":"<model>","max_tokens":16,"stream":true,"messages":[{"role":"user","content":"hi"}]}'

# 3. Inspect the final message_delta event
```

**Before** — `message_delta` carries zeroed usage:
```json
{"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"input_tokens":0,"output_tokens":0}}
```

**After** — `message_delta` carries the real numbers from the upstream's final chunk:
```json
{"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"input_tokens":174,"output_tokens":16}}
```

The same numbers then show up in Claude Code's status bar and in the `~/.claude/projects/.../<session>.jsonl` log.

## Changes

- `src/proxy/transformers/request-transformer.ts`
  - Add optional `stream_options?: { include_usage: boolean }` to the `ProxyOpenAIRequest` interface.
  - In `transform()`, set `stream_options: { include_usage: true }` whenever `source.stream === true`.
  - Inline comment cites the OpenAI streaming spec for future maintainers.
- `tests/unit/proxy/transformers/request-transformer.test.ts`
  - Three new tests:
    1. Streaming requests get `stream_options: { include_usage: true }`.
    2. Explicit non-streaming requests do not get `stream_options`.
    3. Absent `stream` flag (defaults to `false`) does not get `stream_options`.

## Verification

- `bun test tests/unit/proxy/transformers/request-transformer.test.ts` — 7/7 pass (4 existing + 3 new).
- `bun x tsc --noEmit` — clean.
- Live test against LiteLLM-backed `llm.dks.lanit.ru/v1/messages`: streaming response now carries `input_tokens:174, output_tokens:16` in the `message_delta` event; Claude Code's status line and session log reflect those numbers.

## Risk

Minimal. The flag is a documented, additive OpenAI option — providers that ignore unknown fields will behave exactly as before. The only behavioral change for those providers is that they will now ignore `stream_options` instead of returning a usage-less stream they were already returning.