### PR TITLE
fix(websearch): remove `--dangerously-skip-permissions` from Antigravity (agy) fallback

### DIFF
--- a/lib/hooks/websearch-transformer.cjs
+++ b/lib/hooks/websearch-transformer.cjs
@@ -901,17 +901,9 @@ function tryAgySearch(query, timeoutSec = DEFAULT_TIMEOUT_SEC) {
     const timeoutMs = timeoutSec * 1000;
     const model = process.env.CCS_WEBSEARCH_AGY_MODEL || PROVIDER_CONFIG.agy.model;
     const prompt = buildPrompt('agy', query);
-    // gemini flag mapping: `--yolo` -> `--dangerously-skip-permissions`, `-m` -> `--model`,
-    // shell `timeout N` -> native `--print-timeout Ns`. The prompt is passed to `-p` (print mode).
-    const args = [
-      '--model',
-      model,
-      '--dangerously-skip-permissions',
-      '--print-timeout',
-      `${timeoutSec}s`,
-      '-p',
-      prompt,
-    ];
+    // Use print mode without disabling Antigravity permission checks. WebSearch queries can
+    // contain untrusted prompt text, so permission prompts must remain enforced.
+    const args = ['--model', model, '--print-timeout', `${timeoutSec}s`, '-p', prompt];
 
     debug(`Executing Antigravity (agy) fallback with model ${model}`);
     return runAgyCommand(args, timeoutMs);

--- a/tests/unit/hooks/websearch-transformer.test.ts
+++ b/tests/unit/hooks/websearch-transformer.test.ts
@@ -133,6 +133,16 @@ describe('websearch-transformer legacy CLI safety', () => {
     expect(source).not.toContain('shell: isWindows');
     expect(source.match(/shell: false/g) || []).toHaveLength(4);
   });
+
+  it('does not disable Antigravity permission checks for query-derived prompts', () => {
+    const source = readFileSync(hookPath, 'utf8');
+
+    expect(source).not.toContain("'--dangerously-skip-permissions'");
+    expect(source).not.toContain('"--dangerously-skip-permissions"');
+    expect(source).toContain(
+      "const args = ['--model', model, '--print-timeout', `${timeoutSec}s`, '-p', prompt]"
+    );
+  });
 });
 
 describe('websearch-transformer hook helpers', () => {


### PR DESCRIPTION
### Motivation
- The Antigravity (`agy`) WebSearch fallback embedded untrusted query text into an agent prompt while invoking `agy` with `--dangerously-skip-permissions`, which defeats the agent's permission prompts and allows prompt-injection to escalate local privileges.

### Description
- Removed the `--dangerously-skip-permissions` flag from the Antigravity CLI invocation so `agy` is still used in print mode but retains its permission checks (`lib/hooks/websearch-transformer.cjs`).
- Kept `agy` invocation as `-p` (print mode) and preserved the model and timeout arguments to maintain existing WebSearch functionality.
- Added a regression unit test that asserts the hook source no longer contains the dangerous permission-bypass flag and that the expected safe `args` array is present (`tests/unit/hooks/websearch-transformer.test.ts`).

### Testing
- Ran `bun test tests/unit/hooks/websearch-transformer.test.ts` and the modified unit suite passed (23 tests, 0 failures).
- Ran `bun run validate`, which exercises `tsc`, `eslint`, `prettier --check`, and the fast test bucket; `tsc`/unit tests passed but `prettier --check src/` reported unrelated formatting warnings in other `src/` files causing `validate` to fail.
- Verified the specific WebSearch transformer tests demonstrating the permission flag removal passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a448c02f70c83308d558fd96c0e5825)