### PR TITLE
fix: preserve saved Claude extended-context preference

### DIFF
--- a/src/cliproxy/ai-providers/__tests__/extended-context-config.test.ts
+++ b/src/cliproxy/ai-providers/__tests__/extended-context-config.test.ts
@@ -168,6 +168,26 @@ describe('applyExtendedContextConfig', () => {
     expect(env.ANTHROPIC_MODEL).toBe('gemini-2.5-pro(high)[1m]');
   });
 
+  it('preserves a saved [1m] preference for supported Claude models in auto mode', () => {
+    const env: NodeJS.ProcessEnv = {
+      ANTHROPIC_MODEL: 'claude-sonnet-4-5-20250929[1m]',
+    };
+
+    applyExtendedContextConfig(env, 'claude', undefined);
+
+    expect(env.ANTHROPIC_MODEL).toBe('claude-sonnet-4-5-20250929[1m]');
+  });
+
+  it('strips a stale [1m] preference from unsupported native Gemini models', () => {
+    const env: NodeJS.ProcessEnv = {
+      ANTHROPIC_MODEL: 'gemini-2.5-flash[1m]',
+    };
+
+    applyExtendedContextConfig(env, 'gemini', undefined);
+
+    expect(env.ANTHROPIC_MODEL).toBe('gemini-2.5-flash');
+  });
+
   it('handles empty env vars gracefully', () => {
     const env: NodeJS.ProcessEnv = {};
     applyExtendedContextConfig(env, 'gemini', undefined);

--- a/src/cliproxy/config/extended-context-config.ts
+++ b/src/cliproxy/config/extended-context-config.ts
@@ -105,7 +105,7 @@ export function applyExtendedContextConfig(
     if (isNativeGeminiModel(modelId)) {
       envVars[key] = supportsExtendedContext(provider, modelId)
         ? applyExtendedContextSuffixShared(value)
-        : value;
+        : stripExtendedContextSuffix(value);
       continue;
     }
 

--- a/src/cliproxy/config/extended-context-config.ts
+++ b/src/cliproxy/config/extended-context-config.ts
@@ -13,9 +13,12 @@ import type { CLIProxyProvider } from '../types';
 import { supportsExtendedContext } from '../model-catalog';
 import { warn } from '../../utils/ui';
 import {
+  ANTHROPIC_MODEL_ENV_KEYS,
   applyExtendedContextPreferenceToAnthropicModels,
   applyExtendedContextSuffix as applyExtendedContextSuffixShared,
+  hasExtendedContextSuffix,
   isNativeGeminiModel,
+  stripExtendedContextSuffix,
   stripModelConfigurationSuffixes,
 } from '../../shared/extended-context-utils';
 
@@ -73,20 +76,41 @@ export function applyExtendedContextConfig(
   provider: CLIProxyProvider,
   extendedContextOverride?: boolean
 ): void {
-  if (extendedContextOverride === false) {
-    Object.assign(envVars, applyExtendedContextPreferenceToAnthropicModels(envVars, false));
+  if (extendedContextOverride === true || extendedContextOverride === false) {
+    Object.assign(
+      envVars,
+      applyExtendedContextPreferenceToAnthropicModels(envVars, extendedContextOverride, {
+        supportsExtendedContext: (modelId) =>
+          shouldApplyExtendedContext(
+            provider,
+            stripModelConfigurationSuffixes(modelId),
+            extendedContextOverride
+          ),
+      })
+    );
     return;
   }
 
-  Object.assign(
-    envVars,
-    applyExtendedContextPreferenceToAnthropicModels(envVars, true, {
-      supportsExtendedContext: (modelId) =>
-        shouldApplyExtendedContext(
-          provider,
-          stripModelConfigurationSuffixes(modelId),
-          extendedContextOverride
-        ),
-    })
-  );
+  // Auto mode (no explicit --1m/--no-1m this launch): don't force-strip a
+  // previously saved [1m] preference just because the model is Claude — only
+  // strip when the model no longer supports extended context. Native Gemini
+  // models still get auto-toggled based on catalog support.
+  for (const key of ANTHROPIC_MODEL_ENV_KEYS) {
+    const value = envVars[key];
+    if (typeof value !== 'string' || value.trim().length === 0) {
+      continue;
+    }
+    const modelId = stripModelConfigurationSuffixes(value);
+
+    if (isNativeGeminiModel(modelId)) {
+      envVars[key] = supportsExtendedContext(provider, modelId)
+        ? applyExtendedContextSuffixShared(value)
+        : value;
+      continue;
+    }
+
+    if (hasExtendedContextSuffix(value) && !supportsExtendedContext(provider, modelId)) {
+      envVars[key] = stripExtendedContextSuffix(value);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- preserve a saved `[1m]` preference for supported Claude models when no explicit context flag is supplied
- keep native Gemini auto-mode behavior catalog-driven
- strip stale `[1m]` suffixes from unsupported native Gemini models

## Testing

- [x] focused extended-context suite: 28 passed
- [x] `bun run validate:ci-parity`
- [x] E2E suite: 35 passed
- [ ] UI validation not applicable; no UI behavior changed

## Checklist

- [x] Base branch is `dev`
- [x] Tests added for saved supported-Claude and stale unsupported-Gemini auto-mode behavior
- [x] No help or public documentation change needed; this restores the existing `[1m]` contract
- [x] No secrets, tokens, or private config data included

## Docs Impact

Docs impact: `none`

Action: no update needed - restores the existing documented extended-context behavior.
