### PR TITLE
fix(bar): update release target when publishing app

### DIFF
--- a/.github/workflows/bar-release.yml
+++ b/.github/workflows/bar-release.yml
@@ -73,6 +73,6 @@ jobs:
 
           Built automatically from main when macos-bar changes.
           NOTES
-          gh release edit ccs-bar-latest --title "CCS Bar v${VERSION}" --notes-file "$notes"
+          gh release edit ccs-bar-latest --target "$GITHUB_SHA" --title "CCS Bar v${VERSION}" --notes-file "$notes"
           rm -f "$notes"
           echo "[OK] Published CCS Bar v${VERSION} to ccs-bar-latest"


### PR DESCRIPTION
## Summary
- set the ccs-bar-latest release target to the publishing commit when Bar Release updates the floating asset
- keeps `gh release view ccs-bar-latest` provenance aligned with the app bundle that was just published

## Validation
- git diff --check
- manually updated current ccs-bar-latest target to PR #1593 merge commit and verified release metadata

Docs impact: none
Action: no update needed - release metadata workflow fix only.
