### PR TITLE
chore(reports): refresh hardening inventory

### DIFF
--- a/docs/reports/hardening-inventory.json
+++ b/docs/reports/hardening-inventory.json
@@ -1,10 +1,10 @@
 {
   "scope": "src/**/*.{ts,tsx,js,jsx,mjs,cjs}",
   "syncFs": {
-    "totalOccurrences": 2301,
-    "filesAffected": 247,
-    "hotpathOccurrences": 1946,
-    "hotpathFilesAffected": 197,
+    "totalOccurrences": 2358,
+    "filesAffected": 253,
+    "hotpathOccurrences": 1991,
+    "hotpathFilesAffected": 202,
     "topHotpathFiles": [
       {
         "file": "src/cliproxy/__tests__/pool-routing-phase3.test.ts",
@@ -285,8 +285,8 @@
     ]
   },
   "legacyShim": {
-    "totalMarkers": 427,
-    "filesAffected": 164,
+    "totalMarkers": 454,
+    "filesAffected": 170,
     "topFiles": [
       {
         "file": "src/auth/profile-detector.ts",
@@ -310,6 +310,28 @@
           "// Priority 0.25: Check explicit legacy Cursor bridge profile.",
           "// Priority 3: Check settings-based profiles (glm, km) - LEGACY FALLBACK",
           "// Priority 4: Check account-based profiles (work, personal) - LEGACY FALLBACK"
+        ]
+      },
+      {
+        "file": "src/web-server/usage/native-quota-collector.ts",
+        "count": 15,
+        "calls": [],
+        "markers": [
+          "* are used for backward compatibility.",
+          "* Kept for backward compatibility with existing tests.",
+          "* Legacy Codex collector — uses the old getDefaultCodexAccountId dep.",
+          "* List all Claude profiles from the profile registry (merged legacy + unified).",
+          "* profile name. Kept for backward compatibility with existing tests that stub",
+          "* When no enumeration deps are injected (legacy mode / old tests that stub only",
+          "/** Legacy Codex network row builder. */",
+          "/** Legacy Codex row builder (local quota). */",
+          "/** Legacy row builder — no surface/profile/is_subscription fields. */",
+          "// everything except the legacy harness takes the multi-profile path below.",
+          "// For the network fallback: the legacy getDefaultCodexAccountId is the",
+          "// Legacy path: backward-compatible with old tests that only inject",
+          "// Legacy single-profile collectors (unchanged; used by old tests + back-compat)",
+          "// Multi-profile enumeration is the DEFAULT (production) behavior. The legacy",
+          "// Use the legacy single-state approach via profile key '__legacy__' to avoid"
         ]
       },
       {
@@ -373,14 +395,14 @@
         "count": 10,
         "calls": [],
         "markers": [
-          "* - Legacy CLI fallbacks: Gemini, Grok, OpenCode",
           "* Legacy AI CLI fallbacks remain available for compatibility only.",
           "* Uses deterministic search backends first, with optional legacy CLI fallback.",
           "/** Enable Gemini CLI legacy fallback (default: false) */",
           "/** Enable Grok CLI legacy fallback (default: false - requires GROK_API_KEY) */",
           "/** Enable OpenCode CLI legacy fallback (default: false) */",
-          "/** Gemini CLI - optional legacy LLM fallback */",
+          "/** Gemini CLI - deprecated legacy LLM fallback (retired upstream) */",
           "/** Grok CLI - optional legacy LLM fallback */",
+          "/** Model to use (default: gemini-2.5-flash; accepts legacy gemini ids) */",
           "/** OpenCode - optional legacy LLM fallback */",
           "// Legacy fields (deprecated, kept for backwards compatibility)"
         ]
@@ -440,20 +462,6 @@
           "it('legacy variant does not block port allocation', function () {",
           "legacy: {"
         ]
-      },
-      {
-        "file": "src/cliproxy/config/__tests__/config-generator.test.js",
-        "count": 7,
-        "calls": [],
-        "markers": [
-          "'Should preserve lone manual high-version aliases during legacy cleanup'",
-          "'Should preserve manual aliases after legacy migration has already run'",
-          "'Should preserve the manual 3.2 compatibility cluster during legacy cleanup'",
-          "'Should preserve the pruned legacy alias in the migration backup'",
-          "assert(fs.existsSync(backupPath), 'Should keep a backup of the legacy config before pruning');",
-          "it('prunes partially retained broad guessed ranges during legacy cleanup', () => {",
-          "it('writes a one-time backup before pruning legacy Gemini aliases during migration', () => {"
-        ]
       }
     ],
     "explicitShimFiles": [
@@ -468,11 +476,11 @@
   },
   "maintainability": {
     "typedErrors": {
-      "totalThrows": 431,
-      "typedThrows": 37,
-      "plainThrows": 336,
-      "otherThrows": 58,
-      "adoptionRatio": 0.0858,
+      "totalThrows": 440,
+      "typedThrows": 68,
+      "plainThrows": 312,
+      "otherThrows": 60,
+      "adoptionRatio": 0.1545,
       "topSubdomainsByThrows": [
         {
           "subdomain": "web-server",
@@ -488,9 +496,15 @@
         },
         {
           "subdomain": "commands",
-          "count": 33,
-          "typed": 0,
-          "plain": 32
+          "count": 36,
+          "typed": 4,
+          "plain": 30
+        },
+        {
+          "subdomain": "codex-auth",
+          "count": 35,
+          "typed": 4,
+          "plain": 27
         },
         {
           "subdomain": "utils",
@@ -499,22 +513,16 @@
           "plain": 33
         },
         {
-          "subdomain": "codex-auth",
-          "count": 31,
-          "typed": 0,
-          "plain": 27
-        },
-        {
           "subdomain": "targets",
           "count": 27,
-          "typed": 0,
-          "plain": 25
+          "typed": 9,
+          "plain": 16
         },
         {
           "subdomain": "cursor",
           "count": 23,
-          "typed": 0,
-          "plain": 21
+          "typed": 4,
+          "plain": 17
         },
         {
           "subdomain": "cliproxy/accounts",
@@ -543,15 +551,15 @@
         "web-server/routes",
         "auth"
       ],
-      "numerator": 21,
-      "denominator": 23,
-      "ratio": 0.913,
+      "numerator": 22,
+      "denominator": 24,
+      "ratio": 0.9167,
       "targetRatio": 0.4
     },
     "loggerCoverage": {
-      "filesWithCreateLogger": 64,
-      "totalSourceFiles": 745,
-      "coverageRatio": 0.0859,
+      "filesWithCreateLogger": 65,
+      "totalSourceFiles": 751,
+      "coverageRatio": 0.0866,
       "subdomainsWithZeroCreateLogger": [
         "api",
         "bin",
@@ -572,17 +580,17 @@
       "topSubdomainsByFiles": [
         {
           "subdomain": "web-server",
-          "count": 111,
+          "count": 112,
           "withLogger": 10
         },
         {
           "subdomain": "commands",
-          "count": 107,
+          "count": 108,
           "withLogger": 2
         },
         {
           "subdomain": "utils",
-          "count": 87,
+          "count": 88,
           "withLogger": 1
         },
         {
@@ -606,14 +614,14 @@
           "withLogger": 0
         },
         {
+          "subdomain": "codex-auth",
+          "count": 24,
+          "withLogger": 9
+        },
+        {
           "subdomain": "cursor",
           "count": 24,
           "withLogger": 2
-        },
-        {
-          "subdomain": "codex-auth",
-          "count": 23,
-          "withLogger": 8
         },
         {
           "subdomain": "auth",
@@ -623,9 +631,9 @@
       ]
     },
     "hotpathConsoleErrors": {
-      "totalOccurrences": 569,
-      "exemptOccurrences": 302,
-      "hotpathOccurrences": 267,
+      "totalOccurrences": 571,
+      "exemptOccurrences": 305,
+      "hotpathOccurrences": 266,
       "filesAffected": 82,
       "topFiles": [
         {
@@ -691,16 +699,20 @@
       ]
     },
     "largeFiles": {
-      "countOver400": 89,
-      "countOver600": 39,
+      "countOver400": 91,
+      "countOver600": 42,
       "topOver400": [
         {
+          "file": "src/web-server/usage/native-quota-collector.ts",
+          "loc": 1662
+        },
+        {
           "file": "src/web-server/routes/cliproxy-auth-routes.ts",
-          "loc": 1515
+          "loc": 1531
         },
         {
           "file": "src/cliproxy/auth/oauth-handler.ts",
-          "loc": 1455
+          "loc": 1467
         },
         {
           "file": "src/cursor/cursor-executor.ts",
@@ -708,23 +720,23 @@
         },
         {
           "file": "src/web-server/model-pricing.ts",
-          "loc": 1070
+          "loc": 1105
+        },
+        {
+          "file": "src/cliproxy/auth/oauth-process.ts",
+          "loc": 1048
         },
         {
           "file": "src/web-server/routes/settings-routes.ts",
           "loc": 1041
         },
         {
-          "file": "src/cliproxy/config/env-builder.ts",
-          "loc": 1037
-        },
-        {
           "file": "src/cliproxy/proxy/tool-sanitization-proxy.ts",
           "loc": 1020
         },
         {
-          "file": "src/cliproxy/auth/oauth-process.ts",
-          "loc": 1018
+          "file": "src/cliproxy/config/env-builder.ts",
+          "loc": 1017
         },
         {
           "file": "src/cliproxy/config/generator.ts",
@@ -732,7 +744,7 @@
         },
         {
           "file": "src/commands/cliproxy/variant-subcommand.ts",
-          "loc": 978
+          "loc": 997
         },
         {
           "file": "src/cliproxy/quota/quota-manager.ts",
@@ -749,10 +761,6 @@
         {
           "file": "src/cliproxy/accounts/registry.ts",
           "loc": 871
-        },
-        {
-          "file": "src/channels/official-channels-runtime.ts",
-          "loc": 867
         }
       ]
     }

--- a/docs/reports/hardening-inventory.md
+++ b/docs/reports/hardening-inventory.md
@@ -6,12 +6,12 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | Metric | Value |
 |---|---:|
-| Sync fs occurrences (all) | 2301 |
-| Sync fs files affected (all) | 247 |
-| Sync fs occurrences (runtime hotpaths) | 1946 |
-| Sync fs files affected (runtime hotpaths) | 197 |
-| Legacy shim markers | 427 |
-| Legacy shim files affected | 164 |
+| Sync fs occurrences (all) | 2358 |
+| Sync fs files affected (all) | 253 |
+| Sync fs occurrences (runtime hotpaths) | 1991 |
+| Sync fs files affected (runtime hotpaths) | 202 |
+| Legacy shim markers | 454 |
+| Legacy shim files affected | 170 |
 
 ## Top Runtime Hotpath Sync fs Files
 
@@ -33,6 +33,7 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 | File | Marker Count |
 |---|---:|
 | `src/auth/profile-detector.ts` | 18 |
+| `src/web-server/usage/native-quota-collector.ts` | 15 |
 | `src/utils/config-manager.ts` | 13 |
 | `src/cliproxy/__tests__/pool-onboarding-phase5.test.ts` | 12 |
 | `src/cliproxy/executor/__tests__/variant-port-allocation.test.js` | 12 |
@@ -41,7 +42,6 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 | `src/config/migration-manager.ts` | 9 |
 | `src/cliproxy/config/__tests__/env-builder-provider-url.test.ts` | 8 |
 | `src/cliproxy/executor/__tests__/variant-port-edge-cases.test.js` | 8 |
-| `src/cliproxy/config/__tests__/config-generator.test.js` | 7 |
 
 ## Explicit Shim/Re-export Files
 
@@ -56,14 +56,14 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | Metric | Value |
 |---|---:|
-| typed-error adoption (typed/total throws) | 8.6% (37/431) |
-| typed-error adoption (P4 locked subdomains) | 91.3% (21/23), target 40% |
-| hotpath console.error/warn occurrences | 267 (569 total, 302 CLI-UX exempt) |
+| typed-error adoption (typed/total throws) | 15.4% (68/440) |
+| typed-error adoption (P4 locked subdomains) | 91.7% (22/24), target 40% |
+| hotpath console.error/warn occurrences | 266 (571 total, 305 CLI-UX exempt) |
 | hotpath console.error/warn files | 82 |
-| files with createLogger | 64/745 |
+| files with createLogger | 65/751 |
 | subdomains with zero createLogger | 15 (api, bin, channels, cliproxy, cliproxy/accounts, cliproxy/ai-providers, cliproxy/binary, cliproxy/config, cliproxy/management, cliproxy/sync, cliproxy/types, config, dispatcher, shared, types) |
-| files > 400 LOC | 89 |
-| files > 600 LOC | 39 |
+| files > 400 LOC | 91 |
+| files > 600 LOC | 42 |
 
 ### Top Hotpath console.error/warn Files
 
@@ -89,19 +89,19 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | File | LOC |
 |---|---:|
-| `src/web-server/routes/cliproxy-auth-routes.ts` | 1515 |
-| `src/cliproxy/auth/oauth-handler.ts` | 1455 |
+| `src/web-server/usage/native-quota-collector.ts` | 1662 |
+| `src/web-server/routes/cliproxy-auth-routes.ts` | 1531 |
+| `src/cliproxy/auth/oauth-handler.ts` | 1467 |
 | `src/cursor/cursor-executor.ts` | 1234 |
-| `src/web-server/model-pricing.ts` | 1070 |
+| `src/web-server/model-pricing.ts` | 1105 |
+| `src/cliproxy/auth/oauth-process.ts` | 1048 |
 | `src/web-server/routes/settings-routes.ts` | 1041 |
-| `src/cliproxy/config/env-builder.ts` | 1037 |
 | `src/cliproxy/proxy/tool-sanitization-proxy.ts` | 1020 |
-| `src/cliproxy/auth/oauth-process.ts` | 1018 |
+| `src/cliproxy/config/env-builder.ts` | 1017 |
 | `src/cliproxy/config/generator.ts` | 1012 |
-| `src/commands/cliproxy/variant-subcommand.ts` | 978 |
+| `src/commands/cliproxy/variant-subcommand.ts` | 997 |
 | `src/cliproxy/quota/quota-manager.ts` | 954 |
 | `src/web-server/services/codex-dashboard-service.ts` | 940 |
 | `src/glmt/glmt-proxy.ts` | 939 |
 | `src/cliproxy/accounts/registry.ts` | 871 |
-| `src/channels/official-channels-runtime.ts` | 867 |
 


### PR DESCRIPTION
## Summary
Regenerates `docs/reports/hardening-inventory.{json,md}` via `bun run report:hardening`.

The committed artifact aged past the 30-day freshness gate in `scripts/ci-parity-gate.sh` (currently 33d), so `bun run validate:ci-parity` fails for every contributor branch with:

```
[X] Hardening inventory is stale (33d old; max 30d).
```

Refreshing it on `dev` unblocks the local pre-push parity gate for all contributors. No code changes — generated artifact only.