### PR TITLE
docs: refresh contributor and AI guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,23 @@ Profile resolution priority:
 
 All env values written into settings must be strings.
 
+## Documentation Truth
+
+Use the narrowest authoritative source:
+
+1. Source, tests, package scripts, and workflows define implemented behavior.
+2. `CLAUDE.md` and `CONTRIBUTING.md` define repository workflow.
+3. `docs/README.md` maps maintainer documentation and its owners.
+4. The separate `kaitranntt/ccs-docs` repository and published site own user
+   guides and CLI reference.
+5. Generated artifacts and live runtime checks define what shipped or is
+   currently running.
+
+Do not copy inventories, line counts, locale lists, target lists, or command
+details when a stable source link is enough. Update the owning documentation
+when behavior, commands, setup, architecture, security posture, or maintainer
+workflow changes. Remove stale claims instead of preserving them as TODOs.
+
 ## User-Facing Change Checklist
 
 - Update the matching `--help` handler when CLI behavior changes.
@@ -46,7 +63,10 @@ All env values written into settings must be strings.
 - Use neutral broad examples such as `ccs`, `ccs codex`, `ccs glm`, or
   `ccs <provider>` unless the page is provider-specific.
 - If CLI commands, config, providers, install steps, or user workflows change,
-  update the public CCS docs in `/Users/kaitran/CloudPersonal/ccs/docs`.
+  update the separate public CCS docs repository. Maintainers using the
+  standard CloudPersonal checkout may have it at
+  `/Users/kaitran/CloudPersonal/ccs/docs`; fork contributors can use their own
+  checkout and coordinate the matching docs change in the PR.
 
 Help locations:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If you are new to the project, start with a docs fix, a focused bug fix, or an i
 | CLI runtime | `src/`, `lib/`, `config/`, `scripts/` | Add or update tests in `tests/` |
 | Dashboard UI | `ui/src/` | Run `cd ui && bun run validate` |
 | Web server and config APIs | `src/web-server/`, `src/api/`, `src/config/` | Add unit or integration coverage |
-| Documentation | `https://docs.ccs.kaitran.ca`, `README.md`, `docs/`, `CONTRIBUTING.md` | Keep user-facing docs in sync |
+| Documentation | `https://docs.ccs.kaitran.ca`, `README.md`, [`docs/`](./docs/README.md), `CONTRIBUTING.md` | Update the owning source, not every page |
 | Static assets | `assets/` | Verify screenshots and references still match |
 
 Useful directories:
@@ -91,6 +91,21 @@ If `CI` or `Push CI` stays queued for a long time, it is a maintainer infrastruc
 ## AI Agent Rules
 
 `CONTRIBUTING.md` is the human entry point. For AI agents working in this repo, the authoritative automation and workflow rules live in [CLAUDE.md](./CLAUDE.md).
