### PR TITLE
fix: reject case-variant symlinked file paths

### DIFF
--- a/src/web-server/routes/route-helpers.ts
+++ b/src/web-server/routes/route-helpers.ts
@@ -399,8 +399,26 @@ function isSymlinkPath(filePath: string): boolean {
   }
 }
 
+function getRequestedBasePath(basePath: string, targetPath: string): string {
+  const comparisonBasePath = normalizePathForComparison(basePath);
+  const comparisonTargetPath = normalizePathForComparison(targetPath);
+  const comparisonBaseWithSeparator = comparisonBasePath.endsWith(path.sep)
+    ? comparisonBasePath
+    : `${comparisonBasePath}${path.sep}`;
+
+  if (
+    comparisonTargetPath === comparisonBasePath ||
+    comparisonTargetPath.startsWith(comparisonBaseWithSeparator)
+  ) {
+    return targetPath.slice(0, basePath.length);
+  }
+
+  return basePath;
+}
+
 function hasSymlinkSegment(
   basePath: string,
+  targetPath: string,
   comparisonBasePath: string,
   comparisonTargetPath: string
 ): boolean {
@@ -409,8 +427,22 @@ function hasSymlinkSegment(
     return false;
   }
 
-  let currentPath = basePath;
-  const segments = relative.split(path.sep).filter(Boolean);
+  const requestedBasePath = getRequestedBasePath(basePath, targetPath);
+  if (requestedBasePath !== basePath && isSymlinkPath(requestedBasePath)) {
+    return true;
+  }
+
+  const requestedRelative = path.relative(requestedBasePath, targetPath);
+  if (
+    requestedRelative === '' ||
+    requestedRelative.startsWith('..') ||
+    path.isAbsolute(requestedRelative)
+  ) {
+    return false;
+  }
+
+  let currentPath = requestedBasePath;
+  const segments = requestedRelative.split(path.sep).filter(Boolean);
   for (const segment of segments) {
     currentPath = path.join(currentPath, segment);
     if (isSymlinkPath(currentPath)) {
@@ -436,7 +468,7 @@ export function validateFilePath(filePath: string): {
 
   // Check if path is within ~/.ccs/
   if (isPathWithin(ccsDir, normalizedPath)) {
-    if (hasSymlinkSegment(resolvedCcsDir, ccsDir, normalizedPath)) {
+    if (hasSymlinkSegment(resolvedCcsDir, resolvedPath, ccsDir, normalizedPath)) {
       return { valid: false, readonly: false, error: 'Access to this path is not allowed' };
     }
 

--- a/src/web-server/routes/route-helpers.ts
+++ b/src/web-server/routes/route-helpers.ts
@@ -399,8 +399,12 @@ function isSymlinkPath(filePath: string): boolean {
   }
 }
 
-function hasSymlinkSegment(basePath: string, targetPath: string): boolean {
-  const relative = path.relative(basePath, targetPath);
+function hasSymlinkSegment(
+  basePath: string,
+  comparisonBasePath: string,
+  comparisonTargetPath: string
+): boolean {
+  const relative = path.relative(comparisonBasePath, comparisonTargetPath);
   if (relative === '' || relative.startsWith('..') || path.isAbsolute(relative)) {
     return false;
   }
@@ -432,7 +436,7 @@ export function validateFilePath(filePath: string): {
 
   // Check if path is within ~/.ccs/
   if (isPathWithin(ccsDir, normalizedPath)) {
-    if (hasSymlinkSegment(resolvedCcsDir, resolvedPath)) {
+    if (hasSymlinkSegment(resolvedCcsDir, ccsDir, normalizedPath)) {
       return { valid: false, readonly: false, error: 'Access to this path is not allowed' };
     }
 

--- a/tests/unit/web-server/route-helpers.test.ts
+++ b/tests/unit/web-server/route-helpers.test.ts
@@ -99,6 +99,39 @@ describe('validateFilePath', () => {
     expect(result.readonly).toBe(false);
   });
 
+  test('rejects macOS case-variant paths through symlinked segments', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    try {
+      const ccsDir = path.join(tempDir, '.ccs');
+      const caseVariantCcsDir = path.join(tempDir, '.CCS');
+      const sharedDir = path.join(ccsDir, 'shared');
+      const outsideCommandsDir = path.join(tempDir, '.claude', 'commands');
+      const linkedCommandsDir = path.join(sharedDir, 'commands');
+
+      fs.mkdirSync(sharedDir, { recursive: true });
+      fs.mkdirSync(outsideCommandsDir, { recursive: true });
+      fs.symlinkSync(ccsDir, caseVariantCcsDir, 'dir');
+      fs.symlinkSync(outsideCommandsDir, linkedCommandsDir, 'dir');
+
+      const result = validateFilePath(
+        path.join(caseVariantCcsDir, 'shared', 'commands', 'pwned.md')
+      );
+
+      expect(result.valid).toBe(false);
+      expect(result.readonly).toBe(false);
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+    }
+  });
+
   test('rejects symlinked Claude settings path', () => {
     if (process.platform === 'win32') {
       return;

--- a/tests/unit/web-server/route-helpers.test.ts
+++ b/tests/unit/web-server/route-helpers.test.ts
@@ -116,12 +116,55 @@ describe('validateFilePath', () => {
 
       fs.mkdirSync(sharedDir, { recursive: true });
       fs.mkdirSync(outsideCommandsDir, { recursive: true });
-      fs.symlinkSync(ccsDir, caseVariantCcsDir, 'dir');
+      try {
+        fs.symlinkSync(ccsDir, caseVariantCcsDir, 'dir');
+      } catch (error) {
+        const nodeError = error as NodeJS.ErrnoException;
+        if (nodeError.code !== 'EEXIST') {
+          throw error;
+        }
+      }
       fs.symlinkSync(outsideCommandsDir, linkedCommandsDir, 'dir');
 
       const result = validateFilePath(
         path.join(caseVariantCcsDir, 'shared', 'commands', 'pwned.md')
       );
+
+      expect(result.valid).toBe(false);
+      expect(result.readonly).toBe(false);
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+    }
+  });
+
+  test('rejects macOS case-variant CCS directory symlinks', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+    try {
+      const ccsDir = path.join(tempDir, '.ccs');
+      const caseVariantCcsDir = path.join(tempDir, '.CCS');
+      const outsideDir = path.join(tempDir, 'outside');
+
+      fs.mkdirSync(ccsDir, { recursive: true });
+      fs.mkdirSync(outsideDir, { recursive: true });
+      try {
+        fs.symlinkSync(outsideDir, caseVariantCcsDir, 'dir');
+      } catch (error) {
+        const nodeError = error as NodeJS.ErrnoException;
+        if (nodeError.code === 'EEXIST') {
+          return;
+        }
+        throw error;
+      }
+
+      const result = validateFilePath(path.join(caseVariantCcsDir, 'pwned.md'));
 
       expect(result.valid).toBe(false);
       expect(result.readonly).toBe(false);


### PR DESCRIPTION
### Motivation
- Prevent a macOS case-insensitive path/case-folding bypass where a differently-cased `~/.CCS/...` path could pass containment checks but still evade symlink-segment detection and allow writes through symlinked parent directories.
- Restore consistent containment + symlink checks so the generic file API cannot write outside the intended `~/.ccs` tree via case-variant paths.

### Description
- Change `hasSymlinkSegment` to accept explicit comparison paths and use the same normalized/case-folded comparison values as containment checks so the symlink walk is computed against the same collation (`src/web-server/routes/route-helpers.ts`).
- Call `hasSymlinkSegment` with the normalized `ccsDir` and `normalizedPath` (while walking the real `resolvedCcsDir` segments) to ensure case-variant inputs on macOS are correctly detected.
- Add a regression unit test `rejects macOS case-variant paths through symlinked segments` to `tests/unit/web-server/route-helpers.test.ts` which simulates `process.platform='darwin'` and verifies a `.CCS/shared/commands/...` path that traverses a symlink is rejected.

### Testing
- Ran `bun test tests/unit/web-server/route-helpers.test.ts`, which passed (9 tests, 0 failures). 
- Ran `bun run lint` and `bun run typecheck`, both completed without errors (only unrelated file-length warnings). 
- Ran formatting on the touched files with `prettier --write` successfully, but `bun run validate` fails due to existing Prettier formatting issues in unrelated files outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44a0f8700c83308e661e621bdfc3b9)