### PR TITLE
fix(ci): include compose parity in CI Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
 
   # Single always-reporting status that branch protection requires.
   #
-  # The validate/build/test jobs are gated to trusted author associations so
+  # The validate/build/test/compose-parity jobs are gated to trusted author associations so
   # untrusted fork code never executes on the self-hosted runners. A job skipped
   # by a job-level `if` reports no status, so requiring those job names directly
   # leaves fork PRs stuck on "Expected - waiting for status to be reported"
@@ -176,7 +176,7 @@ jobs:
   # third-party code and is safe on the self-hosted runner.
   ci-gate:
     if: always()
-    needs: [validate, build, test]
+    needs: [validate, build, test, compose-parity]
     runs-on: [self-hosted, linux, x64]
     name: CI Gate
     steps:
@@ -185,9 +185,10 @@ jobs:
           VALIDATE: ${{ needs.validate.result }}
           BUILD: ${{ needs.build.result }}
           TEST: ${{ needs.test.result }}
+          COMPOSE_PARITY: ${{ needs.compose-parity.result }}
         run: |
-          echo "validate=$VALIDATE build=$BUILD test=$TEST"
-          for result in "$VALIDATE" "$BUILD" "$TEST"; do
+          echo "validate=$VALIDATE build=$BUILD test=$TEST compose-parity=$COMPOSE_PARITY"
+          for result in "$VALIDATE" "$BUILD" "$TEST" "$COMPOSE_PARITY"; do
             if [ "$result" = "failure" ] || [ "$result" = "cancelled" ]; then
               echo "[X] A required CI job did not pass (result: $result)"
               exit 1


### PR DESCRIPTION
### Motivation
- The aggregate CI Gate intended to represent all gated jobs omitted `compose-parity`, allowing compose parity failures to be hidden when branch protection requires only the gate.

### Description
- Include `compose-parity` in the `ci-gate` `needs` list in `.github/workflows/ci.yml` so the gate waits for the compose-parity job.
- Add `COMPOSE_PARITY: ${{ needs.compose-parity.result }}` to the gate environment and include it in the gate's output logging.
- Extend the gate's validation loop to check `COMPOSE_PARITY` alongside `VALIDATE`, `BUILD`, and `TEST` so failure or cancellation of compose-parity fails the gate.
- Update the gate's explanatory comment to explicitly mention `compose-parity` as a gated job.

### Testing
- Ran a targeted Python assertion that confirms the workflow now contains `needs: [validate, build, test, compose-parity]` and that `COMPOSE_PARITY` is wired into the gate script, which succeeded.
- Ran `bun run validate:ci-parity` to exercise CI-parity checks; the run failed in the repository's formatting check (`prettier --check`) due to existing style warnings in `src/cliproxy/quota/quota-manager.ts` and `src/management/checks/image-analysis-check.ts`, and these unrelated style issues were not changed by this CI-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dd3821a0833090dba9287bd67555)