### PR TITLE
feat(ui): add codex fast service-tier toggle

### DIFF
--- a/ui/src/components/cliproxy/provider-model-selector.tsx
+++ b/ui/src/components/cliproxy/provider-model-selector.tsx
@@ -18,15 +18,22 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Switch } from '@/components/ui/switch';
 import type { CliproxyProviderRoutingHints } from '@/lib/api-client';
 import type { CodexEffort, CodexServiceTier } from '@/lib/codex-effort';
 import {
+  applyCodexServiceTierSuffix,
   getCodexEffortDisplay,
   getCodexEffortVariants,
   parseCodexEffort,
   parseCodexServiceTier,
+  stripCodexEffortSuffix,
 } from '@/lib/codex-effort';
-import { getResolvedCatalogModels, getSupplementalCatalogModels } from '@/lib/model-catalogs';
+import {
+  findCatalogModel,
+  getResolvedCatalogModels,
+  getSupplementalCatalogModels,
+} from '@/lib/model-catalogs';
 import { getReasoningAdapter } from '@/lib/reasoning-control';
 import { cn } from '@/lib/utils';
 
@@ -586,6 +593,19 @@ export function FlexibleModelSelector({
     !selectableReasoningLevels.includes(currentReasoningLevel)
       ? [...selectableReasoningLevels, currentReasoningLevel]
       : selectableReasoningLevels;
+  const currentServiceTier = isCodexProvider ? parseCodexServiceTier(value) : undefined;
+  const selectedCodexBaseModel =
+    isCodexProvider && catalog && value
+      ? findCatalogModel(
+          catalog.provider,
+          stripCodexEffortSuffix(normalizeModelValue(value, routing)),
+          catalog
+        )
+      : undefined;
+  const showFastToggle =
+    isCodexProvider &&
+    (selectedCodexBaseModel?.codexServiceTiers?.includes('fast') === true ||
+      currentServiceTier === 'fast');
 
   return (
     <div className="space-y-1.5">
@@ -701,6 +721,19 @@ export function FlexibleModelSelector({
               ))}
             </SelectContent>
           </Select>
+        )}
+        {showFastToggle && (
+          <label className="flex h-9 shrink-0 items-center gap-1.5">
+            <Switch
+              checked={currentServiceTier === 'fast'}
+              onCheckedChange={(checked) => onChange(applyCodexServiceTierSuffix(value, checked))}
+              disabled={disabled || !value}
+              aria-label={t('providerModelSelector.fastTier')}
+            />
+            <span className="text-xs text-muted-foreground">
+              {t('providerModelSelector.fastTier')}
+            </span>
+          </label>
         )}
       </div>
       {selectedRoutingHint ? (

--- a/ui/src/lib/codex-effort.ts
+++ b/ui/src/lib/codex-effort.ts
@@ -66,6 +66,12 @@ export function applyCodexEffortSuffix(
   return [normalizedModelId, effort, parsed.serviceTier].filter(Boolean).join('-');
 }
 
+export function applyCodexServiceTierSuffix(modelId: string | undefined, enabled: boolean): string {
+  const parsed = parseCodexTuningSuffix(modelId);
+  if (!parsed.baseModel) return parsed.baseModel;
+  return [parsed.baseModel, parsed.effort, enabled ? 'fast' : undefined].filter(Boolean).join('-');
+}
+
 export function getCodexEffortVariants(
   modelId: string,
   maxEffort: CodexEffort | undefined,

--- a/ui/src/lib/i18n.ts
+++ b/ui/src/lib/i18n.ts
@@ -230,6 +230,7 @@ const resources = {
         codexFastVariants: 'Fast variants',
         effortLabel: 'Effort',
         effortAuto: 'Auto',
+        fastTier: 'Fast',
       },
       createAuthProfileDialog: {
         title: 'Create New Account',
@@ -2958,6 +2959,7 @@ const resources = {
         codexFastVariants: '快速变体',
         effortLabel: '推理强度',
         effortAuto: '自动',
+        fastTier: '快速',
       },
       createAuthProfileDialog: {
         title: '创建新账号',
@@ -5569,6 +5571,7 @@ const resources = {
         codexFastVariants: 'Biến thể nhanh',
         effortLabel: 'Mức suy luận',
         effortAuto: 'Tự động',
+        fastTier: 'Nhanh',
       },
       createAuthProfileDialog: {
         title: 'Tạo tài khoản mới',
@@ -8296,6 +8299,7 @@ const resources = {
         codexFastVariants: '高速バリアント',
         effortLabel: '推論レベル',
         effortAuto: '自動',
+        fastTier: '高速',
       },
       createAuthProfileDialog: {
         title: '新しいアカウントを作成',
@@ -11046,6 +11050,7 @@ const resources = {
         codexFastVariants: '빠른 변형',
         effortLabel: '추론 강도',
         effortAuto: '자동',
+        fastTier: '고속',
       },
       createAuthProfileDialog: {
         title: '새 계정 생성',

--- a/ui/src/lib/model-catalogs.ts
+++ b/ui/src/lib/model-catalogs.ts
@@ -1150,6 +1150,9 @@ export function buildUiCatalog(
           : (model.extendedContext ?? staticModel?.extendedContext),
       presetMapping: staticModel?.presetMapping,
       reasoningLevels: model.reasoningLevels ?? staticModel?.reasoningLevels,
+      codexMaxEffort: model.codexMaxEffort ?? staticModel?.codexMaxEffort,
+      codexEfforts: model.codexEfforts ?? staticModel?.codexEfforts,
+      codexServiceTiers: model.codexServiceTiers ?? staticModel?.codexServiceTiers,
     };
   });
 

--- a/ui/tests/unit/ui/lib/codex-effort.test.ts
+++ b/ui/tests/unit/ui/lib/codex-effort.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyCodexEffortSuffix,
+  applyCodexServiceTierSuffix,
   getCodexEffortDisplay,
   getCodexEffortVariants,
   getSelectableCodexEfforts,
@@ -108,6 +109,40 @@ describe('codex effort helpers', () => {
       'gpt-5.4-high',
       'gpt-5.4-high-fast',
     ]);
+  });
+});
+
+describe('applyCodexServiceTierSuffix', () => {
+  it('adds the fast tier while preserving the effort suffix', () => {
+    expect(applyCodexServiceTierSuffix('gpt-5.4-high', true)).toBe('gpt-5.4-high-fast');
+  });
+
+  it('removes only the fast tier', () => {
+    expect(applyCodexServiceTierSuffix('gpt-5.4-high-fast', false)).toBe('gpt-5.4-high');
+    expect(applyCodexServiceTierSuffix('gpt-5.4-fast', false)).toBe('gpt-5.4');
+  });
+
+  it('preserves routing prefixes', () => {
+    expect(applyCodexServiceTierSuffix('codex/gpt-5.6-sol', true)).toBe('codex/gpt-5.6-sol-fast');
+  });
+
+  it('is idempotent and safe on empty input', () => {
+    expect(applyCodexServiceTierSuffix('gpt-5.4-fast', true)).toBe('gpt-5.4-fast');
+    expect(applyCodexServiceTierSuffix('gpt-5.4', false)).toBe('gpt-5.4');
+    expect(applyCodexServiceTierSuffix(undefined, true)).toBe('');
+    expect(applyCodexServiceTierSuffix('', true)).toBe('');
+  });
+
+  it('composes with applyCodexEffortSuffix in both orders', () => {
+    expect(applyCodexEffortSuffix(applyCodexServiceTierSuffix('gpt-5.4', true), 'high')).toBe(
+      'gpt-5.4-high-fast'
+    );
+    expect(applyCodexServiceTierSuffix(applyCodexEffortSuffix('gpt-5.4', 'high'), true)).toBe(
+      'gpt-5.4-high-fast'
+    );
+    expect(
+      applyCodexEffortSuffix(applyCodexServiceTierSuffix('gpt-5.4-high-fast', false), 'low')
+    ).toBe('gpt-5.4-low');
   });
 });
 

--- a/ui/tests/unit/ui/lib/model-catalogs-codex-merge.test.ts
+++ b/ui/tests/unit/ui/lib/model-catalogs-codex-merge.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { buildUiCatalog } from '@/lib/model-catalogs';
+
+describe('buildUiCatalog codex tuning metadata merge', () => {
+  it('preserves static codex effort and service-tier metadata when the live catalog omits them', () => {
+    const merged = buildUiCatalog('codex', {
+      provider: 'codex',
+      displayName: 'Codex',
+      defaultModel: 'gpt-5.6-sol',
+      models: [{ id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol' }],
+    });
+
+    const model = merged?.models.find((entry) => entry.id === 'gpt-5.6-sol');
+    expect(model?.codexMaxEffort).toBe('xhigh');
+    expect(model?.codexEfforts).toEqual(['low', 'medium', 'high', 'xhigh']);
+    expect(model?.codexServiceTiers).toEqual(['fast']);
+  });
+
+  it('prefers live metadata over static when the live catalog provides it', () => {
+    const merged = buildUiCatalog('codex', {
+      provider: 'codex',
+      displayName: 'Codex',
+      defaultModel: 'gpt-5.6-sol',
+      models: [{ id: 'gpt-5.6-sol', name: 'GPT-5.6 Sol', codexServiceTiers: [] }],
+    });
+
+    const model = merged?.models.find((entry) => entry.id === 'gpt-5.6-sol');
+    expect(model?.codexServiceTiers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a dedicated **Fast** switch beside the effort dropdown for Codex tier rows, so the `-fast` service-tier suffix no longer requires picking `…-high-fast` variants from the model list.
- New helper `applyCodexServiceTierSuffix` composes/removes `-fast` while preserving the effort suffix and routing prefix; state derives from the value string, so the switch and the existing variant groups can never disagree.
- Visibility: shown when the selected base model's catalog entry lists `codexServiceTiers: ['fast']`, or when the current value already carries `-fast` (hand-typed custom values stay toggleable).
- i18n keys in all 5 locales.

## Bug fix included
`buildUiCatalog` dropped `codexMaxEffort` / `codexEfforts` / `codexServiceTiers` when merging live catalog data over the static catalog, so live-catalog sessions lost effort caps and the fast tier entirely. The merge now falls back to static metadata (`fix(ui): preserve codex tuning metadata in live catalog merge`), with regression tests covering both directions (static fills gaps; live values win when present).

## Validation
- `cd ui && bun run format && bun run validate` green; full UI suite green (includes 20 codex-effort helper tests + 2 new catalog-merge tests).
- Manual dashboard pass: toggle round-trips per tier, persists through save/reload, and stays consistent with `-fast` variants picked from the dropdown.