+
+## Documentation Ownership
+
+Documentation follows this truth order:
+
+1. Source, tests, package scripts, and workflows define implemented behavior.
+2. [CLAUDE.md](./CLAUDE.md) and this guide define repository workflow.
+3. [docs/README.md](./docs/README.md) maps maintainer documentation.
+4. [docs.ccs.kaitran.ca](https://docs.ccs.kaitran.ca) owns detailed user guides
+   and CLI reference.
+
+Update documentation when a change affects behavior, commands, setup,
+architecture, security posture, or contributor workflow. Prefer links to
+authoritative source files over copied trees, counts, and option lists that
+drift quickly.
 
 ## AI Review Lane
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# CCS Maintainer Documentation
+
+This directory explains how the CLI repository is organized and maintained.
+User-facing guides and command reference live at
+[docs.ccs.kaitran.ca](https://docs.ccs.kaitran.ca).
+
+## Truth Hierarchy
+
+Use the narrowest authoritative source:
+
+1. Source, tests, package scripts, and workflows define implemented behavior.
+2. [`CLAUDE.md`](../CLAUDE.md) and
+   [`CONTRIBUTING.md`](../CONTRIBUTING.md) define repository workflow.
+3. The documents below explain architecture, rationale, and maintainer
+   decisions.
+4. Build artifacts, releases, and runtime checks define shipped or observed
+   state.
+
+When sources disagree, verify the implementation first and update or remove the
+stale prose. Avoid copying volatile counts, recursive trees, and exhaustive
+option lists when a source link can remain accurate.
+
+## Start Here
+
+| Need | Owner |
+| --- | --- |
+| Repository domains and source entry points | [Codebase summary](./codebase-summary.md) |
+| Coding, testing, error, and size conventions | [Code standards](./code-standards.md) |
+| System boundaries and data flow | [System architecture](./system-architecture/index.md) |
+| Current maintenance direction | [Project roadmap](./project-roadmap.md) |
+| Release mechanics | [Release process](./release-process.md) |
+| Dashboard localization | [Dashboard i18n](./i18n-dashboard.md) |
+| Test layout and commands | [Test suite](../tests/README.md) |
+| Dashboard development | [UI guide](../ui/README.md) |
+
+Feature-specific maintainer notes remain in this directory. Discover them by
+filename, then verify referenced behavior against the linked source.
+
+## Update Triggers
+
+Update the owning documentation in the same change when any of these move:
+
+- CLI or dashboard behavior, commands, flags, or configuration
+- installation, deployment, release, or contributor workflow
+- architecture, data flow, persistence, security, or public contracts
+- source ownership or the stable entry point named by a guide
+
+Pure refactors need documentation changes only when they invalidate a
+maintainer decision or navigation link. Public behavior changes also require a
+matching update in the separate `kaitranntt/ccs-docs` repository on the same
+target branch. Maintainers using the standard CloudPersonal checkout may have
+that repository at `/Users/kaitran/CloudPersonal/ccs/docs`; fork contributors
+can use their own checkout and coordinate the matching docs change in the PR.
+
+## Validation
+
+Before review:
+
+```bash
+bash tests/docs/quickstart-parity.sh
+git diff --check
+```
+
+The repository-owned docs test currently checks the canonical quickstart
+snippet only. For other changed Markdown, verify each relative link and
+referenced path directly, then run the focused validation command for any code
+or workflow the document describes.

--- a/docs/code-standards.md
+++ b/docs/code-standards.md
@@ -1,749 +1,199 @@
 # CCS Code Standards
 
-Last Updated: 2026-04-07
-
-Code standards, modularization patterns, and conventions for the CCS codebase.
-
----
-
-## Core Principles
-
-### YAGNI (You Aren't Gonna Need It)
-- No features "just in case"
-- Only implement what is currently needed
-- Delete unused code rather than commenting it out
-
-### KISS (Keep It Simple, Stupid)
-- Prefer simple solutions over clever ones
-- Reduce complexity at every opportunity
-- Use established patterns over custom implementations
-
-### DRY (Don't Repeat Yourself)
-- One source of truth for configuration
-- Extract common logic into shared utilities
-- Use barrel exports to centralize imports
-
----
-
-## File Organization
-
-### Directory Structure Rules
-
-1. **Domain-based organization**: Group files by business domain, not by file type
-2. **Barrel exports required**: Every directory must have an `index.ts` aggregating exports
-3. **Flat within depth**: Keep nesting to 3 levels maximum
-4. **Co-location**: Keep related files together (component + hooks + utils)
-
-### File Naming Conventions
-
-| Convention | Example | When to Use |
-|------------|---------|-------------|
-| kebab-case | `cliproxy-executor.ts` | All TypeScript/TSX files |
-| kebab-case | `profile-detector.ts` | Multi-word file names |
-| *-adapter.ts | `claude-adapter.ts`, `droid-adapter.ts` | TargetAdapter implementations |
-| *-detector.ts | `droid-detector.ts` | Binary detection logic |
-| *-manager.ts | `droid-config-manager.ts` | Config/state management |
-| PascalCase | `BinaryManager` | Class exports only |
-| camelCase | `detectProfile` | Function exports |
-
-**File names should be descriptive**: LLMs should understand the file's purpose from its name alone without reading content.
-
-### Correct Examples
-
-```
-src/cliproxy/binary-manager.ts      # Binary management logic
-src/commands/doctor-command.ts      # Doctor CLI command handler
-ui/src/components/cliproxy/provider-editor/index.tsx
-```
-
-### Incorrect Examples
-
-```
-src/utils/helper.ts                 # Too vague
-src/cliproxy/manager.ts             # Which manager?
-ui/src/components/Editor.tsx        # Not kebab-case
-```
-
----
-
-## File Size Limit: 200 Lines
-
-**Target**: All code files should be under 200 lines.
-
-**Exceptions** (with justification):
-- Data files (model-pricing.ts, model-catalog.ts)
-- Entry points with routing logic (ccs.ts)
-- Complex transformation logic that cannot be meaningfully split
-
-### Why 200 Lines?
-
-1. **Context efficiency**: LLMs process smaller files faster
-2. **Single responsibility**: Forces focused, testable modules
-3. **Navigation**: Easier to scan and understand
-4. **Maintainability**: Reduces merge conflicts
-
-### When Files Exceed 200 Lines
-
-If a file grows beyond 200 lines:
-
-1. **Identify extraction candidates**:
-   - Helper functions that could be utilities
-   - Constants and type definitions
-   - Subcomponents within React components
-   - Related logic that forms a cohesive unit
-
-2. **Create subdirectory structure**:
-   ```
-   # Before
-   provider-editor.tsx (921 lines)
-
-   # After
-   provider-editor/
-   ├── index.tsx           # Main component (200 lines)
-   ├── model-mapping-form.tsx
-   ├── endpoint-config.tsx
-   ├── auth-section.tsx
-   ├── hooks.ts
-   ├── types.ts
-   └── utils.ts
-   ```
-
-3. **Preserve public API**: Main export remains the same through barrel export
-
----
-
-## Barrel Export Pattern
-
-### What is a Barrel Export?
-
-An `index.ts` file that aggregates and re-exports module contents:
-
-```typescript
-// src/cliproxy/index.ts
-
-// Types (with explicit type keyword)
-export type { PlatformInfo, BinaryInfo } from './types';
-
-// Functions
-export { detectPlatform } from './platform-detector';
-export { BinaryManager } from './binary-manager';
-
-// From subdirectories
-export * from './auth';
-export * from './services';
-```
-
-### Rules for Barrel Exports
-
-1. **Every domain directory must have `index.ts`**
-2. **Export types with `export type`** for tree-shaking
-3. **Re-export subdirectories** for deep access
-4. **Keep barrel exports flat** - no logic, only exports
-
-### Import Patterns
-
-```typescript
-// CORRECT: Import from domain barrel
-import { execClaudeWithCLIProxy, CLIProxyProvider } from '../cliproxy';
-import { Config, Settings } from '../types';
-
-// INCORRECT: Import from specific file (bypasses barrel)
-import { execClaudeWithCLIProxy } from '../cliproxy/cliproxy-executor';
-```
-
-### Exception: Deep Imports
-
-Allowed when:
-- Importing private utilities not exposed in barrel
-- Circular dependency avoidance
-- Performance-critical tree-shaking
-
----
-
-## Target Adapter Pattern
-
-The target adapter pattern enables pluggable support for multiple CLI implementations (Claude Code, Factory Droid, Codex CLI, etc.) while preserving a unified profile system.
-
-### Pattern Overview
-
-**Each CLI target implements a `TargetAdapter` interface:**
-
-```typescript
-interface TargetAdapter {
-  readonly type: TargetType;                                    // 'claude' | 'droid' | 'codex'
-  readonly displayName: string;                                 // Human-readable name
-
-  detectBinary(): TargetBinaryInfo | null;                      // Find CLI on system
-  prepareCredentials(creds: TargetCredentials): Promise<void>;  // Deliver credentials
-  buildArgs(profile: string, userArgs: string[]): string[];    // Build CLI args
-  buildEnv(creds: TargetCredentials, type: string): Env;       // Build env vars
-  exec(args: string[], env: Env): void;                        // Spawn CLI process
-  supportsProfileType(type: string): boolean;                  // Validate profile
-}
-```
-
-### Key Differences Per Target
-
-| Aspect | Claude | Droid | Codex |
-|--------|--------|-------|-------|
-| **Credential delivery** | Environment variables | Config file (~/.factory/settings.json) | Transient `-c` overrides + `CCS_CODEX_API_KEY` |
-| **Spawn args** | `claude <args>` | `droid -m custom:ccs-<profile> <args>` | `codex <args>` or `codex -c ... <args>` |
-| **Config write** | None (uses env) | `upsertCcsModel()` writes to settings | None at runtime; dashboard edits user-owned `~/.codex/config.toml` only |
-| **Binary detection** | `detectClaudeCli()` | `detectDroidCli()` with version check | `detectCodexCli()` plus `--config` capability probe |
-
-### Target Resolution Priority
-
-Resolves which adapter to use via `resolveTargetType()`:
-
-```
-1. --target <name> flag (highest priority)
-   ↓
-2. explicit runtime entrypoint (`CCS_INTERNAL_ENTRY_TARGET`):
-   - ccs-droid / ccsd → droid
-   - ccs-codex / ccsx → codex
-   - ccsxp → codex (native cliproxy shortcut)
-   ↓
-3. argv[0] detection (runtime alias pattern / custom alias map):
-   - ccs-droid → droid
-   - ccsd → droid
-   - ccs-codex → codex
-   - ccsx → codex
-   - ccs → default
-   ↓
-4. Profile config: profileConfig.target field
-   ↓
-5. Fallback: 'claude' (lowest priority)
-```
-
-### Registration Pattern
-
-At startup, adapters self-register into the runtime registry:
-
-```typescript
-// In ccs.ts or initialization
-registerTarget(new ClaudeAdapter());
-registerTarget(new DroidAdapter());
-registerTarget(new CodexAdapter());
-
-// Later, when executing
-const targetType = resolveTargetType(args, profileConfig);
-const adapter = getTarget(targetType);
-
-await adapter.prepareCredentials(credentials);
-const spawnArgs = adapter.buildArgs(profile, userArgs);
-adapter.exec(spawnArgs, adapter.buildEnv(credentials, profileType));
-```
-
-### Adding a New Target
-
-To add support for a new CLI (e.g., `newcli`):
-
-1. Create `src/targets/newcli-adapter.ts` implementing `TargetAdapter`
-2. Implement each required method (detection, credential delivery, spawning)
-3. Create `src/targets/newcli-detector.ts` for binary detection logic
-4. Export from `src/targets/index.ts`
-5. Register in `ccs.ts`: `registerTarget(new NewCliAdapter())`
-6. Update `TargetType` union to include `'newcli'`
-
----
-
-## Monster File Splitting Methodology
-
-When splitting large files (500+ lines), follow this process:
-
-### Step 1: Analyze Structure
-
-Identify logical boundaries:
-- Render sections in React components
-- Handler groups in route files
-- Related utility functions
-- Constants and types
-
-### Step 2: Extract Types First
-
-```typescript
-// types.ts
-export interface ProviderEditorProps {
-  providerId: string;
-  onSave: (config: ProviderConfig) => void;
-}
-
-export interface ModelMappingValues {
-  model: string;
-  endpoint: string;
-}
-```
-
-### Step 3: Extract Utilities
-
-```typescript
-// utils.ts
-export function validateEndpoint(url: string): boolean { ... }
-export function formatModelName(name: string): string { ... }
-```
-
-### Step 4: Extract Hooks
-
-```typescript
-// hooks.ts
-export function useProviderConfig(providerId: string) { ... }
-export function useModelValidation() { ... }
-```
-
-### Step 5: Extract Subcomponents
-
-```typescript
-// model-mapping-form.tsx
-export function ModelMappingForm({ values, onChange }: Props) { ... }
-```
-
-### Step 6: Compose in Index
-
-```typescript
-// index.tsx
-import { ModelMappingForm } from './model-mapping-form';
-import { useProviderConfig } from './hooks';
-import type { ProviderEditorProps } from './types';
-
-export function ProviderEditor({ providerId, onSave }: ProviderEditorProps) {
-  const config = useProviderConfig(providerId);
-  return (
-    <div>
-      <ModelMappingForm values={config.mapping} onChange={...} />
-    </div>
-  );
-}
-
-// Re-export types for consumers
-export type { ProviderEditorProps, ModelMappingValues } from './types';
-```
-
----
-
-## TypeScript Standards
-
-### Strict Mode Required
-
-All projects use TypeScript strict mode:
-
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true
-  }
-}
-```
-
-### Type Annotations
-
-```typescript
-// CORRECT: Explicit return types for public functions
-export function detectProfile(args: string[]): DetectedProfile { ... }
-
-// CORRECT: Inferred types for internal functions
-const formatName = (name: string) => name.trim().toLowerCase();
-
-// INCORRECT: any type
-function processData(data: any) { ... }  // Use unknown or proper type
-```
-
-### Type Exports
-
-```typescript
-// CORRECT: Use type keyword for type-only exports
-export type { Config, Settings } from './config';
-
-// CORRECT: Group type exports in barrel
-export type {
-  PlatformInfo,
-  BinaryInfo,
-  DownloadProgress,
-} from './types';
-```
-
----
-
-## ESLint Rules (Enforced)
-
-| Rule | Level | Notes |
-|------|-------|-------|
-| `@typescript-eslint/no-unused-vars` | error | Ignore `_` prefix |
-| `@typescript-eslint/no-explicit-any` | error | Use proper types |
-| `@typescript-eslint/no-non-null-assertion` | error | No `!` assertions |
-| `prefer-const` | error | Immutable by default |
-| `no-var` | error | Use const/let |
-| `eqeqeq` | error | Strict equality |
-| `react-hooks/*` | recommended | (UI only) |
-
----
-
-## Terminal Output Standards
-
-### CCS Logging Standards
-
-- Use the shared logger from `src/services/logging/` for CCS-owned runtime diagnostics, request tracing, and structured events.
-- Keep `utils/ui` and deliberate `console.log`/`console.error` output for user-facing CLI UX only.
-- Redact secrets before persistence; never write raw tokens, cookies, API keys, or password hashes into CCS-owned logs.
-- Persist CCS-owned logs only under `getCcsDir()/logs`; do not invent per-feature log roots.
-- When adding dashboard polling or diagnostics routes, prevent them from recursively logging the log viewer itself.
-
-### ASCII Only
-
-```typescript
-// CORRECT
-console.log('[OK] Operation successful');
-console.log('[!] Warning message');
-console.log('[X] Error occurred');
-console.log('[i] Information');
-
-// INCORRECT - NO EMOJIS
-console.log('Operation successful');  // NO
-console.log('Warning message');       // NO
-```
-
-### Color Handling
-
-```typescript
-import { colors } from '../utils/ui';
-
-// Colors are TTY-aware and respect NO_COLOR
-console.log(colors.green('[OK]') + ' Operation successful');
-```
-
-### Box Borders
-
-Use ASCII box drawing for error displays:
-
-```
-+=====================================+
-|  [X] ERROR: Configuration failed    |
-|                                     |
-|  Details: Unable to parse config    |
-+=====================================+
-```
-
-### Cross-Platform Adapter Spawning
-
-When implementing target adapters, handle platform differences for binary spawning:
-
-```typescript
-// Window shell detection (.cmd, .bat, .ps1 require shell)
-const needsShell = isWindows && /\.(cmd|bat|ps1)$/i.test(binaryPath);
-
-if (needsShell) {
-  // Escape arguments and use shell: true
-  const cmdString = [binaryPath, ...args].map(escapeShellArg).join(' ');
-  spawn(cmdString, { shell: true, stdio: 'inherit' });
-} else {
-  // Direct spawn (Unix-like, unshelled Windows executables)
-  spawn(binaryPath, args, { stdio: 'inherit' });
-}
-```
-
-This pattern is used in both `ClaudeAdapter` and `DroidAdapter` to ensure cross-platform consistency.
-
-For all Claude child-process launches (delegation, adapters, proxies, helper spawners), sanitize env before spawn:
-
-```typescript
-const cleanEnv = stripClaudeCodeEnv(mergedEnv); // case-insensitive remove of CLAUDECODE
-spawn(binaryPath, args, { env: cleanEnv, stdio: 'inherit' });
-```
-
-This prevents Claude Code nested-session guard failures when CCS runs inside parent Claude sessions.
-
----
-
-## React Component Standards (UI)
-
-### Component Structure
-
-```typescript
-// component-name.tsx
-
-// 1. Imports (grouped: react, external, internal, relative)
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { useProfiles } from '@/hooks';
-import { formatName } from './utils';
-import type { ComponentProps } from './types';
-
-// 2. Types (if not in separate file)
-interface Props {
-  id: string;
-  onSave: () => void;
-}
-
-// 3. Component
-export function ComponentName({ id, onSave }: Props) {
-  // Hooks first
-  const profiles = useProfiles();
-  const [state, setState] = useState(null);
-
-  // Handlers
-  const handleClick = () => { ... };
-
-  // Render
-  return ( ... );
-}
-```
-
-### Naming Conventions
-
-| Item | Convention | Example |
-|------|------------|---------|
-| Component files | kebab-case.tsx | `provider-editor.tsx` |
-| Component exports | PascalCase | `ProviderEditor` |
-| Hook files | use-*.ts | `use-profiles.ts` |
-| Hook exports | useCamelCase | `useProfiles` |
-| Utility files | kebab-case.ts | `path-utils.ts` |
-| Utility exports | camelCase | `formatPath` |
-
----
-
-## Input State Persistence Patterns
-
-When building forms and editors that allow users to make changes, follow these patterns to prevent data loss.
-
-### Pattern 1: Key-Based Remounting
-
-**Use when**: Component has complex local state that should reset on prop changes.
-
-```typescript
-// Parent component
-<ProfileEditor
-  key={profileId}  // Forces remount when profile changes
-  profileId={profileId}
-  onSave={handleSave}
-/>
-```
-
-**Why**: Without `key`, React reuses the component instance. Local `useState` values persist even when props change, causing stale data bugs.
-
-### Pattern 2: Unsaved Changes Confirmation
-
-**Use when**: User might navigate away while editing.
-
-```typescript
-// Parent tracks dirty state
-const [editorHasChanges, setEditorHasChanges] = useState(false);
-const [pendingSwitch, setPendingSwitch] = useState<string | null>(null);
-
-// Child notifies parent of dirty state
-useEffect(() => {
-  onHasChangesUpdate?.(computedHasChanges);
-}, [computedHasChanges, onHasChangesUpdate]);
-
-// Intercept navigation
-const handleSelect = (id: string) => {
-  if (editorHasChanges && currentId !== id) {
-    setPendingSwitch(id);  // Show confirmation dialog
-  } else {
-    setCurrentId(id);
-  }
-};
-```
-
-**Flow**:
-1. Child computes `hasChanges` from local state vs saved data
-2. Child notifies parent via callback
-3. Parent intercepts navigation when dirty
-4. Show confirmation dialog: "Discard & Switch" or "Cancel"
-5. On confirm: reset dirty state, then switch
-
-### Pattern 3: Auto-Save with Visual Feedback
-
-**Use when**: Simple inputs that should save immediately.
-
-```typescript
-const [saved, setSaved] = useState(false);
-
-const handleBlur = async () => {
-  if (value !== savedValue) {
-    await saveToBackend(value);
-    setSaved(true);
-    setTimeout(() => setSaved(false), 2000);
-  }
-};
-
-return (
-  <div className="flex items-center gap-2">
-    <Input value={value} onChange={...} onBlur={handleBlur} />
-    {saved && (
-      <span className="text-green-600 text-xs flex items-center gap-1">
-        <Check className="w-3.5 h-3.5" /> Saved
-      </span>
-    )}
-  </div>
-);
-```
-
-**When to use which**:
-| Scenario | Pattern |
-|----------|---------|
-| Complex multi-field editor | Pattern 2 (confirmation dialog) |
-| Simple single input | Pattern 3 (auto-save + feedback) |
-| List item selection | Pattern 1 (key-based remount) + Pattern 2 |
-
----
-
-## Quality Gates
-
-### Pre-Commit Sequence
+These standards describe current repository practice. Enforced configuration
+and tests take precedence over prose.
+
+## Source of Truth
+
+| Contract | Authoritative source |
+| --- | --- |
+| TypeScript and CLI lint rules | [`eslint.config.mjs`](../eslint.config.mjs) |
+| Formatting | [`.prettierrc`](../.prettierrc) |
+| Root commands and test entry points | [`package.json`](../package.json) |
+| UI commands and dependencies | [`ui/package.json`](../ui/package.json) |
+| Commit syntax | [`commitlint.config.cjs`](../commitlint.config.cjs) |
+| Release effects | [`.releaserc.cjs`](../.releaserc.cjs) |
+| Repository workflow | [`CLAUDE.md`](../CLAUDE.md) and [`CONTRIBUTING.md`](../CONTRIBUTING.md) |
+
+Update this document when one of those contracts changes. Do not duplicate
+exhaustive rule, command, target, or dependency lists here.
+
+## Design Priorities
+
+Apply these in order:
+
+1. **YAGNI**: build only behavior required by the accepted scope.
+2. **KISS**: prefer a small local change over a new abstraction or dependency.
+3. **DRY**: share stable domain behavior, not incidental similarity.
+
+Preserve public contracts unless the change intentionally updates them. Error
+messages should explain recovery, and configuration changes should remain
+CLI-complete with dashboard parity where the feature supports both surfaces.
+
+## Organization and Imports
+
+- Keep code inside the domain that owns its behavior.
+- Split files at cohesive boundaries such as types, pure utilities, lifecycle
+  services, hooks, or view components.
+- Follow nearby naming and import patterns. New TypeScript files normally use
+  descriptive kebab-case names.
+- There is no universal maximum directory depth.
+- Barrel exports are optional compatibility boundaries, not a repository-wide
+  requirement. Preserve an existing barrel when consumers depend on it; use a
+  direct import when that is the local pattern or the symbol is intentionally
+  private.
+- Before creating a module, check whether the runtime, standard library,
+  installed dependencies, or an existing repository utility already owns the
+  behavior.
+
+## File Size
+
+Two different thresholds serve different purposes:
+
+- **200 lines is a review heuristic.** When a code file grows beyond roughly
+  200 lines, check whether it contains multiple responsibilities. A cohesive
+  file may remain larger.
+- **400 lines is the current CLI lint warning.**
+  [`eslint.config.mjs`](../eslint.config.mjs) configures `max-lines` as a
+  warning for `src/**/*.ts`, excluding blank lines and comments.
+
+Do not split mechanically to satisfy a number. Split when the result improves
+ownership, testing, reuse, or reviewability. Preserve existing exports and
+behavior when they are part of a consumed contract.
+
+## TypeScript and Linting
+
+The CLI uses strict TypeScript. Current enforced CLI rules include:
+
+- no explicit `any`
+- no non-null assertions
+- no unused variables, except names intentionally prefixed with `_`
+- `prefer-const`, `no-var`, and strict equality
+
+Use `unknown` at untrusted boundaries and narrow it before use. Keep types close
+to their owning domain; export types only when another module consumes them.
+
+New generic `throw new Error(...)` sites are blocked by the local
+`ccs/no-new-throw-error` rule. Use the typed errors in
+[`src/errors/error-types.ts`](../src/errors/error-types.ts) so
+[`src/errors/error-handler.ts`](../src/errors/error-handler.ts) can map failures
+consistently. The generated baseline in
+[`eslint-rules/throw-error-baseline.json`](../eslint-rules/throw-error-baseline.json)
+grandfathers existing sites; do not expand it to bypass a new error design.
+
+## Terminal and Process Behavior
+
+- CLI terminal output is ASCII only: `[OK]`, `[!]`, `[X]`, `[i]`.
+- Respect `NO_COLOR` and TTY-aware output.
+- Prefer argument arrays when spawning processes. When a platform wrapper
+  requires a shell, use the existing quoting and wrapper utilities rather than
+  interpolating untrusted input.
+- Preserve target-specific stdio, signal, and exit-code behavior. The adapter
+  contract lives in
+  [`src/targets/target-adapter.ts`](../src/targets/target-adapter.ts).
+
+## Target Adapters
+
+Runtime target behavior is divided across:
+
+| Concern | Source |
+| --- | --- |
+| Target names, aliases, persistence | [`src/targets/target-metadata.ts`](../src/targets/target-metadata.ts) |
+| Selection priority and flag parsing | [`src/targets/target-resolver.ts`](../src/targets/target-resolver.ts) |
+| Adapter contract | [`src/targets/target-adapter.ts`](../src/targets/target-adapter.ts) |
+| Registration and lookup | [`src/targets/target-registry.ts`](../src/targets/target-registry.ts) |
+| Startup registration | [`src/ccs.ts`](../src/ccs.ts) |
+
+A target change should update metadata, implementation, registration, tests,
+help text, and public documentation as applicable. Do not copy the target list
+into new guides; link to metadata when maintainers need the current set.
+
+## Configuration and Test Isolation
+
+- Treat persisted environment values as strings.
+- Route CCS paths through `getCcsDir()` in
+  [`src/utils/config-manager.ts`](../src/utils/config-manager.ts).
+- Never run tests against a contributor's real `~/.ccs/` or `~/.claude/`.
+  Set `CCS_HOME` to a temporary directory.
+- Preserve documented configuration and profile-resolution priority. Add a
+  focused test when changing precedence or fallback behavior.
+- Treat Docker service `ccs` and network `ccs-net` as public contracts; see
+  [`CONTRIBUTING.md`](../CONTRIBUTING.md#if-you-change-the-docker-network-or-service-name).
+
+## Dashboard Code
+
+- Keep page orchestration in `ui/src/pages/`, reusable UI in
+  `ui/src/components/`, server-state access in `ui/src/hooks/`, and shared
+  helpers in `ui/src/lib/` when that matches the owning domain.
+- Preserve unsaved input across background refreshes. Destructive replacement
+  of dirty state requires an explicit user action or confirmation.
+- Use the existing API and query helpers before adding a new data-access layer.
+- Keep accessibility, keyboard interaction, responsive layout, loading,
+  empty, and error states in scope for user-facing changes.
+- Locale codes and normalization are owned by
+  [`ui/src/lib/locales.ts`](../ui/src/lib/locales.ts); translations are wired
+  through [`ui/src/lib/i18n.ts`](../ui/src/lib/i18n.ts).
+
+The UI has its own ESLint, TypeScript, Prettier, and Vitest configuration.
+Verify commands against [`ui/package.json`](../ui/package.json).
+
+## Tests and Quality Gates
+
+The root TypeScript suites run with Bun's test runner. The dashboard uses
+Vitest. Native shell and PowerShell probes cover platform-specific behavior.
+See [`tests/README.md`](../tests/README.md) for ownership and commands.
+
+Run the smallest relevant test first, then the normal gate:
 
 ```bash
