### PR TITLE
fix: fail closed on WebSearch launch provisioning

### DIFF
--- a/src/cliproxy/executor/__tests__/executor-option-value.test.ts
+++ b/src/cliproxy/executor/__tests__/executor-option-value.test.ts
@@ -141,7 +141,7 @@ describe('execClaudeWithCLIProxy browser flag validation', () => {
     }
   });
 
-  it('degrades WebSearch provisioning failures for CLIProxy launches', async () => {
+  it('fails closed on WebSearch provisioning failures for CLIProxy launches', async () => {
     makeWebSearchProvisioningFail();
 
     const markerPath = path.join(tmpHome, 'fake-claude-launched');
@@ -176,26 +176,30 @@ describe('execClaudeWithCLIProxy browser flag validation', () => {
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
-      await execClaudeWithCLIProxy(
-        fakeClaudePath,
-        'gemini',
-        [
-          '--proxy-host',
-          '127.0.0.1',
-          '--proxy-port',
-          String(address.port),
-          '--proxy-auth-token',
-          'SECRET_TOKEN_FOR_VALIDATION',
-          '--remote-only',
-          '--print',
-          'hello',
-        ],
-        {}
+      await expect(
+        execClaudeWithCLIProxy(
+          fakeClaudePath,
+          'gemini',
+          [
+            '--proxy-host',
+            '127.0.0.1',
+            '--proxy-port',
+            String(address.port),
+            '--proxy-auth-token',
+            'SECRET_TOKEN_FOR_VALIDATION',
+            '--remote-only',
+            '--print',
+            'hello',
+          ],
+          {}
+        )
+      ).rejects.toThrow(
+        'WebSearch is enabled, but CCS could not prepare the local WebSearch tool.'
       );
 
-      expect(await waitForFile(markerPath)).toBe(true);
+      expect(await waitForFile(markerPath)).toBe(false);
       expect(requestCount).toBeGreaterThan(0);
-      expect(exitSpy).toHaveBeenCalledWith(0);
+      expect(exitSpy).not.toHaveBeenCalledWith(0);
     } finally {
       exitSpy.mockRestore();
       logSpy.mockRestore();

--- a/src/utils/websearch/mcp-installer.ts
+++ b/src/utils/websearch/mcp-installer.ts
@@ -440,28 +440,14 @@ export function ensureWebSearchMcpOrThrow(): void {
 }
 
 /**
- * Prepare WebSearch for a user launch without blocking Claude startup.
+ * Prepare WebSearch for a user launch.
  *
- * Returns true when the normal WebSearch status line is still accurate. A
- * failed MCP prepare already prints a degraded-path warning, so callers should
- * skip the ready/status line when this returns false.
+ * WebSearch-enabled launches must fail closed when the managed local MCP
+ * runtime cannot be prepared. Otherwise CCS would still suppress Claude's
+ * native WebSearch and inject fallback steering while the constrained MCP
+ * search path is unavailable.
  */
 export function ensureWebSearchMcpForLaunch(): boolean {
-  const wsConfig = getWebSearchConfig();
-  if (!wsConfig.enabled) {
-    return true;
-  }
-
-  const ready = ensureWebSearchMcp();
-  if (!ready) {
-    process.stderr.write(
-      String(
-        warn(
-          'WebSearch is enabled, but CCS could not prepare the local WebSearch tool. This session will continue without local WebSearch.'
-        )
-      ) + '\n'
-    );
-  }
-
-  return ready;
+  ensureWebSearchMcpOrThrow();
+  return true;
 }

--- a/tests/unit/targets/settings-profile-websearch-launch.test.ts
+++ b/tests/unit/targets/settings-profile-websearch-launch.test.ts
@@ -62,6 +62,11 @@ describe('settings profile WebSearch launch', () => {
       JSON.stringify({ profiles: { glm: settingsPath } }, null, 2) + '\n'
     );
     fs.writeFileSync(
+      path.join(ccsDir, 'config.yaml'),
+      ['version: 12', 'websearch:', '  enabled: true', ''].join('\n'),
+      'utf8'
+    );
+    fs.writeFileSync(
       settingsPath,
       JSON.stringify(
         {
@@ -93,6 +98,7 @@ exit 0
       CCS_HOME: tmpHome,
       CCS_CLAUDE_PATH: fakeClaudePath,
       CCS_DEBUG: '1',
+      CCS_SKIP_PREFLIGHT: '1',
     };
   });
 
@@ -104,40 +110,30 @@ exit 0
     fs.rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it('continues without local WebSearch when the tool runtime cannot be prepared', () => {
+  it('fails closed when the local WebSearch tool runtime cannot be prepared', () => {
     if (process.platform === 'win32') return;
 
     fs.writeFileSync(path.join(ccsDir, 'hooks'), 'not-a-directory', 'utf8');
 
     const result = runCcs(['glm', 'smoke'], baseEnv);
 
-    expect(result.status).toBe(0);
+    expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('could not prepare the local WebSearch tool');
-    expect(result.stderr).toContain('This session will continue without local WebSearch');
-    expect(fs.existsSync(claudeArgsLogPath)).toBe(true);
-    const launchedArgs = fs.readFileSync(claudeArgsLogPath, 'utf8');
-    expect(launchedArgs).toContain('--disallowedTools');
-    expect(launchedArgs).toContain('WebSearch');
-    expect(launchedArgs).toContain('--append-system-prompt');
-    expect(launchedArgs).toContain(STEERING_PROMPT_SNIPPET);
+    expect(result.stderr).not.toContain('This session will continue without local WebSearch');
+    expect(fs.existsSync(claudeArgsLogPath)).toBe(false);
   });
 
-  it('continues delegated headless launch when the local WebSearch tool runtime cannot be prepared', () => {
+  it('fails closed for delegated headless launch when the local WebSearch tool runtime cannot be prepared', () => {
     if (process.platform === 'win32') return;
 
     fs.writeFileSync(path.join(ccsDir, 'hooks'), 'not-a-directory', 'utf8');
 
     const result = runCcs(['glm', '-p', 'smoke'], baseEnv);
 
-    expect(result.status).toBe(0);
+    expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('could not prepare the local WebSearch tool');
-    expect(result.stderr).toContain('This session will continue without local WebSearch');
-    expect(fs.existsSync(claudeArgsLogPath)).toBe(true);
-    const launchedArgs = fs.readFileSync(claudeArgsLogPath, 'utf8');
-    expect(launchedArgs).toContain('--disallowedTools');
-    expect(launchedArgs).toContain('WebSearch');
-    expect(launchedArgs).toContain('--append-system-prompt');
-    expect(launchedArgs).toContain(STEERING_PROMPT_SNIPPET);
+    expect(result.stderr).not.toContain('This session will continue without local WebSearch');
+    expect(fs.existsSync(claudeArgsLogPath)).toBe(false);
   });
 
   it('keeps launch non-fatal when WebSearch is disabled', () => {
@@ -145,7 +141,7 @@ exit 0
 
     fs.writeFileSync(
       path.join(ccsDir, 'config.yaml'),
-      'version: 12\nwebsearch:\n  enabled: false\n',
+      ['version: 12', 'websearch:', '  enabled: false', ''].join('\n'),
       'utf8'
     );
     fs.writeFileSync(path.join(ccsDir, 'hooks'), 'not-a-directory', 'utf8');
@@ -165,6 +161,11 @@ exit 0
   it('writes a source-side launch trace for settings profiles when tracing is enabled', () => {
     if (process.platform === 'win32') return;
 
+    fs.writeFileSync(
+      path.join(ccsDir, 'config.yaml'),
+      ['version: 12', 'websearch:', '  enabled: false', ''].join('\n'),
+      'utf8'
+    );
     const tracePath = path.join(ccsDir, 'logs', 'websearch-trace.jsonl');
     const result = runCcs(['glm', 'smoke'], {
       ...baseEnv,


### PR DESCRIPTION
### Motivation

- Prevent degraded "fail-open" launches that suppress native WebSearch and inject a steering prompt allowing Bash/network fallback when the managed local WebSearch MCP runtime cannot be prepared, which increases risk of local disclosure or command execution.

### Description

- Make `ensureWebSearchMcpForLaunch()` fail closed by delegating to the strict helper `ensureWebSearchMcpOrThrow()` so enabled WebSearch launches abort when MCP provisioning fails (changed in `src/utils/websearch/mcp-installer.ts`).
- Update unit tests to reflect the strict behavior: adjust settings-profile tests to expect launch failure when provisioning fails and preserve disabled-WebSearch behavior (`tests/unit/targets/settings-profile-websearch-launch.test.ts`).
- Update CLIProxy test assertions to expect rejection / no Claude launch on provisioning failure (`src/cliproxy/executor/__tests__/executor-option-value.test.ts`).
- Minor test scaffolding changes: test config writes and environment (`config.yaml` writes and `CCS_SKIP_PREFLIGHT` in test env) to ensure deterministic test runs.

### Testing

- Ran `bun test tests/unit/targets/settings-profile-websearch-launch.test.ts` and the suite passed after updates. (4 tests, all pass)
- Ran `bun test ./src/cliproxy/executor/__tests__/executor-option-value.test.ts` and relevant cases passed.
- Ran `bun run lint:fix` which completed; existing `max-lines` warnings in unrelated files remain and were not changed by this PR.
- Ran `bun run validate` which failed due to pre-existing Prettier/formatting issues in unrelated files; the change itself is type-checked and unit tests covering the modified behavior passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43eff2ac4c8330952e5bc7505ecac3)