### PR TITLE
fix(auth): honor legacy-only profiles set as unified default

### DIFF
--- a/src/auth/profile-detector.ts
+++ b/src/auth/profile-detector.ts
@@ -427,6 +427,14 @@ class ProfileDetector {
     // Check if account-based default exists (legacy)
     const profiles = this.readProfiles();
 
+    if (unifiedConfig?.default && profiles.profiles[unifiedConfig.default]) {
+      return {
+        type: 'account',
+        name: unifiedConfig.default,
+        profile: profiles.profiles[unifiedConfig.default],
+      };
+    }
+
     if (profiles.default && profiles.profiles[profiles.default]) {
       return {
         type: 'account',

--- a/tests/unit/auth/profile-detector.test.ts
+++ b/tests/unit/auth/profile-detector.test.ts
@@ -190,6 +190,51 @@ describe('ProfileDetector', () => {
       }
     });
 
+    it('should resolve a unified default that points to a legacy-only account profile', () => {
+      const originalCcsHome = process.env.CCS_HOME;
+      process.env.CCS_HOME = tempDir;
+      const ccsDir = path.join(tempDir, '.ccs');
+      fs.mkdirSync(ccsDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(ccsDir, 'profiles.json'),
+        JSON.stringify({
+          default: 'oldDefault',
+          profiles: {
+            oldDefault: { created: '2025-01-01', last_used: '2025-01-02' },
+            legacyOnly: { created: '2025-02-01', last_used: '2025-02-02' },
+          },
+        })
+      );
+
+      const mockUnifiedConfig = {
+        version: 2,
+        default: 'legacyOnly',
+        profiles: {},
+        accounts: {},
+      };
+
+      const isUnifiedModeSpy = spyOn(unifiedConfigLoader, 'isUnifiedMode').mockReturnValue(true);
+      const loadUnifiedConfigSpy = spyOn(unifiedConfigLoader, 'loadUnifiedConfig').mockReturnValue(
+        mockUnifiedConfig as any
+      );
+
+      try {
+        const localDetector = new ProfileDetector();
+        const result = localDetector.resolveDefaultProfileResult();
+        expect(result.type).toBe('account');
+        expect(result.name).toBe('legacyOnly');
+        expect(result.profile).toEqual({ created: '2025-02-01', last_used: '2025-02-02' });
+      } finally {
+        isUnifiedModeSpy.mockRestore();
+        loadUnifiedConfigSpy.mockRestore();
+        if (originalCcsHome !== undefined) {
+          process.env.CCS_HOME = originalCcsHome;
+        } else {
+          delete process.env.CCS_HOME;
+        }
+      }
+    });
+
     it('should return null for unknown profile (throws error)', () => {
       const isUnifiedModeSpy = spyOn(unifiedConfigLoader, 'isUnifiedMode').mockReturnValue(false);
       // Mock readConfig/readProfiles to return empty


### PR DESCRIPTION
### Motivation
- Unified-mode `setDefaultUnified()` was allowed to persist a legacy-only profile name into `config.default`, but runtime default resolution ignored legacy account entries named by `config.default`, causing implicit profile selection to still use the old legacy default.

### Description
- Adjust `ProfileDetector.resolveDefaultProfile()` to check `unifiedConfig.default` against legacy `profiles.json` entries and return an `account` result when a match is found. 
- Add a unit test `should resolve a unified default that points to a legacy-only account profile` in `tests/unit/auth/profile-detector.test.ts` that reproduces the regression and verifies the fix. 
- The change is minimal and preserves existing priority order: unified-config explicit profiles still win, and the legacy-account lookup is only consulted when `config.default` names a legacy account.

### Testing
- Ran the focused unit tests with `bun test tests/unit/auth/profile-detector.test.ts`, and the file passed all tests (17 pass, 0 fail). 
- Ran `tsc --noEmit`, `prettier --write`, and `eslint` for the modified files and typecheck, which succeeded for the touched code; `bun run validate` failed due to unrelated formatting drift in other files (15 files) and not because of these changes. 
- Ran broader test suite `bun run test:fast` which encountered an unrelated existing failure in `tests/unit/commands/bar-command.test.ts` and was terminated; this is unrelated to the default-resolution fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43ef5b57008330842b7c4f5ebd3835)