-# Main project
 bun run format
 bun run lint:fix
 bun run validate
-bun run validate:ci-parity
+```
 
-# UI project (if changed)
+Before review or merge confidence:
+
+```bash
+bun run validate:ci-parity
+```
+
+For dashboard changes:
+
+```bash
 cd ui
 bun run format
-bun run lint:fix
 bun run validate
+bun run test:run
 ```
 
-### Validate Runs
+Do not weaken or skip a failing check to make a change pass. If a full gate
+cannot run, report the exact focused checks completed and the blocker.
 
-| Project | Command | Checks |
-|---------|---------|--------|
-| Main | `bun run validate` | typecheck + lint + format:check + test:fast |
-| UI | `bun run validate` | typecheck + lint + format:check |
+## Commits and Releases
 
----
+Commitlint accepts conventional types defined in
+[`commitlint.config.cjs`](../commitlint.config.cjs), with a 100-character header
+limit. Use focused subjects such as:
 
-## Conventional Commits
-
-All commits must follow conventional commit format:
-
-```
-<type>(<scope>): <description>
+```text
+fix(doctor): handle missing config
+feat(cliproxy): add provider quota check
+docs(contributing): clarify validation
 ```
 
-### Types
+Semantic-release owns versions, changelog entries, tags, npm publishing, and
+GitHub releases. Do not bump versions, tag, or publish manually. Release effects
+for each branch and commit type are defined in
+[`.releaserc.cjs`](../.releaserc.cjs).
 
-| Type | When to Use | Version Bump |
-|------|-------------|--------------|
-| `feat` | New feature | MINOR |
-| `fix` | Bug fix | PATCH |
-| `perf` | Performance | PATCH |
-| `docs` | Documentation | None |
-| `style` | Formatting | None |
-| `refactor` | Code restructure | None |
-| `test` | Tests | None |
-| `chore` | Maintenance | None |
+## Documentation Triggers
 
-### Examples
+Update the owning guide when a change affects behavior, commands, setup,
+architecture, security posture, public contracts, or future maintainer
+decisions. Start at [`docs/README.md`](./README.md). Public CLI, provider,
+configuration, installation, or workflow changes also require the matching page
+in the separate `kaitranntt/ccs-docs` repository; see the docs index for
+checkout guidance.
 
