### PR TITLE
feat(models): add claude-sonnet-5 to model catalogs

### DIFF
--- a/src/cliproxy/model-catalog.ts
+++ b/src/cliproxy/model-catalog.ts
@@ -431,6 +431,22 @@ export const MODEL_CATALOG: Partial<Record<CLIProxyProvider, ProviderCatalog>> =
         extendedContext: true,
       },
       {
+        id: 'claude-sonnet-5',
+        name: 'Claude Sonnet 5',
+        description: 'Latest generation Sonnet',
+        nativeImageInput: true,
+        // Claude 5 generation: same adaptive-thinking surface as Fable 5 /
+        // Opus 4.8. Anthropic accepts only effort levels; manual budget_tokens
+        // is rejected with 400.
+        thinking: {
+          type: 'levels',
+          levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          maxLevel: 'max',
+          dynamicAllowed: true,
+        },
+        extendedContext: true,
+      },
+      {
         id: 'claude-sonnet-4-6',
         name: 'Claude Sonnet 4.6',
         description: 'Balanced performance and speed',

--- a/src/web-server/model-pricing.ts
+++ b/src/web-server/model-pricing.ts
@@ -203,6 +203,13 @@ const PRICING_REGISTRY: Record<string, ModelPricing> = {
     cacheCreationPerMillion: 3.75,
     cacheReadPerMillion: 0.3,
   },
+  // Claude 5 Sonnet ($3/$15)
+  'claude-sonnet-5': {
+    inputPerMillion: 3.0,
+    outputPerMillion: 15.0,
+    cacheCreationPerMillion: 3.75,
+    cacheReadPerMillion: 0.3,
+  },
   // Claude 4.6 Sonnet ($3/$15)
   'claude-sonnet-4-6': {
     inputPerMillion: 3.0,

--- a/ui/src/lib/model-catalogs.ts
+++ b/ui/src/lib/model-catalogs.ts
@@ -801,6 +801,18 @@ export const MODEL_CATALOGS: Record<string, ProviderCatalog> = {
         },
       },
       {
+        id: 'claude-sonnet-5',
+        name: 'Claude Sonnet 5',
+        description: 'Latest generation Sonnet',
+        extendedContext: true,
+        presetMapping: {
+          default: 'claude-sonnet-5',
+          opus: 'claude-opus-4-8',
+          sonnet: 'claude-sonnet-5',
+          haiku: 'claude-haiku-4-5-20251001',
+        },
+      },
+      {
         id: 'claude-sonnet-4-6',
         name: 'Claude Sonnet 4.6',
         description: 'Balanced performance and speed',


### PR DESCRIPTION
## Summary
Adds **Claude Sonnet 5** (Claude 5 generation) as a selectable model.

- **Backend** `src/cliproxy/model-catalog.ts`: new `claude-sonnet-5` entry, adaptive-thinking `levels` (low..max) matching Fable 5 / Opus 4.8.
- **UI** `ui/src/lib/model-catalogs.ts`: mirror entry, `presetMapping` opus->`claude-opus-4-8`, sonnet/default->`claude-sonnet-5`.
- **Pricing** `src/web-server/model-pricing.ts`: `claude-sonnet-5` at $3/$15 per MTok (current Sonnet tier).

Provider `defaultModel` unchanged (`claude-sonnet-4-6`).

## Notes / assumptions
- Thinking surface assumed `levels` (Claude 5 family, like Fable 5 / Opus 4.8 — manual `budget_tokens` rejected 400).
- Pricing assumed same as prior Sonnet generations ($3/$15); adjust if official differs.

## Validation
- `bun run validate` (backend) + `ui` validate: pass.
- `model-catalog` / `model-catalog-compat` tests: 59 pass, sonnet-5 resolves via static path.