### PR TITLE
fix: close bar launch case bypass

### DIFF
--- a/macos-bar/Sources/CCSBarApp/BarServerLauncher.swift
+++ b/macos-bar/Sources/CCSBarApp/BarServerLauncher.swift
@@ -105,12 +105,19 @@ struct BarServerLauncher: Sendable {
   }
 
   private func isUnderCcsDir(_ path: String) -> Bool {
-    let ccsPath = URL(fileURLWithPath: home)
-      .appendingPathComponent(".ccs")
-      .standardizedFileURL
-      .path
-    let targetPath = URL(fileURLWithPath: path).standardizedFileURL.path
+    let ccsPath = pathForComparison(
+      URL(fileURLWithPath: home)
+        .appendingPathComponent(".ccs")
+    )
+    let targetPath = pathForComparison(URL(fileURLWithPath: path))
     return targetPath == ccsPath || targetPath.hasPrefix(ccsPath + "/")
+  }
+
+  private func pathForComparison(_ url: URL) -> String {
+    url.standardizedFileURL
+      .resolvingSymlinksInPath()
+      .path
+      .lowercased()
   }
 
   private func isAbsolutePath(_ path: String) -> Bool {

--- a/src/web-server/routes/route-helpers.ts
+++ b/src/web-server/routes/route-helpers.ts
@@ -377,7 +377,9 @@ export function updateSettingsFile(
  */
 function normalizePathForComparison(filePath: string): string {
   const normalized = path.resolve(path.normalize(filePath));
-  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  return process.platform === 'win32' || process.platform === 'darwin'
+    ? normalized.toLowerCase()
+    : normalized;
 }
 
 function isPathWithin(basePath: string, targetPath: string): boolean {
@@ -437,7 +439,8 @@ export function validateFilePath(filePath: string): {
     // Block access to sensitive subdirectories
     const relativePath = path.relative(ccsDir, normalizedPath);
     const pathSegments = relativePath.split(path.sep).filter(Boolean);
-    if (pathSegments.includes('.git') || pathSegments.includes('node_modules')) {
+    const comparisonSegments = pathSegments.map((segment) => segment.toLowerCase());
+    if (comparisonSegments.includes('.git') || comparisonSegments.includes('node_modules')) {
       return { valid: false, readonly: false, error: 'Access to this path is not allowed' };
     }
 
@@ -445,9 +448,9 @@ export function validateFilePath(filePath: string): {
     // It must only be written by trusted bar install/launch code paths, not the
     // generic dashboard file API.
     if (
-      pathSegments.length === 2 &&
-      pathSegments[0] === 'bar' &&
-      pathSegments[1] === 'launch.json'
+      comparisonSegments.length === 2 &&
+      comparisonSegments[0] === 'bar' &&
+      comparisonSegments[1] === 'launch.json'
     ) {
       return { valid: false, readonly: false, error: 'Access to this path is not allowed' };
     }

--- a/tests/unit/web-server/route-helpers.test.ts
+++ b/tests/unit/web-server/route-helpers.test.ts
@@ -50,6 +50,14 @@ describe('validateFilePath', () => {
     expect(result.readonly).toBe(false);
   });
 
+  test('rejects case variants of the macOS bar launch descriptor', () => {
+    const filePath = path.join(tempDir, '.ccs', 'BAR', 'LAUNCH.JSON');
+    const result = validateFilePath(filePath);
+
+    expect(result.valid).toBe(false);
+    expect(result.readonly).toBe(false);
+  });
+
   test('still allows other writes inside the bar directory', () => {
     const filePath = path.join(tempDir, '.ccs', 'bar', 'serve.log');
     const result = validateFilePath(filePath);


### PR DESCRIPTION
### Motivation
- Prevent a case-insensitive filesystem bypass where dashboard file API writes using mixed-case path components could alias and overwrite the macOS bar launch descriptor `~/.ccs/bar/launch.json`.
- Stop the native macOS bar launcher from accepting entrypoint paths that are case variants of `~/.ccs` so attacker-writable files under the CCS tree cannot be executed.

### Description
- In `src/web-server/routes/route-helpers.ts` case-fold `normalizePathForComparison` on `darwin` as well as `win32`, and compare path segments using a lowercased `comparisonSegments` array so sensitive segments (e.g. `.git`, `node_modules`, and `bar/launch.json`) are matched case-insensitively.
- In `macos-bar/Sources/CCSBarApp/BarServerLauncher.swift` add `pathForComparison(_:)` which resolves symlinks, standardizes, and lowercases paths, and use it in `isUnderCcsDir(_:)` so containment checks are robust against case variants and symlink aliases.
- Add a regression test in `tests/unit/web-server/route-helpers.test.ts` that verifies case-variant writes like `~/.ccs/BAR/LAUNCH.JSON` are rejected by `validateFilePath`.

### Testing
- Ran `bun test tests/unit/web-server/route-helpers.test.ts` and the new/updated tests passed (8 passed, 0 failed).
- Ran `bun run typecheck` (`tsc --noEmit`) and it completed without errors.
- Ran `bun run format:check` / `prettier --check` which surfaced pre-existing style warnings in unrelated files (format check reported warnings that pre-existed the change).
- Attempted `swift build` for the macOS bundle but it cannot complete in the Linux CI environment due to the missing `SwiftUI` module, so native build verification was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3826fcd104833082f96f61aa734451)