-```bash
-# Correct
-git commit -m "feat(cliproxy): add OAuth token refresh"
-git commit -m "fix(doctor): handle missing config gracefully"
-git commit -m "refactor(ui): split provider-editor into modules"
-
-# Incorrect - REJECTED
-git commit -m "added new feature"
-git commit -m "Fixed bug"
-```
-
----
-
-## Anti-Patterns to Avoid
-
-### 1. God Files
-
-```typescript
-// BAD: One file doing everything
-// src/utils.ts (2000 lines with mixed concerns)
-
-// GOOD: Split by domain
-// src/utils/ui/colors.ts
-// src/utils/ui/boxes.ts
-// src/utils/shell-executor.ts
-// src/utils/config-manager.ts
-```
-
-### 2. Barrel Import Bypass
-
-```typescript
-// BAD: Direct import bypassing barrel
-import { detectPlatform } from '../cliproxy/platform-detector';
-
-// GOOD: Import from domain barrel
-import { detectPlatform } from '../cliproxy';
-```
-
-### 3. Inline Everything
-
-```typescript
-// BAD: Huge inline functions in components
-function Component() {
-  const handleComplexOperation = () => {
-    // 100 lines of logic...
-  };
-}
-
-// GOOD: Extract to hooks or utilities
-function Component() {
-  const { handleComplexOperation } = useComplexOperation();
-}
-```
-
-### 4. Type Duplication
-
-```typescript
-// BAD: Same types defined in multiple files
-// file1.ts
-interface Config { ... }
-// file2.ts
-interface Config { ... }
-
-// GOOD: Single source of truth
-// types/config.ts
-export interface Config { ... }
-```
-
-### 5. Config Priority Pattern
-
-When resolving configuration from multiple sources, follow this priority order:
-
-```typescript
-// proxy-config-resolver.ts pattern
-// Priority: CLI flags > Environment variables > config.yaml > defaults
-
-const resolved = {
-  ...DEFAULT_CONFIG,                    // 4. Defaults (lowest)
-  ...yamlConfig,                        // 3. config.yaml
-  ...envConfig,                         // 2. Environment variables
-  ...cliFlags,                          // 1. CLI flags (highest)
-};
-```
-
-This pattern is used in:
-- `src/cliproxy/proxy-config-resolver.ts` - Remote proxy config
-- `src/config/unified-config-loader.ts` - Main config loading
-
----
-
-## Lint Enforcement Gates
-
-Two ESLint gates (`eslint.config.mjs`) lock in the maintainability epic's gains:
-
-- **`ccs/no-new-throw-error`** (error): flags new `throw new Error(...)`. Use a typed error from `src/errors/error-types.ts` (`AuthError`, `ConfigError`, `ProfileError`, `ProviderError`, `NetworkError`, `ProxyError`, `MigrationError`, `ValidationError`, `RetryableError`) so `handleError` emits a differentiated exit code. Existing ~340 sites are grandfathered in `eslint-rules/throw-error-baseline.json`; only **new** violations error. Regenerate the baseline when intentionally grandfathering a new site, or quarterly to prune converted entries:
-  ```bash
-  node scripts/generate-throw-error-baseline.js
-  ```
-- **`max-lines`** (warn, 400): warns on source files over 400 lines (`skipBlankLines`, `skipComments`). Split via the Monster File Splitting methodology above (barrel `index.ts` preserves the public API).
-
-When the no-throw rule blocks a change, prefer converting to the matching typed error. Only add to the baseline when the throw is genuinely out of scope to convert (and regenerate the baseline so the entry is explicit, not silent).
-
-## Related Documentation
-
-- [Codebase Summary](./codebase-summary.md) - Full directory structure
-- [System Architecture](./system-architecture/index.md) - Architecture diagrams
-- [CLAUDE.md](../CLAUDE.md) - AI-facing development guidance
+Prefer source links over copied trees and metrics. Remove stale sections rather
+than leaving TODO markers.

--- a/docs/codebase-summary.md
+++ b/docs/codebase-summary.md
@@ -1,673 +1,173 @@
 # CCS Codebase Summary
 
