### PR TITLE
fix(ci): isolate Bar command fast tests

### DIFF
--- a/scripts/run-test-bucket.js
+++ b/scripts/run-test-bucket.js
@@ -47,6 +47,7 @@ const slowTests = [
 const fastJsTests = new Set(['tests/unit/flag-parsing-simple.test.js']);
 
 const isolatedTests = new Set([
+  'tests/unit/commands/bar-command.test.ts',
   'tests/unit/targets/codex-adapter-exec.test.ts',
   'tests/unit/targets/codex-adapter.test.ts',
   'tests/unit/targets/droid-adapter.test.ts',

--- a/tests/unit/scripts/run-test-bucket.test.js
+++ b/tests/unit/scripts/run-test-bucket.test.js
@@ -87,11 +87,13 @@ describe('run-test-bucket', () => {
   test('isolates known sticky mock suites outside src', () => {
     const runs = bucket.getBunRuns('fast', [
       'tests/unit/scripts/run-test-bucket.test.js',
+      'tests/unit/commands/bar-command.test.ts',
       'tests/unit/targets/target-registry.test.ts',
     ]);
 
     expect(runs.map((run) => run.label)).toEqual([
       'shared',
+      'tests/unit/commands/bar-command.test.ts',
       'tests/unit/targets/target-registry.test.ts',
     ]);
   });


### PR DESCRIPTION
## Summary

- run the stateful Bar command suite in its own Bun process
- add a bucket-routing regression assertion
- prevent the shared fast-test process from terminating mid-suite on Linux runners

This unblocks the post-merge Push CI and Dev Release runs for #1642. Both failed at the same truncated Bar test with no assertion failure; the suite passes when isolated.

## Validation

- `bun test tests/unit/scripts/run-test-bucket.test.js`
- `bun run test:fast` (395 selected files)
- Prettier and `git diff --check`

## Docs impact

None. Test orchestration only; no user-facing behavior, commands, setup, or public contract change.