### PR TITLE
fix: restrict bar release workflow to main

### DIFF
--- a/.github/workflows/bar-release.yml
+++ b/.github/workflows/bar-release.yml
@@ -5,7 +5,7 @@ name: Bar Release
 #
 # Scoped deliberately so it NEVER burdens other PRs or CI:
 #   - Triggers ONLY on push to `main` that changes `macos-bar/**`, or a manual
-#     run. Regular PRs, dev pushes, and non-bar changes do not start it.
+#     run from `main`. Regular PRs, dev pushes, and non-bar changes do not start it.
 #   - Runs ONLY on the dedicated self-hosted macOS runner (label `ccs-bar` on
 #     kai-minim4). The Linux CI runners never match this job, and this job never
 #     competes for them.
@@ -32,10 +32,14 @@ concurrency:
 jobs:
   release:
     name: Build and publish CCS Bar
+    if: github.ref == 'refs/heads/main'
     runs-on: [self-hosted, macos, ccs-bar]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: main
+          persist-credentials: false
 
       - name: Read bar version
         id: ver

--- a/docs/ccs-bar.md
+++ b/docs/ccs-bar.md
@@ -126,10 +126,10 @@ The app ships as a single floating GitHub release asset, `CCS-Bar.app.zip` under
 
 The `Bar Release` workflow (`.github/workflows/bar-release.yml`) builds and publishes the asset automatically. It is scoped tightly so it never affects other PRs or CI:
 
-- It runs only on a push to `main` that touches `macos-bar/**`, or a manual run from the Actions tab (`workflow_dispatch`).
+- It runs only on a push to `main` that touches `macos-bar/**`, or a manual run from the Actions tab (`workflow_dispatch`) when the selected ref is `main`.
 - It runs only on the dedicated self-hosted macOS runner (label `ccs-bar`); the Linux CI runners never pick it up and it never competes for them.
 
-So bar changes reach users when they land on `main` (the stable cadence). To cut a release without a code change, or to re-publish, trigger the workflow manually.
+So bar changes reach users when they land on `main` (the stable cadence). To cut a release without a code change, or to re-publish, trigger the workflow manually with `main` selected as the workflow ref.
 
 ### Manual fallback
 


### PR DESCRIPTION
### Motivation
- The Bar release workflow allowed `workflow_dispatch` without ensuring the selected ref was `main`, which could let an attacker or compromised account publish branch-controlled builds to the floating `ccs-bar-latest` release asset consumed by the installer.

### Description
- Add a job-level guard so the `release` job runs only when `github.ref == 'refs/heads/main'` in `.github/workflows/bar-release.yml`.
- Force the checkout to `main` and disable persisted credentials by setting `with: ref: main` and `persist-credentials: false` for `actions/checkout@v4` to prevent building an attacker-controlled ref or reusing the workflow token.
- Update `docs/ccs-bar.md` to document that manual workflow dispatches must select `main` as the workflow ref.

### Testing
- Confirmed workflow changes with a local `python3` assertion that checked for `if: github.ref == 'refs/heads/main'`, `ref: main`, and `persist-credentials: false` (passed).
- Ran formatting and linting (`bun run format` and `bun run lint:fix`) which completed and reported only existing warnings unrelated to these changes.
- Attempted full validation (`bun run validate`) which ran typecheck and many unit/integration tests successfully, but the `test:fast` run stalled on `src/cliproxy/proxy/__tests__/tool-sanitization-proxy-integration.test.ts`, so end-to-end CI validation was not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382694124c83309cb750d56bde78f8)