-Last Updated: 2026-05-18
-
-Comprehensive overview of the modularized CCS codebase structure following the Phase 9 modularization effort (Settings, Analytics, Auth Monitor splits + Test Infrastructure), v7.1 Remote CLIProxy feature, v7.2 Kiro + GitHub Copilot (ghcp) OAuth providers, v7.14 Hybrid Quota Management, v7.34 Image Analysis Hook, account-context validation hardening, Official Claude Channels runtime support, native Codex runtime target support, native Codex/Droid usage collectors, and models.dev-backed model pricing metadata.
-
-## Repository Structure
-
-```
-ccs/
-├── src/                      # CLI TypeScript source
-├── dist/                     # Compiled JavaScript (npm package)
-├── lib/                      # Native shell scripts (bash, PowerShell)
-├── ui/                       # React dashboard application
-│   ├── src/                  # UI source code
-│   └── dist/                 # Built UI bundle
-├── docker/                   # Docker deployment configuration
-│   ├── Dockerfile            # Multi-stage build (bun 1.2.21, node:20-bookworm-slim)
-│   ├── docker-compose.yml    # Compose setup with resource limits, healthcheck
-│   ├── entrypoint.sh         # Entrypoint with privilege dropping, usage help
-│   └── README.md             # Docker deployment guide
-├── tests/                    # Test suites
-├── docs/                     # Documentation
-└── assets/                   # Static assets (logos, screenshots)
-```
-
----
-
-## CLI Source (`src/`)
-
-The main CLI is organized into domain-specific modules with barrel exports.
-
-### Directory Structure
-
-```
-src/
-├── ccs.ts                    # Main entry point & profile execution flow
-├── bin/                      # Dedicated runtime entrypoints
-│   ├── droid-runtime.ts      # Forces droid target for ccs-droid / ccsd package bins
-│   ├── codex-runtime.ts      # Forces codex target for ccs-codex / ccsx package bins
-│   └── ccsxp-runtime.ts      # Forces codex target + native cliproxy override for ccsxp
-├── types/                    # TypeScript type definitions
-│   ├── index.ts              # Barrel export (aggregates all types)
-│   ├── cli.ts                # CLI types (ParsedArgs, ExitCode)
-│   ├── config.ts             # Config types (Settings, EnvVars)
-│   ├── delegation.ts         # Delegation types (sessions, events)
-│   ├── glmt.ts               # Legacy transformer types (messages, transforms)
-│   └── utils.ts              # Utility types (ErrorCode, LogLevel)
-│
-├── commands/                 # CLI command handlers
-│   ├── api-command/          # API profile subcommands (split facade + handlers)
-│   │   ├── index.ts          # API command facade/router
-│   │   ├── shared.ts         # Shared API arg parsing helpers
-│   │   └── [subcommand files...]
-│   ├── cliproxy-command.ts   # CLIProxy subcommand handling
-│   ├── config-command.ts     # Config management commands
-│   ├── config-image-analysis-command.ts  # First-class ImageAnalysis config (NEW v7.34)
-│   ├── named-command-router.ts  # Reusable named-command dispatcher
-│   ├── doctor-command.ts     # Health diagnostics
-│   ├── env-command.ts        # Export shell env vars for third-party tools (v7.39)
-│   ├── help-command.ts       # Help text generation
-│   ├── install-command.ts    # Install/uninstall logic
-│   ├── root-command-router.ts  # Extracted top-level command dispatch from ccs.ts
-│   ├── shell-completion-command.ts
-│   ├── sync-command.ts       # Symlink synchronization
-│   ├── update-command.ts     # Self-update logic
-│   └── version-command.ts    # Version display
-│
-├── targets/                  # Multi-target adapter system (NEW)
-│   ├── index.ts              # Barrel export
-│   ├── target-adapter.ts     # TargetAdapter interface contract
-│   ├── target-registry.ts    # Registry for runtime adapter lookup
-│   ├── target-resolver.ts    # Resolution logic (flag > runtime entrypoint / argv[0] > config)
-│   ├── target-metadata.ts    # Runtime vs persisted target metadata and alias lists
-│   ├── target-runtime-compatibility.ts # Guardrails for target/profile combinations
-│   ├── claude-adapter.ts     # Claude Code CLI implementation
-│   ├── droid-adapter.ts      # Factory Droid CLI implementation
-│   ├── codex-adapter.ts      # Native Codex CLI implementation
-│   ├── codex-detector.ts     # Codex binary detection and capability probing
-│   ├── droid-detector.ts     # Droid binary detection & version checks
-│   └── droid-config-manager.ts  # ~/.factory/settings.json management
-│
-├── auth/                     # Authentication module
-│   ├── index.ts              # Barrel export
-│   ├── commands/             # Auth-specific CLI commands
-│   │   └── index.ts
-│   ├── account-switcher.ts   # Account switching logic
-│   └── profile-detector.ts   # Profile detection (474 lines)
-│
-├── config/                   # Configuration management
-│   ├── index.ts              # Barrel export
-│   ├── unified-config-loader.ts  # Central config loader (546 lines)
-│   └── migration-manager.ts  # Config migration logic
-│
-├── proxy/                    # OpenAI-compatible proxy runtime
-│   ├── index.ts              # Barrel export
-│   ├── proxy-daemon-entry.ts # Daemon entrypoint
-│   ├── proxy-daemon.ts       # Lifecycle, health, and port binding
-│   ├── proxy-port-resolver.ts # Adaptive per-profile port selection
-│   ├── request-router.ts     # Request-time profile/model routing
-│   ├── profile-router.ts     # Profile resolution helpers
-│   ├── proxy-env.ts          # Local runtime env construction
-│   ├── routing-config.ts     # Proxy routing config parsing
-│   ├── upstream-url.ts       # Upstream endpoint resolution
-│   ├── proxy-daemon-state.ts # Persistent running-state metadata
-│   ├── server/               # HTTP server and routes
-│   └── transformers/         # Request and SSE translation
-│
-├── channels/                 # Official Claude channel integration
-│   ├── official-channels-runtime.ts  # Runtime gating, plugin specs, setup guidance
-│   └── official-channels-store.ts    # Claude channel token/env storage helpers
-│
-├── cliproxy/                 # CLIProxyAPI integration (heavily modularized)
-│   ├── index.ts              # Barrel export (137 lines, extensive)
-│   ├── auth/                 # OAuth handlers, token management
-│   │   └── index.ts
-│   ├── binary/               # Binary management
-│   │   └── index.ts
-│   ├── services/             # Service layer
-│   │   └── index.ts
-│   ├── cliproxy-executor.ts  # Main executor (666 lines)
-│   ├── config-generator.ts   # Config file generation (531 lines)
-│   ├── account-manager.ts    # Account management (509 lines)
-│   ├── quota-manager.ts      # Hybrid quota management (NEW v7.14)
-│   ├── quota-fetcher.ts      # Provider quota API integration (NEW v7.14)
-│   ├── platform-detector.ts  # OS/arch detection
-│   ├── binary-manager.ts     # Binary download/update
-│   ├── auth-handler.ts       # Authentication handling
-│   ├── model-catalog.ts      # Provider model definitions
-│   ├── model-config.ts       # Model configuration
-│   ├── codex-plan-compatibility.ts  # Codex free/paid model fallback guardrails
-│   ├── service-manager.ts    # Background service
-│   ├── proxy-detector.ts     # Running proxy detection
-│   ├── startup-lock.ts       # Race condition prevention
-│   ├── remote-proxy-client.ts    # Remote proxy health checks (v7.1)
-│   ├── proxy-config-resolver.ts  # CLI/env/config merging (v7.1)
-│   ├── types.ts              # ResolvedProxyConfig for local/remote modes
-│   └── [more files...]
-│
-├── copilot/                  # GitHub Copilot integration
-│   ├── index.ts              # Barrel export
-│   └── copilot-package-manager.ts  # Package management (515 lines)
-│
-├── glmt/                     # Legacy transformer internals kept for compatibility
-│   ├── index.ts              # Barrel export
-│   ├── pipeline/             # Processing pipeline
-│   │   └── index.ts
-│   ├── glmt-proxy.ts         # Legacy proxy runtime kept for internal compatibility
-│   └── delta-accumulator.ts  # Delta processing (484 lines)
-│
-├── delegation/               # Task delegation & headless execution
-│   ├── index.ts              # Barrel export
-│   ├── executor/             # Execution engine
-│   └── [delegation files...]
-│
-├── errors/                   # Centralized error handling
-│   ├── index.ts              # Barrel export
-│   ├── error-handler.ts      # Main error handler
-│   ├── exit-codes.ts         # Exit code definitions
-│   └── cleanup.ts            # Cleanup logic
-│
-├── management/               # Doctor diagnostics
-│   ├── index.ts              # Barrel export
-│   ├── checks/               # Diagnostic checks
-│   │   ├── index.ts
-│   │   └── image-analysis-check.ts  # ImageAnalysis runtime validation (NEW v7.34)
-│   └── repair/               # Auto-repair logic
-│       └── index.ts
-│
-├── api/                      # API utilities & services
-│   ├── index.ts              # Barrel export
-│   └── services/             # API services
-│       ├── index.ts
-│       ├── profile-reader.ts
-│       └── profile-writer.ts
-│
-├── utils/                    # Utilities (modularized into subdirs)
-│   ├── index.ts              # Barrel export
-│   ├── ui/                   # Terminal UI utilities
-│   │   ├── index.ts
-│   │   ├── boxes.ts          # Box drawing
-│   │   ├── colors.ts         # Terminal colors
-│   │   └── spinners.ts       # Progress spinners
-│   ├── websearch/            # Search tool integrations
-│   │   └── index.ts
-│   ├── hooks/                # Claude Code compatibility hooks (NEW v7.34)
-│   │   ├── index.ts
-│   │   ├── image-analyzer-hook-installer.ts
-│   │   ├── image-analyzer-hook-configuration.ts
-│   │   ├── image-analyzer-profile-hook-injector.ts
-│   │   └── get-image-analysis-hook-env.ts
-│   ├── image-analysis/       # ImageAnalysis MCP/runtime utilities (NEW v7.34)
-│   │   ├── index.ts
-│   │   ├── hook-installer.ts
-│   │   ├── mcp-installer.ts
-│   │   └── claude-tool-args.ts
-│   └── [utility files...]
-│
-└── web-server/               # Express web server (heavily modularized)
-    ├── index.ts              # Server entry & barrel export
-    ├── routes/               # 15+ route handlers
-    │   ├── index.ts
-    │   ├── accounts-route.ts
-    │   ├── auth-route.ts
-    │   ├── channels-routes.ts
-    │   ├── cliproxy-route.ts
-    │   ├── copilot-route.ts
-    │   ├── doctor-route.ts
-    │   ├── glmt-route.ts
-    │   ├── health-route.ts
-    │   ├── profiles-route.ts
-    │   └── [more routes...]
-    ├── health/               # Health check system
-    │   └── index.ts
-    ├── usage/                # Usage analytics module (default Claude, CCS instances, native Codex/Droid, CLIProxy snapshots)
-    │   ├── index.ts
-    │   ├── handlers.ts       # Request handlers (633 lines)
-    │   ├── aggregator.ts     # Data aggregation (538 lines)
-    │   ├── codex-native-usage-collector.ts  # Native Codex rollout JSONL collector
-    │   ├── droid-native-usage-collector.ts  # Native Droid SQLite collector
-    │   └── data-aggregator.ts
-    ├── models-dev/           # Cached models.dev metadata/pricing registry integration
-    │   ├── registry-cache.ts
-    │   ├── pricing-resolver.ts
-    │   └── types.ts
-    ├── services/             # Shared services
-    │   └── index.ts
-    └── model-pricing.ts      # Static pricing fallback + models.dev resolver
-```
-
-### Module Categories
-
-| Category | Directories | Purpose |
-|----------|-------------|---------|
-| Core | `commands/`, `errors/` | CLI commands, error handling |
-| Targets | `bin/`, `targets/` | Multi-CLI adapter pattern (Claude Code, Factory Droid, Codex CLI, extensible) |
-| Auth | `auth/`, `cliproxy/auth/` | Authentication across providers |
-| Config | `config/`, `types/` | Configuration & type definitions |
-| OpenAI Proxy | `proxy/` | Adaptive local OpenAI-compatible proxy runtime, profile routing, and SSE transforms |
-| Providers | `cliproxy/`, `copilot/`, `glmt/` | Provider integrations plus retained legacy transformer internals |
-| Quota | `cliproxy/quota-*.ts`, `account-manager.ts` | Hybrid quota management (v7.14) |
-| Remote Proxy | `cliproxy/remote-*.ts`, `proxy-config-resolver.ts` | Remote CLIProxy support (v7.1) |
-| Image Analysis | `utils/image-analysis/`, `utils/hooks/` | Vision model proxying (v7.34) |
-| Services | `web-server/`, `api/` | HTTP server, API services |
-| Utilities | `utils/`, `management/` | Helpers, diagnostics |
-
-### Account Context Metadata Flow
-
-- Source fields: `accounts.<name>.context_mode`, `accounts.<name>.context_group`, `accounts.<name>.continuity_mode` in `~/.ccs/config.yaml`.
-- Runtime policy resolver: `src/auth/account-context.ts`.
-- Metadata storage normalization: `src/auth/profile-registry.ts`.
-- API write validation: `PUT /api/config` in `src/web-server/routes/config-routes.ts`.
-- Rules:
-  - mode is isolation-first (`isolated` default, `shared` opt-in)
-  - shared mode requires non-empty valid `context_group`
-  - shared mode continuity depth is `standard` by default, optional `deeper`
-  - `context_group` is normalized (trim + lowercase + whitespace collapse to `-`)
-  - API route rejects `context_group`/`continuity_mode` when mode is not `shared`
-  - registry normalization drops malformed persisted `context_group` values
-
-### Shared Plugin Layout
-
-- Shared payload owner: `src/management/shared-manager.ts`.
-- Profile entry point: `src/management/instance-manager.ts`.
-- `plugins/marketplaces/`, `plugins/cache/`, and `installed_plugins.json` stay shared through the `~/.ccs/shared/` topology.
-- `known_marketplaces.json` is now instance-local under `~/.ccs/instances/<profile>/plugins/` so Claude Code validates `installLocation` against the active `CLAUDE_CONFIG_DIR` instead of a last-writer-wins shared file.
-
-### Official Claude Channels
-
-- Runtime contract lives in `src/channels/official-channels-runtime.ts` and is consumed from `src/ccs.ts`, `src/commands/config-channels-command.ts`, and `src/web-server/routes/channels-routes.ts`.
-- Canonical config lives under `channels.*` in `~/.ccs/config.yaml`; legacy `discord_channels.*` remains read-compatible only when canonical fields are absent.
-
-### Native Codex Runtime Target
-
-- Dedicated runtime entrypoints: `ccs-codex` and `ccsx` resolve through `src/bin/codex-runtime.ts`, while `ccsxp` resolves through `src/bin/ccsxp-runtime.ts`; all three set `CCS_INTERNAL_ENTRY_TARGET=codex` before delegating to `src/targets/target-resolver.ts`.
-- Native Codex passthrough: `ccsx --help`, `ccsx --version`, and known upstream Codex subcommands such as `ccsx exec ...`, `ccsx apply ...`, `ccsx mcp ...`, `ccsx plugin ...`, `ccsx completion ...`, and `ccsx resume ...` short-circuit before CCS profile detection; upstream aliases such as `ccsx e ...` and `ccsx a ...` are included. CCS-owned `ccsx auth`, `ccsx doctor`, and `ccsx update` remain reserved for CCS.
-- Provider shortcut behavior: `ccsxp` strips user-supplied `--target` overrides and prepends `--config model_provider="cliproxy"` so it behaves like native Codex plus the CLIProxy provider recipe. The stricter CCS-managed bridge remains available explicitly through `ccs codex --target codex`. It pins `CODEX_HOME` to native `~/.codex` by default so inherited launcher state does not send history/config writes to a nonstandard Codex root; `CCSXP_CODEX_HOME` is the explicit override. On launch, CCS repairs the native `[model_providers.cliproxy]` stanza in `config.toml`, preserves a valid custom `base_url`, reads that provider's configured `env_key` (default `CLIPROXY_API_KEY`), and injects the effective CLIProxy auth token into that key for the child Codex process.
-- Implicit Codex launches such as `ccs --target codex` and `ccsxp` use native Codex default mode even when the CCS default profile is a Claude account. Explicit unsupported profiles such as `ccs work --target codex` still fail fast with native-vs-pool guidance.
-- `argv[0]` alias mapping still exists in `src/targets/target-resolver.ts` for same-binary/custom alias scenarios, but the built-in npm bins above do not depend on that map at runtime.
-- Metadata boundary: `src/targets/target-metadata.ts` keeps Codex runtime-only in v1, so persisted default targets remain `claude | droid`.
-- Compatibility guardrails: `src/targets/target-runtime-compatibility.ts` centralizes which profile types can execute on Codex.
-- Adapter behavior: `src/targets/codex-adapter.ts` and `src/targets/codex-detector.ts` launch native Codex without rewriting `~/.codex/config.toml`; CCS-backed routes use transient `codex -c key=value` overrides and env-key injection.
-- Dashboard control center: `src/web-server/services/codex-dashboard-service.ts`, `src/web-server/routes/codex-routes.ts`, `ui/src/pages/codex.tsx`, and `ui/src/components/compatible-cli/codex-*.tsx` expose a split-view Codex dashboard with guided editors for top-level settings, trust, profiles, providers, MCP servers, and feature flags plus a raw TOML fallback.
-- Structured-edit boundary: guided Codex saves intentionally reserialize the whole TOML document, so comments/formatting are normalized and the raw editor remains the fidelity-preserving escape hatch.
-- Follow-up behavior: structured saves refresh the raw snapshot immediately, refresh discards stale raw drafts, structured controls stay disabled while raw TOML is dirty/invalid/unreadable, project trust paths must be absolute or `~/...`, unsupported upstream top-level shapes are preserved instead of deleted, and feature flags can be reset to default.
-- Supported Codex flows in v1:
-  - `default`
-  - CLIProxy provider `codex`
-  - settings/API profiles only when they resolve to a Codex CLIProxy bridge
-- Telegram and Discord bot tokens are intentionally written into Claude-managed machine state under `~/.claude/channels/<channel>/.env`, unless the official `*_STATE_DIR` environment override redirects that channel elsewhere.
-- iMessage is tokenless, macOS-only, and still depends on Claude-side plugin install plus OS permissions.
-- Auto-enable is gated on Bun availability, verified Claude Code v2.1.80+, verified `claude.ai` auth, native Claude `default/account` sessions, and per-channel setup readiness.
-- The dashboard channels section surfaces Bun/version/auth/state-scope status from `/api/channels`, preserves token drafts when save-follow-up refresh fails, and keeps unsupported selected iMessage visible only so it can be turned off.
-
-### Structured Logging Domain
-
-- CCS-owned runtime logging now lives in `src/services/logging/`.
-- The shared domain owns path resolution, redaction, rotation/pruning, buffered recent-entry reads, and the logger factory used by CLI/server/runtime code.
-- Dashboard exposure lives in `src/web-server/routes/logs-routes.ts`, `src/web-server/services/logs-dashboard-service.ts`, and `src/web-server/middleware/request-logging-middleware.ts`.
-- The native dashboard viewer lives at `ui/src/pages/logs.tsx` with supporting components under `ui/src/components/logs/` and hooks in `ui/src/hooks/use-logs.ts`.
-- Legacy CLIProxy error files still exist under `~/.ccs/cliproxy/logs` and are surfaced as a labeled legacy source rather than the primary CCS logging model.
-
-### Target Adapter Module
-
-The targets module provides an extensible interface for dispatching profiles to different CLI implementations.
-
-**Key components:**
-
-1. **TargetAdapter Interface** - Contract that each CLI implementation must fulfill:
-   - binary detection
-   - credential preparation
-   - target-specific args/env construction
-   - process execution
-   - profile compatibility checks
-
-2. **Target Resolution** - Priority order:
-   - `--target <cli>` flag (CLI argument)
-   - Explicit runtime entrypoint via `CCS_INTERNAL_ENTRY_TARGET` (used by `src/bin/droid-runtime.ts`, `src/bin/codex-runtime.ts`, and `src/bin/ccsxp-runtime.ts`)
-   - `argv[0]` detection for custom/same-binary runtime aliases
-   - Per-profile `target` field (from config.yaml)
-   - Default: `claude`
-
-3. **Implementations:**
-   - **ClaudeAdapter** - Wraps existing behavior; delivers credentials via environment variables
-   - **DroidAdapter** - New; writes to ~/.factory/settings.json and spawns with `-m custom:ccs-<profile>` flag
-
-4. **Registry** - Map-based lookup (O(1)) for registered adapters at runtime
-
-**Usage flow:**
-```
-Profile resolution (existing)
-  ↓
-Target resolution (via resolver.ts)
-  ↓
-Get adapter from registry
-  ↓
-Prepare credentials (adapter.prepareCredentials)
-  ↓
-Build args & env (adapter.buildArgs, buildEnv)
-  ↓
-Spawn target CLI (adapter.exec)
-```
-
----
-
-## UI Source (`ui/src/`)
-
-The React dashboard organized by domain with barrel exports at every level.
-
-### Directory Structure
-
-```
-ui/src/
-├── components/
-│   ├── index.ts              # Main barrel (aggregates all domains)
-│   │
-│   ├── account/              # Account management
-│   │   ├── index.ts          # Barrel export
-│   │   ├── accounts-table.tsx
-│   │   ├── add-account-dialog.tsx
-│   │   └── flow-viz/         # Flow visualization (split from 1,144-line file)
-│   │       ├── index.tsx     # Main component (200 lines)
-│   │       ├── account-card.tsx
-│   │       ├── account-card-stats.tsx
-│   │       ├── connection-timeline.tsx
-│   │       ├── flow-paths.tsx
-│   │       ├── flow-viz-header.tsx
-│   │       ├── provider-card.tsx
-│   │       ├── hooks.ts
-│   │       ├── types.ts
-│   │       ├── utils.ts
-│   │       ├── path-utils.ts
-│   │       └── zone-utils.ts
-│   │
-│   ├── analytics/            # Usage charts, stats cards
-│   │   ├── index.ts
-│   │   ├── cliproxy-stats-card.tsx
-│   │   └── usage-trend-chart.tsx
-│   │
-│   ├── cliproxy/             # CLIProxy configuration
-│   │   ├── index.ts          # Barrel export (30 lines)
-│   │   ├── provider-editor/  # Split from 921-line file
-│   │   │   ├── index.tsx     # Main editor (250 lines)
-│   │   │   └── [13 focused modules]
-│   │   ├── config/           # YAML editor, file tree
-│   │   │   ├── config-split-view.tsx
-│   │   │   ├── diff-dialog.tsx
-│   │   │   ├── file-tree.tsx
-│   │   │   └── yaml-editor.tsx
-│   │   ├── overview/         # Health lists, preferences
-│   │   │   ├── credential-health-list.tsx
-│   │   │   ├── model-preferences-grid.tsx
-│   │   │   └── quick-stats-row.tsx
-│   │   └── [7 top-level component files]
-│   │
-│   ├── copilot/              # Copilot settings
-│   │   ├── index.ts
-│   │   └── config-form/      # Split from 846-line file
-│   │       └── [13 focused modules]
-│   │
-│   ├── health/               # System health gauges
-│   │   └── index.ts
-│   │
-│   ├── layout/               # App structure
-│   │   ├── index.ts
-│   │   ├── sidebar.tsx
-│   │   └── footer.tsx
-│   │
-│   ├── monitoring/           # Error logs, auth monitor
-│   │   ├── index.ts
-│   │   ├── proxy-status-widget.tsx
-│   │   ├── auth-monitor/     # Split from 465-line file (8 files)
-│   │   │   ├── index.tsx     # Main component
-│   │   │   ├── types.ts
-│   │   │   ├── hooks.ts
-│   │   │   ├── utils.ts
-│   │   │   └── components/
-│   │   │       ├── live-pulse.tsx
-│   │   │       ├── inline-stats-badge.tsx
-│   │   │       ├── provider-card.tsx
-│   │   │       └── summary-card.tsx
-│   │   └── error-logs/       # Split from 617-line file
-│   │       └── [6 focused modules]
-│   │
-│   ├── profiles/             # Profile management
-│   │   ├── index.ts
-│   │   ├── profile-dialog.tsx
-│   │   ├── profile-create-dialog.tsx
-│   │   └── editor/           # Split from 531-line file
-│   │       └── [10 focused modules]
-│   │
-│   ├── setup/                # Quick setup wizard
-│   │   ├── index.ts
-│   │   └── wizard/           # Step-based wizard
-│   │       ├── index.tsx
-│   │       └── steps/
-│   │
-│   ├── shared/               # Reusable components (19 components)
-│   │   ├── index.ts
-│   │   ├── ccs-logo.tsx
-│   │   ├── code-editor.tsx
-│   │   ├── confirm-dialog.tsx
-│   │   ├── provider-icon.tsx
-│   │   ├── settings-dialog.tsx
-│   │   ├── stat-card.tsx
-│   │   └── [13 more shared components]
-│   │
-│   └── ui/                   # shadcn/ui primitives
-│       ├── button.tsx
-│       ├── card.tsx
-│       ├── dialog.tsx
-│       ├── searchable-select.tsx  # Shared searchable combobox for model pickers
-│       ├── sidebar.tsx       # Custom sidebar (674 lines)
-│       └── [UI primitives...]
-│
-├── contexts/                 # React Contexts
-│   ├── privacy-context.tsx
-│   ├── theme-context.tsx
-│   └── websocket-context.tsx
-│
-├── hooks/                    # Custom hooks (domain-prefixed)
-│   ├── use-accounts.ts
-│   ├── use-cliproxy.ts
-│   ├── use-health.ts
-│   ├── use-profiles.ts
-│   ├── use-websocket.ts
-│   └── [more hooks...]
-│
-├── lib/                      # Utilities
-│   ├── api.ts                # API client
-│   ├── model-catalogs.ts     # Model definitions
-│   └── utils.ts              # Helper functions
-│
-├── pages/                    # Page components (lazy-loaded)
-│   ├── analytics/            # Split from 420-line file (8 files)
-│   │   ├── index.tsx         # Main layout
-│   │   ├── types.ts          # Analytics types
-│   │   ├── hooks.ts          # Data fetching hooks
-│   │   ├── utils.ts          # Utility functions
-│   │   └── components/
-│   │       ├── analytics-header.tsx
-│   │       ├── analytics-skeleton.tsx
-│   │       ├── charts-grid.tsx
-│   │       └── cost-by-model-card.tsx
-│   ├── settings/             # Split from 1,781-line file (20 files)
-│   │   ├── index.tsx         # Main layout with lazy loading
-│   │   ├── context.tsx       # Settings provider wrapper
-│   │   ├── settings-context.ts
-│   │   ├── types.ts
-│   │   ├── hooks.ts          # Legacy re-exports
-│   │   ├── hooks/
-│   │   │   ├── index.ts
-│   │   │   ├── context-hooks.ts
-│   │   │   ├── use-official-channels-config.ts
-│   │   │   ├── use-settings-tab.ts
-│   │   │   ├── use-proxy-config.ts
-│   │   │   ├── use-websearch-config.ts
-│   │   │   ├── use-globalenv-config.ts
-│   │   │   └── use-raw-config.ts
-│   │   ├── components/
-│   │   │   ├── section-skeleton.tsx
-│   │   │   └── tab-navigation.tsx
-│   │   └── sections/
-│   │       ├── channels.tsx
-│   │       ├── globalenv-section.tsx
-│   │       ├── websearch/
-│   │       │   ├── index.tsx
-│   │       │   └── provider-card.tsx
-│   │       └── proxy/
-│   │           ├── index.tsx
-│   │           ├── local-proxy-card.tsx
-│   │           └── remote-proxy-card.tsx
-│   ├── api.tsx               # API profiles page (350 lines)
-│   ├── cliproxy.tsx          # CLIProxy page (405 lines)
-│   ├── copilot.tsx           # Copilot page (295 lines)
-│   └── health.tsx            # Health page (256 lines)
-│
-└── providers/                # Context providers
-    └── websocket-provider.tsx
-```
-
-### Component Statistics
-
-| Domain | Components | Subdirs | Split Files |
-|--------|------------|---------|-------------|
-| account | 3 | flow-viz (12 files) | 1 monster split |
-| analytics | 3 | - | - |
-| cliproxy | 10 | provider-editor, config, overview | 1 monster split |
-| copilot | 2 | config-form (13 files) | 1 monster split |
-| health | 2 | - | - |
-| layout | 3 | - | - |
-| monitoring | 3 | auth-monitor (8 files), error-logs (6 files) | 2 monster splits |
-| profiles | 4 | editor (10 files) | 1 monster split |
-| setup | 2 | wizard/steps | - |
-| shared | 19 | - | - |
-| **Total** | **51+** | **10 subdirs** | **7 splits** |
-
-### Page Statistics
-
-| Page | Structure | Files | Notes |
-|------|-----------|-------|-------|
-| analytics | Directory | 8 | Split 2025-12-21 |
-| settings | Directory | 20 | Split 2025-12-21, lazy-loaded sections |
-| api | Single file | 1 | 350 lines |
-| cliproxy | Single file | 1 | 405 lines |
-| copilot | Single file | 1 | 295 lines |
-| health | Single file | 1 | 256 lines |
-
----
-
-## Key File Metrics
-
-### Largest Files (Acceptable Exceptions)
-
-**CLI (`src/`):**
-
-| File | Lines | Status |
-|------|-------|--------|
-| model-pricing.ts | 920 | Static pricing fallback and resolver entrypoint |
-| glmt-proxy.ts | 675 | Legacy internal compatibility path - acceptable for now |
-| cliproxy-executor.ts | 666 | Core logic - acceptable |
-| cliproxy-command.ts | 634 | Could split if needed |
-| usage/handlers.ts | 633 | Could split if needed |
-| ccs.ts | 596 | Entry point - acceptable |
-| unified-config-loader.ts | 546 | Complex - acceptable |
-
-**UI (`ui/src/`):**
-
-| File | Lines | Status |
-|------|-------|--------|
-| components/ui/sidebar.tsx | 674 | shadcn - acceptable |
-| pages/cliproxy.tsx | 405 | Acceptable |
-| pages/api.tsx | 350 | Acceptable |
-| pages/copilot.tsx | 295 | Acceptable |
-| pages/health.tsx | 256 | Acceptable |
-
-**Split Files (Completed):**
-
-| Original | Lines | New Location | Files |
-|----------|-------|--------------|-------|
-| pages/settings.tsx | 1,781 | pages/settings/ | 20 |
-| pages/analytics.tsx | 420 | pages/analytics/ | 8 |
-| monitoring/auth-monitor.tsx | 465 | monitoring/auth-monitor/ | 8 |
-
----
-
-## Import Patterns
-
-### Standard Import Path
-
-```typescript
-// From any file in src/
-import { Config, Settings } from '../types';
-import { execClaudeWithCLIProxy } from '../cliproxy';
-import { handleError } from '../errors';
-
-// From any file in ui/src/
-import { AccountsTable, ProviderIcon, StatCard } from '@/components';
-import { useAccounts, useProfiles } from '@/hooks';
-```
-
-### Barrel Export Pattern
-
-Every domain directory has an `index.ts` that aggregates exports:
-
-```typescript
-// ui/src/components/cliproxy/index.ts
-export { CategorizedModelSelector } from './categorized-model-selector';
-export { CliproxyDialog } from './cliproxy-dialog';
-// ...
-
-// From subdirectories
-export { ProviderEditor } from './provider-editor';
-export type { ProviderEditorProps } from './provider-editor';
-```
-
----
-
-## Test Structure
-
-```
-tests/
-├── unit/                     # Unit tests (7 core test files)
-│   ├── data-aggregator.test.ts
-│   ├── cliproxy/
-│   │   └── remote-proxy-client.test.ts
-│   ├── commands/
-│   │   └── env-command.test.ts
-│   ├── jsonl-parser.test.ts
-│   ├── model-pricing.test.ts
-│   ├── unified-config.test.ts
-│   └── mcp-manager.test.ts
-├── integration/              # Integration tests
-├── native/                   # Native install tests
-│   ├── linux/
-│   ├── macos/
-│   └── windows/
-├── npm/                      # npm package tests
-├── shared/                   # Shared test utilities
-└── README.md
-```
-
-### Test Metrics
-
-| Metric | Value |
-|--------|-------|
-| Total Tests | 1440 |
-| Passing | 1440 |
-| Skipped | 6 |
-| Failed | 0 |
-| Coverage Threshold | 90% |
-| Test Files | 41 |
-
----
-
-## Build Outputs
-
-| Output | Source | Purpose |
-|--------|--------|---------|
-| `dist/` | `src/` | npm package (CLI) |
-| `dist/ui/` | `ui/src/` | Built React app (served by Express) |
-| `lib/` | N/A | Native shell scripts |
-
----
-
-## Related Documentation
-
-- [Code Standards](./code-standards.md) - Modularization patterns, file size rules
-- [System Architecture](./system-architecture/index.md) - High-level architecture diagrams
-- [Project Roadmap](./project-roadmap.md) - Modularization phases and future work
-- [WebSearch](./websearch.md) - WebSearch feature documentation
-- [Image Analysis](./image-analysis.md) - First-class ImageAnalysis runtime documentation
-- [CLAUDE.md](../CLAUDE.md) - AI-facing development guidance
+CCS is a TypeScript/Bun CLI and local React dashboard for selecting profiles,
+preparing provider credentials, and launching Claude Code, Codex CLI, Factory
+Droid, and compatible proxy-backed workflows. This page maps stable ownership;
+source and tests remain the implementation truth.
+
+## Runtime Surfaces
+
+| Surface | Entry point | Responsibility |
+| --- | --- | --- |
+| `ccs` CLI | [`src/ccs.ts`](../src/ccs.ts) | Parse global input, register targets, resolve profiles, dispatch commands or runtimes |
+| Runtime aliases | [`package.json`](../package.json) | Expose packaged binaries such as `ccs`, `ccsx`, and target-specific entry points |
+| Command handlers | [`src/commands/`](../src/commands/) | Implement CCS-owned command families and help text |
+| Local web server | [`src/web-server/index.ts`](../src/web-server/index.ts) | Serve configuration APIs, WebSocket updates, and the built dashboard |
+| Dashboard | [`ui/src/main.tsx`](../ui/src/main.tsx) | Mount the React application used by `ccs config` |
+| Bootstrap wrappers | [`lib/`](../lib/) | Start the packaged CLI on Unix and Windows |
+
+Detailed user workflows and command reference live at
+[docs.ccs.kaitran.ca](https://docs.ccs.kaitran.ca). Do not infer current flags
+from this overview; inspect the owning handler and its tests.
+
+## CLI Domain Ownership
+
+| Domain | Main source | Owns |
+| --- | --- | --- |
+| Command routing | [`src/commands/`](../src/commands/) | Command parsing, command-specific help, setup, doctor, config, Docker, and management flows |
+| Profile dispatch | [`src/dispatcher/`](../src/dispatcher/) | Resolve a launch into target-specific execution flows |
+| Runtime targets | [`src/targets/`](../src/targets/) | Target metadata, resolution, adapters, binary detection, and execution |
+| Configuration | [`src/config/`](../src/config/) | Schema validation, loading, and normalized configuration access |
+| CLIProxy | [`src/cliproxy/`](../src/cliproxy/) | Provider auth, configuration, routing, quota, lifecycle, and execution |
+| Authentication | [`src/auth/`](../src/auth/) and [`src/codex-auth/`](../src/codex-auth/) | Account and OAuth-oriented authentication flows |
+| Channels | [`src/channels/`](../src/channels/) | Official Claude channel readiness and configuration |
+| Local proxy | [`src/proxy/`](../src/proxy/) | Anthropic-compatible proxy server and request/response transformers |
+| Web API | [`src/api/`](../src/api/) and [`src/web-server/`](../src/web-server/) | Local dashboard services, routes, middleware, health, usage, and live updates |
+| Shared services | [`src/services/`](../src/services/) | Cross-cutting runtime services, including structured logging |
+| Errors | [`src/errors/`](../src/errors/) | Typed error taxonomy, handling, and exit behavior |
+| Utilities | [`src/utils/`](../src/utils/) | CCS path handling and bounded shared helpers for browser, hooks, web search, image analysis, and UI support |
+| Compatibility | [`src/glmt/`](../src/glmt/), [`src/copilot/`](../src/copilot/), [`src/cursor/`](../src/cursor/) | Legacy translation and integration-specific behavior |
+| Packaging/runtime bins | [`src/bin/`](../src/bin/) | Target-specific packaged entry points |
+
+The table is intentionally domain-level. Use repository search and nearby tests
+to find the current implementation instead of relying on a recursive file tree.
+
+## Profile and Target Dispatch
+
+Profile resolution follows the repository contract in
+[`CLAUDE.md`](../CLAUDE.md):
+
+1. built-in CLIProxy providers
+2. user-defined `config.cliproxy` providers
+3. settings-based `config.profiles`
+4. account-based `profiles.json` entries with isolated `CLAUDE_CONFIG_DIR`
+
+Target selection is a separate layer:
+
+| Concern | Source |
+| --- | --- |
+| Target names, aliases, and persistence | [`src/targets/target-metadata.ts`](../src/targets/target-metadata.ts) |
+| Selection priority and `--target` parsing | [`src/targets/target-resolver.ts`](../src/targets/target-resolver.ts) |
+| Adapter interface | [`src/targets/target-adapter.ts`](../src/targets/target-adapter.ts) |
+| Adapter registry | [`src/targets/target-registry.ts`](../src/targets/target-registry.ts) |
+| Claude implementation | [`src/targets/claude-adapter.ts`](../src/targets/claude-adapter.ts) |
+| Droid implementation | [`src/targets/droid-adapter.ts`](../src/targets/droid-adapter.ts) |
+| Codex implementation | [`src/targets/codex-adapter.ts`](../src/targets/codex-adapter.ts) |
+
+All targets currently marked `persistedTarget` in target metadata are valid
+profile targets. Runtime aliases are also derived from that metadata. Link to
+the source instead of maintaining a second target list here.
+
+At startup, [`src/ccs.ts`](../src/ccs.ts) registers adapters. The dispatcher
+resolves the profile and target, asks the adapter to prepare credentials and
+arguments, then executes the selected CLI. Target-specific behavior belongs in
+the adapter or its supporting target module, not in generic command routing.
+
+## Configuration and Local State
+
+[`src/utils/config-manager.ts`](../src/utils/config-manager.ts) owns CCS home
+resolution and honors `CCS_HOME`. Tests must point `CCS_HOME` at a temporary
+directory and must not touch a contributor's real `~/.ccs/` or `~/.claude/`.
+
+Configuration schemas and loaders live under [`src/config/`](../src/config/).
+Provider- and CLIProxy-specific persistence stays under
+[`src/cliproxy/config/`](../src/cliproxy/config/). Values written to settings
+environment maps must remain strings.
+
+Some integrations intentionally write state owned by the launched runtime, such
+as Claude channel configuration or Codex configuration. Verify those boundaries
+in the owning module and tests before changing paths, permissions, or cleanup.
+
+## Dashboard Ownership
+
+The dashboard is a separate TypeScript package under [`ui/`](../ui/):
+
+| Area | Path | Responsibility |
+| --- | --- | --- |
+| Pages | [`ui/src/pages/`](../ui/src/pages/) | Route-level orchestration and settings sections |
+| Components | [`ui/src/components/`](../ui/src/components/) | Domain UI and shared primitives |
+| Hooks | [`ui/src/hooks/`](../ui/src/hooks/) | Server-state access and reusable UI behavior |
+| Contexts/providers | [`ui/src/contexts/`](../ui/src/contexts/) and [`ui/src/providers/`](../ui/src/providers/) | Cross-page client state |
+| Libraries | [`ui/src/lib/`](../ui/src/lib/) | API client, localization, catalogs, formatting, and helpers |
+
+The browser communicates with routes and services under
+[`src/web-server/`](../src/web-server/). When a configuration feature supports
+both surfaces, keep CLI and dashboard behavior aligned.
+
+Localization codes, normalization, persistence, and fallback are owned by
+[`ui/src/lib/locales.ts`](../ui/src/lib/locales.ts). Translation resources and
+i18next wiring live in [`ui/src/lib/i18n.ts`](../ui/src/lib/i18n.ts).
+
+## Logging and Operational Data
+
+Structured CCS logging lives in
+[`src/services/logging/`](../src/services/logging/). Dashboard log routes and
+services live under [`src/web-server/`](../src/web-server/), with UI consumers
+under [`ui/src/components/logs/`](../ui/src/components/logs/) and the matching
+page and hooks.
+
+Keep secrets and raw credentials out of logs. Treat legacy CLIProxy log files as
+a distinct source rather than folding them into CCS-owned structured logs.
+
+## Tests
+
+Root TypeScript tests run with Bun's test runner. Bucket selection is implemented
+by [`scripts/run-test-bucket.js`](../scripts/run-test-bucket.js). The dashboard
+uses Vitest as configured in [`ui/package.json`](../ui/package.json).
+
+| Coverage area | Location |
+| --- | --- |
+| Focused module behavior | [`tests/unit/`](../tests/unit/) and colocated `src/**/__tests__/` |
+| Cross-module behavior | [`tests/integration/`](../tests/integration/) |
+| CLI end-to-end behavior | [`tests/e2e/`](../tests/e2e/) |
+| Package installation and exports | [`tests/npm/`](../tests/npm/) |
+| Shell and platform behavior | [`tests/native/`](../tests/native/) |
+| Docker public contracts | [`tests/docker/`](../tests/docker/) |
+| Documentation checks | [`tests/docs/`](../tests/docs/) |
+| Dashboard behavior | [`ui/tests/`](../ui/tests/) and colocated UI tests |
+
+Commands and bucket behavior are documented in
+[`tests/README.md`](../tests/README.md) and defined in
+[`package.json`](../package.json). Avoid copying test counts or pass totals into
+evergreen documentation.
+
+## Build and Release
+
+| Output or process | Source of truth |
+| --- | --- |
+| CLI compilation into `dist/` | root scripts in [`package.json`](../package.json) |
+| Dashboard build into `dist/ui/` | UI and root build scripts |
+| Bundle verification | [`scripts/verify-bundle.js`](../scripts/verify-bundle.js) |
+| Local CI-equivalent gate | [`scripts/ci-parity-gate.sh`](../scripts/ci-parity-gate.sh) |
+| Commit policy | [`commitlint.config.cjs`](../commitlint.config.cjs) |
+| Branch-aware releases | [`.releaserc.cjs`](../.releaserc.cjs) |
+| GitHub automation | [`.github/workflows/`](../.github/workflows/) |
+
+Semantic-release owns versions, changelog updates, tags, npm publication, and
+GitHub releases. Generated `dist/` contents and release artifacts are outputs,
+not architectural source.
+
+## Documentation Map
+
+- [Maintainer docs index](./README.md)
+- [Code standards](./code-standards.md)
+- [System architecture](./system-architecture/index.md)
+- [Project roadmap](./project-roadmap.md)
+- [Dashboard i18n](./i18n-dashboard.md)
+- [OpenAI-compatible provider routing](./openai-compatible-providers.md)
+- [Image analysis user guide](https://docs.ccs.kaitran.ca/features/ai/image-analysis)
+- [AI agent guide](../CLAUDE.md)
+- [Contributor guide](../CONTRIBUTING.md)
+
+Update this summary only when domain ownership, stable entry points, build
+boundaries, or truth sources change.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,65 +1,79 @@
 # CCS Test Suite
 
-## Organization
+Root TypeScript and JavaScript tests run with Bun's test runner. Native shell,
+PowerShell, Docker, and standalone probes cover contracts that need a real
+platform or process boundary.
 
-```
-tests/
-├── unit/              # Module unit tests (Mocha)
-│   ├── glmt/          # Legacy GLMT transformer/internal compatibility tests
-│   └── delegation/    # Delegation module tests
-├── npm/               # npm package tests (Mocha)
-├── native/            # Native installation tests (bash/PowerShell)
-│   ├── unix/          # Unix/Linux/macOS tests
-│   └── windows/       # Windows PowerShell tests
-├── integration/       # Integration + smoke tests
-└── shared/            # Shared utilities
-    ├── fixtures/      # Test configuration and environment
-    ├── unit/          # Helper function tests
-    ├── helpers.sh     # Bash test utilities
-    └── test-data.js   # Test data for npm tests
-```
+## Ownership
 
-## Running Tests
+| Area | Path | Use for |
+| --- | --- | --- |
+| Unit | [`unit/`](./unit/) | Focused module and command behavior |
+| Integration | [`integration/`](./integration/) | Cross-module, process, proxy, auth, and web-server behavior |
+| End to end | [`e2e/`](./e2e/) | Packaged CLI workflows |
+| npm package | [`npm/`](./npm/) | Installation, exports, and package behavior |
+| Native | [`native/`](./native/) | Unix and Windows shell behavior |
+| Docker | [`docker/`](./docker/) | Compose and stable network/service contracts |
+| Documentation | [`docs/`](./docs/) | Repository documentation invariants |
+| Shared support | [`shared/`](./shared/) | Fixtures and helpers reused by suites |
+| Mocks | [`mocks/`](./mocks/) | Bounded test doubles and fixtures |
+
+Some source domains also keep focused tests in `src/**/__tests__/`. Follow the
+nearest established pattern and avoid moving tests solely for taxonomy.
+
+## Commands
+
+Commands are defined in [`../package.json`](../package.json). Bucket membership
+and execution live in
+[`../scripts/run-test-bucket.js`](../scripts/run-test-bucket.js).
 
 ```bash
-bun run test           # All automated tests (unit + integration + npm)
-bun run test:unit      # Unit tests only
-bun run test:npm       # npm package tests
-bun run test:native    # Native Unix tests (bash)
+bun run test:fast      # Fast Bun test bucket
+bun run test:slow      # Slow Bun test bucket
+bun run test:all       # All root non-e2e Bun test buckets
+bun run test:unit      # tests/unit
+bun run test:npm       # tests/npm
+bun run test:native    # Native Unix edge-case script
+bun run test:e2e       # tests/e2e with fail-fast and extended timeout
+bun run test           # Build, then test:all
 ```
 
-## Test Categories
+For the normal contributor gate:
 
-### Unit Tests (`unit/`)
-Module-level tests using Mocha framework:
-- `unit/glmt/` - Legacy transformer internals kept for Cursor translation compatibility
-- `unit/delegation/` - Permission mode, session manager, result formatter
+```bash
+bun run format
+bun run lint:fix
+bun run validate
+```
 
-### npm Tests (`npm/`)
-npm package functionality tests using Mocha:
-- `postinstall.test.js` - Postinstall behavior
-- `cli.test.js` - CLI argument parsing
-- `cross-platform.test.js` - Cross-platform compatibility
-- `special-commands.test.js` - Integration tests
+For the closest local equivalent to PR CI:
 
-### Native Tests (`native/`)
-Installation tests for curl|bash (Unix) and irm|iex (Windows):
-- `native/unix/edge-cases.sh` - Unix edge case tests
-- `native/windows/edge-cases.ps1` - Windows edge case tests
+```bash
+bun run validate:ci-parity
+```
 
-### Integration Tests (`integration/`)
-Integration and smoke coverage for scenarios that exercise multiple layers:
-- Automated `*.test.ts` files run as part of `bun run test:all` and CI
-- Shell and standalone probe scripts remain on-demand for targeted debugging
-- `cursor-daemon-lifecycle.test.ts` - local daemon process + HTTP smoke coverage
-- `image-analyzer-hook.test.ts` - hook integration coverage
-- `glmt-integration-test.sh` - legacy GLMT compatibility smoke probe
-- `symlink-chain-test.sh` - Symlink chain handling
-- `ux-integration-test.sh` - CLI UX integration
+Dashboard tests use Vitest and are documented in
+[`../ui/README.md`](../ui/README.md).
 
-## Adding New Tests
+## Test Isolation
 
-- **Unit tests**: Add to `unit/<module>/` for isolated module behavior
-- **npm tests**: Add to `npm/` for package behavior
-- **Native tests**: Add to `native/unix/` or `native/windows/`
-- **Integration tests**: Add automated cross-layer smoke coverage to `integration/*.test.ts`
+- Set `CCS_HOME` to a temporary directory.
+- Never read or modify a contributor's real `~/.ccs/` or `~/.claude/`.
+- Use `getCcsDir()` from
+  [`../src/utils/config-manager.ts`](../src/utils/config-manager.ts) for CCS
+  paths.
+- Keep fixtures deterministic and free of credentials or private account data.
+- Use real behavior at the boundary under test; do not weaken assertions to
+  hide regressions.
+
+## Adding Coverage
+
+- Add a focused unit test for isolated logic.
+- Add integration coverage when behavior crosses modules, processes, HTTP, or
+  persistence boundaries.
+- Add e2e coverage when command routing or packaged CLI behavior is the
+  contract.
+- Add native or Docker coverage only when platform/runtime behavior cannot be
+  represented faithfully in Bun tests.
+- Run the smallest relevant command first, then broaden to the contributor or
+  CI-parity gate when shared contracts changed.

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,76 +1,78 @@
 # CCS Dashboard UI
 
-React + TypeScript + Vite frontend for the CCS local dashboard.
-
-This UI is served by the CCS web server and is accessed via:
+React, TypeScript, and Vite frontend for the local dashboard served by the CCS
+web server through:
 
 ```bash
 ccs config
 ```
 
----
-
 ## Development
 
-From project root:
+From the repository root, build the server and open the integrated dashboard:
 
 ```bash
 bun run dev
 ```
 
-This starts the CCS server, opens a local browser URL, and prints bind/network details for the dashboard.
-If the runtime bind is reachable beyond loopback, CCS also prints an auth reminder.
-
-For remote device access during development, run:
+Pass a host explicitly when testing network access:
 
 ```bash
 bun run dev -- --host 0.0.0.0
-```
-
-For local-only development, run:
-
-```bash
 bun run dev -- --host 127.0.0.1
 ```
 
-From `ui/` only (frontend dev server):
+For the frontend-only Vite server:
 
 ```bash
 cd ui
 bun run dev
 ```
 
----
+Root and UI scripts are defined in
+[`../package.json`](../package.json) and [`package.json`](./package.json).
+
+## Source Ownership
+
+| Area | Path |
+| --- | --- |
+| Route-level pages | [`src/pages/`](./src/pages/) |
+| Domain and shared components | [`src/components/`](./src/components/) |
+| Server-state hooks | [`src/hooks/`](./src/hooks/) |
+| Cross-page context/providers | [`src/contexts/`](./src/contexts/) and [`src/providers/`](./src/providers/) |
+| API, localization, catalogs, helpers | [`src/lib/`](./src/lib/) |
+| UI tests | [`tests/`](./tests/) and colocated tests |
+
+Follow the owning domain's existing import pattern. Barrel exports are optional,
+not required at every directory level.
 
 ## Quality Commands
 
 ```bash
 cd ui
+bun run format
 bun run typecheck
 bun run lint
 bun run validate
 bun run test:run
 ```
 
----
+`bun run validate` currently runs typecheck, lint with fixes, and the format
+check. UI tests run with Vitest; use `test`, `test:run`, `test:coverage`, or
+`test:ui` as defined in [`package.json`](./package.json).
 
-## i18n
+## Localization
 
 Dashboard localization uses `react-i18next`.
 
-- Main setup: `ui/src/lib/i18n.ts`
-- Locale helpers: `ui/src/lib/locales.ts`
-- Language switcher: `ui/src/components/layout/language-switcher.tsx`
+| Concern | Source |
+| --- | --- |
+| Supported locales, normalization, fallback, persistence | [`src/lib/locales.ts`](./src/lib/locales.ts) |
+| i18next setup and translation resources | [`src/lib/i18n.ts`](./src/lib/i18n.ts) |
+| Language switcher | [`src/components/layout/language-switcher.tsx`](./src/components/layout/language-switcher.tsx) |
 
-For full architecture, conventions, and locale onboarding, see:
-
-- [`../docs/i18n-dashboard.md`](../docs/i18n-dashboard.md)
-
----
-
-## Notes
-
-- UI locale persistence uses browser localStorage key `ccs-ui-locale`.
-- Current supported locales are managed in `ui/src/lib/locales.ts`.
-- Current locales: `en`, `zh-CN`, `vi`.
-- Fallback locale is English (`en`).
+English is the fallback. The selected locale is stored in browser local storage
+under `ccs-ui-locale`. Treat `src/lib/locales.ts` as the complete source of
+truth for supported locale codes. When adding or removing a locale, update the
+translation resources, switcher, tests, and
+[dashboard i18n guide](../docs/i18n-dashboard.md) in the same change.


### PR DESCRIPTION
## Summary

- define the documentation truth hierarchy and update triggers
- replace stale trees and volatile metrics with durable ownership maps
- align contributor, Bun/Vitest, UI locale, and file-size guidance with executable source

## Validation

- independent code review and clean re-review
- fast pre-push gate: typecheck, lint, format, 401 test files, UI validation
- quickstart parity and scoped Markdown link checks

Docs impact: major
Action: refreshed internal AI, contributor, test, UI, and maintainer guidance. Public CCS docs are unchanged.

Parent: #1663
Closes #1664