### PR TITLE
feat(cliproxy): strip anthropic-only tool fields for xai and kimi routes

### DIFF
--- a/src/cliproxy/proxy/__tests__/tool-sanitization-proxy-integration.test.ts
+++ b/src/cliproxy/proxy/__tests__/tool-sanitization-proxy-integration.test.ts
@@ -690,6 +690,200 @@ describe('ToolSanitizationProxy Integration', () => {
       });
     }
 
+    it('strips only cache_control for root-routed grok-* models while surviving other fields', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      try {
+        await fetch(`http://127.0.0.1:${port}/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: 'grok-4',
+            tools: [
+              {
+                name: 'grok_tool',
+                description: 'Root-routed Grok test',
+                cache_control: { type: 'ephemeral' },
+                strict: true,
+                input_examples: [{ x: 1 }],
+                defer_loading: true,
+                type: 'custom',
+                input_schema: {
+                  type: 'object',
+                  properties: {
+                    x: {
+                      type: 'string',
+                      examples: ['keep the schema'],
+                    },
+                  },
+                },
+              },
+            ],
+          }),
+        });
+
+        const sentTools = (lastRequest!.body as Record<string, unknown>).tools as Array<
+          Record<string, unknown>
+        >;
+        expect(sentTools[0].name).toBe('grok_tool');
+        expect(sentTools[0].description).toBe('Root-routed Grok test');
+        expect(sentTools[0].cache_control).toBeUndefined();
+        // Round-trip: untouched top-level fields survive (codex-parity strip set).
+        expect(sentTools[0].strict).toBe(true);
+        expect(sentTools[0].input_examples).toEqual([{ x: 1 }]);
+        expect(sentTools[0].defer_loading).toBe(true);
+        expect(sentTools[0].type).toBe('custom');
+        expect(sentTools[0].input_schema).toEqual({
+          type: 'object',
+          properties: {
+            x: {
+              type: 'string',
+            },
+          },
+        });
+      } finally {
+        proxy.stop();
+      }
+    });
+
+    it('strips only cache_control on the xai provider path', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      try {
+        await fetch(`http://127.0.0.1:${port}/api/provider/xai/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: 'grok-4',
+            tools: [
+              {
+                name: 'xai_tool',
+                description: 'xai path test',
+                cache_control: { type: 'ephemeral' },
+                strict: true,
+              },
+            ],
+          }),
+        });
+
+        const sentTools = (lastRequest!.body as Record<string, unknown>).tools as Array<
+          Record<string, unknown>
+        >;
+        expect(sentTools[0].name).toBe('xai_tool');
+        expect(sentTools[0].cache_control).toBeUndefined();
+        expect(sentTools[0].strict).toBe(true);
+      } finally {
+        proxy.stop();
+      }
+    });
+
+    it('strips only cache_control on the kimi provider path', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      try {
+        await fetch(`http://127.0.0.1:${port}/api/provider/kimi/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: 'kimi-k2',
+            tools: [
+              {
+                name: 'kimi_tool',
+                description: 'kimi path test',
+                cache_control: { type: 'ephemeral' },
+                strict: true,
+              },
+            ],
+          }),
+        });
+
+        const sentTools = (lastRequest!.body as Record<string, unknown>).tools as Array<
+          Record<string, unknown>
+        >;
+        expect(sentTools[0].name).toBe('kimi_tool');
+        expect(sentTools[0].cache_control).toBeUndefined();
+        expect(sentTools[0].strict).toBe(true);
+      } finally {
+        proxy.stop();
+      }
+    });
+
+    it('strips only cache_control for kimi aliases on the iflow provider path', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      try {
+        // kimi-k2.5 normalizes to kimi-k2 on the iflow route, then still strips.
+        await fetch(`http://127.0.0.1:${port}/api/provider/iflow/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: 'kimi-k2.5',
+            tools: [
+              {
+                name: 'iflow_kimi_tool',
+                description: 'iflow kimi alias test',
+                cache_control: { type: 'ephemeral' },
+                strict: true,
+              },
+            ],
+          }),
+        });
+
+        const sentBody = lastRequest!.body as Record<string, unknown>;
+        expect(sentBody.model).toBe('kimi-k2');
+        const sentTools = sentBody.tools as Array<Record<string, unknown>>;
+        expect(sentTools[0].name).toBe('iflow_kimi_tool');
+        expect(sentTools[0].cache_control).toBeUndefined();
+        expect(sentTools[0].strict).toBe(true);
+      } finally {
+        proxy.stop();
+      }
+    });
+
+    it('preserves top-level tool fields for non-kimi models on the iflow provider path', async () => {
+      const proxy = new ToolSanitizationProxy({
+        upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,
+      });
+      const port = await proxy.start();
+
+      try {
+        await fetch(`http://127.0.0.1:${port}/api/provider/iflow/v1/messages`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            model: 'qwen3-coder-plus',
+            tools: [
+              {
+                name: 'iflow_qwen_tool',
+                description: 'iflow non-kimi passthrough',
+                cache_control: { type: 'ephemeral' },
+              },
+            ],
+          }),
+        });
+
+        const sentTools = (lastRequest!.body as Record<string, unknown>).tools as Array<
+          Record<string, unknown>
+        >;
+        expect(sentTools[0].name).toBe('iflow_qwen_tool');
+        expect(sentTools[0].cache_control).toEqual({ type: 'ephemeral' });
+      } finally {
+        proxy.stop();
+      }
+    });
+
     it('preserves top-level tool fields for non-target root routes', async () => {
       const proxy = new ToolSanitizationProxy({
         upstreamBaseUrl: `http://127.0.0.1:${mockUpstreamPort}`,

--- a/src/cliproxy/proxy/tool-sanitization-proxy.ts
+++ b/src/cliproxy/proxy/tool-sanitization-proxy.ts
@@ -60,6 +60,13 @@ const GEMINI_UNSUPPORTED_TOOL_FIELDS = new Set([
 ]);
 
 const CODEX_UNSUPPORTED_TOOL_FIELDS = new Set(['cache_control']);
+
+// xAI (Grok) and Moonshot (Kimi) get the same minimal strip set as Codex: the
+// Anthropic-only `cache_control` tool field. Kept codex-parity until live PoC
+// evidence justifies stripping more, to avoid over-stripping fields a backend
+// actually consumes.
+const XAI_UNSUPPORTED_TOOL_FIELDS = new Set(['cache_control']);
+const KIMI_UNSUPPORTED_TOOL_FIELDS = new Set(['cache_control']);
 const CODEX_FAST_SERVICE_TIER = 'priority';
 const EXTENDED_CONTEXT_SUFFIX_REGEX = /\[1m\]$/i;
 const LEGACY_CODEX_MODEL_ID_REGEX = /^gpt-5(?:\.\d+)?-codex(?:-(?:mini|max))?$/i;
@@ -220,6 +227,26 @@ function getUnsupportedToolFields(
     (normalizedProvider === null && isKnownCodexModelId(model))
   ) {
     return CODEX_UNSUPPORTED_TOOL_FIELDS;
+  }
+
+  // xAI (Grok): explicit provider path, or root-routed `grok-*` model. The xai
+  // profile points at the proxy root, so providerFromPath is null for Grok
+  // traffic and detection must fall back to the model prefix.
+  if (
+    normalizedProvider === 'xai' ||
+    (normalizedProvider === null && normalizedModel?.startsWith('grok-'))
+  ) {
+    return XAI_UNSUPPORTED_TOOL_FIELDS;
+  }
+
+  // Kimi (Moonshot): explicit kimi path, the iflow route serving kimi model
+  // aliases, or a root-routed `kimi-*` model.
+  if (
+    normalizedProvider === 'kimi' ||
+    (normalizedProvider === 'iflow' && normalizedModel?.startsWith('kimi-')) ||
+    (normalizedProvider === null && normalizedModel?.startsWith('kimi-'))
+  ) {
+    return KIMI_UNSUPPORTED_TOOL_FIELDS;
   }
 
   return null;


### PR DESCRIPTION
## Summary
`getUnsupportedToolFields` in the tool-sanitization proxy only returns a strip set for gemini/codex, so Grok and Kimi traffic leaks Anthropic-only top-level tool fields (`cache_control`, …) to those backends. This adds codex-parity strip sets for both:

- **xAI (Grok):** provider path `xai`, plus a `grok-` model-prefix fallback for root-routed requests — the xai profile points at the proxy root, so `providerFromPath` is `null` for Grok traffic.
- **Kimi (Moonshot):** provider path `kimi`, the `iflow` route serving `kimi-*` aliases, and a root-routed `kimi-` prefix fallback.

Strip sets start minimal (`cache_control`, same as codex) and are kept as separate per-provider constants so each can widen independently once verified against the live backends. Gemini/codex behavior is unchanged.

## Tests
5 new cases in the existing integration suite covering the full detection matrix (root+grok, xai path, kimi path, iflow+kimi alias incl. `kimi-k2.5` → `kimi-k2` normalization, iflow+non-kimi passthrough) plus a strip round-trip asserting untouched fields survive. Suite: 46/46 pass.

## Validation
- `bun run format && bun run lint:fix && bun run validate` green.
- `bun run validate:ci-parity` full pass.

## Note for review
A live PoC against authenticated xai/kimi backends wasn't possible in my environment (providers unconfigured), so the sets are deliberately conservative; happy to widen them if you have evidence other fields (`strict`, `input_examples`, `defer_loading`, `type`) break those backends.