### PR TITLE
fix(cursor): align daemon Anthropic auth token

### DIFF
--- a/src/cliproxy/quota/quota-manager.ts
+++ b/src/cliproxy/quota/quota-manager.ts
@@ -483,9 +483,8 @@ export async function reconcileExhaustedRotationAccounts(
     return [];
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();
@@ -593,9 +592,8 @@ export async function preflightCheck(provider: CLIProxyProvider): Promise<Prefli
     return { proceed: true, accountId: defaultAccount?.id || '' };
   }
 
-  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } = await import(
-    '../accounts/account-safety'
-  );
+  const { pauseAccountForQuotaCooldown, restoreExpiredQuotaPauses } =
+    await import('../accounts/account-safety');
   restoreExpiredQuotaPauses();
 
   const config = loadOrCreateUnifiedConfig();

--- a/src/cursor/cursor-daemon-entry.ts
+++ b/src/cursor/cursor-daemon-entry.ts
@@ -327,7 +327,11 @@ export function startCursorDaemonServer(options: DaemonRuntimeOptions): http.Ser
       }
 
       if (isAnthropicRoute) {
-        const expectedToken = (process.env.ANTHROPIC_AUTH_TOKEN || 'cursor-managed').trim();
+        const expectedToken = (
+          process.env.ANTHROPIC_AUTH_TOKEN ||
+          process.env.CCS_CURSOR_DAEMON_TOKEN ||
+          'cursor-managed'
+        ).trim();
         const requestToken = getAnthropicRequestToken(req.headers);
         if (!expectedToken || requestToken !== expectedToken) {
           await pipeWebResponseToNode(

--- a/src/cursor/cursor-daemon.ts
+++ b/src/cursor/cursor-daemon.ts
@@ -53,6 +53,14 @@ async function resolveDaemonEntrypoint(): Promise<string | null> {
   return null;
 }
 
+export function buildDaemonProcessEnv(daemonToken: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CCS_CURSOR_DAEMON_TOKEN: daemonToken,
+    ANTHROPIC_AUTH_TOKEN: daemonToken,
+  };
+}
+
 /**
  * Check if cursor daemon is running on the specified port.
  * Uses 127.0.0.1 instead of localhost for more reliable local connections.
@@ -224,10 +232,7 @@ export async function startDaemon(
       proc = spawn(process.execPath, args, {
         stdio: 'ignore',
         detached: true,
-        env: {
-          ...process.env,
-          CCS_CURSOR_DAEMON_TOKEN: effectiveConfig.daemon_token || '',
-        },
+        env: buildDaemonProcessEnv(effectiveConfig.daemon_token || ''),
       });
 
       // Unref so parent can exit

--- a/src/management/checks/image-analysis-check.ts
+++ b/src/management/checks/image-analysis-check.ts
@@ -112,9 +112,8 @@ export async function runImageAnalysisCheck(results: HealthCheck): Promise<void>
  * Fix image analysis configuration issues
  */
 export async function fixImageAnalysisConfig(): Promise<boolean> {
-  const { updateConfig, loadOrCreateUnifiedConfig } = await import(
-    '../../config/config-loader-facade'
-  );
+  const { updateConfig, loadOrCreateUnifiedConfig } =
+    await import('../../config/config-loader-facade');
 
   const config = loadOrCreateUnifiedConfig();
   let fixed = false;

--- a/tests/unit/cursor/cursor-daemon.test.ts
+++ b/tests/unit/cursor/cursor-daemon.test.ts
@@ -16,6 +16,7 @@ import {
   getDaemonStatus,
   stopDaemon,
   startDaemon,
+  buildDaemonProcessEnv,
 } from '../../../src/cursor/cursor-daemon';
 import { getCcsDir } from '../../../src/utils/config-manager';
 import { handleCursorCommand } from '../../../src/commands/cursor-command';
@@ -145,6 +146,26 @@ describe('removePidFile', () => {
 
   it('does not throw when PID file does not exist', () => {
     expect(() => removePidFile()).not.toThrow();
+  });
+});
+
+describe('buildDaemonProcessEnv', () => {
+  it('uses the daemon token for both daemon and Anthropic caller auth', () => {
+    const originalAnthropicToken = process.env.ANTHROPIC_AUTH_TOKEN;
+    process.env.ANTHROPIC_AUTH_TOKEN = 'inherited-stale-token';
+
+    try {
+      const env = buildDaemonProcessEnv('generated-daemon-token');
+
+      expect(env.CCS_CURSOR_DAEMON_TOKEN).toBe('generated-daemon-token');
+      expect(env.ANTHROPIC_AUTH_TOKEN).toBe('generated-daemon-token');
+    } finally {
+      if (originalAnthropicToken !== undefined) {
+        process.env.ANTHROPIC_AUTH_TOKEN = originalAnthropicToken;
+      } else {
+        delete process.env.ANTHROPIC_AUTH_TOKEN;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
### Motivation
- The Anthropic route validated x-api-key/Bearer against `process.env.ANTHROPIC_AUTH_TOKEN` (or the static `cursor-managed`) while the launched client and daemon use a generated daemon token, causing legitimate Cursor Anthropic-compatible requests to be rejected.

### Description
- Add `buildDaemonProcessEnv(daemonToken)` in `src/cursor/cursor-daemon.ts` to construct the child-process environment with both `CCS_CURSOR_DAEMON_TOKEN` and `ANTHROPIC_AUTH_TOKEN` set to the generated daemon token.
- Use `buildDaemonProcessEnv(...)` when spawning the daemon in `startDaemon` so the daemon and clients share the same Anthropic-compatible token.
- Update the Anthropic route check in `src/cursor/cursor-daemon-entry.ts` to fall back to `process.env.CCS_CURSOR_DAEMON_TOKEN` before the legacy `'cursor-managed'` default so generated daemon tokens are accepted.
- Add a unit test for the new env builder in `tests/unit/cursor/cursor-daemon.test.ts` and apply Prettier formatting fixes to a few touched files.

### Testing
- Ran `bun test tests/unit/cursor/cursor-daemon.test.ts` and all unit assertions in that file passed.
- Ran `bun test tests/integration/cursor-daemon-lifecycle.test.ts` and the Cursor daemon lifecycle integration tests passed (5 tests, all green).
- Ran `bun run format:check` (Prettier) and formatting matched project style after adjustments.
- Ran `bun run validate` (typecheck/lint/format + `test:fast`); typecheck/lint/format succeeded but `test:fast` failed on unrelated/environment-sensitive existing tests (Codex/ACCOUNT/Browser tests); `env -u CODEX_HOME bun run validate` removed one unrelated failure but two unrelated tests still fail, indicating the remaining failures are pre-existing and environment-sensitive rather than caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28dd25fa488330846e27ba07a4e97a)