### PR TITLE
feat: support Claude Opus 5

### DIFF
--- a/docs/reports/hardening-inventory.json
+++ b/docs/reports/hardening-inventory.json
@@ -735,7 +735,7 @@
         },
         {
           "file": "src/web-server/model-pricing.ts",
-          "loc": 1105
+          "loc": 1127
         },
         {
           "file": "src/cliproxy/auth/oauth-process.ts",

--- a/docs/reports/hardening-inventory.md
+++ b/docs/reports/hardening-inventory.md
@@ -93,7 +93,7 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 | `src/web-server/routes/cliproxy-auth-routes.ts` | 1531 |
 | `src/cliproxy/auth/oauth-handler.ts` | 1467 |
 | `src/cursor/cursor-executor.ts` | 1234 |
-| `src/web-server/model-pricing.ts` | 1105 |
+| `src/web-server/model-pricing.ts` | 1127 |
 | `src/cliproxy/auth/oauth-process.ts` | 1048 |
 | `src/web-server/routes/settings-routes.ts` | 1042 |
 | `src/cliproxy/config/generator.ts` | 1034 |

--- a/src/cliproxy/__tests__/model-catalog.test.js
+++ b/src/cliproxy/__tests__/model-catalog.test.js
@@ -236,6 +236,22 @@ describe('Model Catalog', () => {
       assert.strictEqual(fable5.extendedContext, true);
     });
 
+    it('includes Claude Opus 5 with adaptive levels and extended context', () => {
+      const { MODEL_CATALOG } = modelCatalog;
+      const opus5 = MODEL_CATALOG.claude.models.find((m) => m.id === 'claude-opus-5');
+      assert(opus5, 'Should include Claude Opus 5');
+      assert.strictEqual(opus5.name, 'Claude Opus 5');
+      // Opus 5 requires adaptive thinking (type: 'levels') like Sonnet 5 and Opus 4.8;
+      // manual budget_tokens is rejected with 400. Proxy reports zero + dynamic allowed.
+      assert.strictEqual(opus5.thinking.type, 'levels');
+      assert.deepStrictEqual(opus5.thinking.levels, ['low', 'medium', 'high', 'xhigh', 'max']);
+      assert.strictEqual(opus5.thinking.maxLevel, 'max');
+      assert.strictEqual(opus5.thinking.zeroAllowed, true);
+      assert.strictEqual(opus5.thinking.dynamicAllowed, true);
+      assert.strictEqual(opus5.nativeImageInput, true);
+      assert.strictEqual(opus5.extendedContext, true);
+    });
+
     it('retains previous 4.5 snapshot models for explicit selection', () => {
       const { MODEL_CATALOG } = modelCatalog;
       const ids = MODEL_CATALOG.claude.models.map((m) => m.id);

--- a/src/cliproxy/model-catalog.ts
+++ b/src/cliproxy/model-catalog.ts
@@ -504,7 +504,7 @@ export const MODEL_CATALOG: Partial<Record<CLIProxyProvider, ProviderCatalog>> =
         name: 'Claude Opus 5',
         description: 'Latest premium model',
         nativeImageInput: true,
-        // Opus 5 (released 2026-07-14) uses adaptive thinking, matching Sonnet 5
+        // Opus 5 (released 2026-07-24) uses adaptive thinking, matching Sonnet 5
         // and Opus 4.8: Anthropic accepts only effort levels; manual budget_tokens
         // is rejected with 400. Proxy metadata reports zero + dynamic allowed.
         thinking: {

--- a/src/cliproxy/model-catalog.ts
+++ b/src/cliproxy/model-catalog.ts
@@ -500,6 +500,23 @@ export const MODEL_CATALOG: Partial<Record<CLIProxyProvider, ProviderCatalog>> =
         extendedContext: true,
       },
       {
+        id: 'claude-opus-5',
+        name: 'Claude Opus 5',
+        description: 'Latest premium model',
+        nativeImageInput: true,
+        // Opus 5 (released 2026-07-14) uses adaptive thinking, matching Sonnet 5
+        // and Opus 4.8: Anthropic accepts only effort levels; manual budget_tokens
+        // is rejected with 400. Proxy metadata reports zero + dynamic allowed.
+        thinking: {
+          type: 'levels',
+          levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          maxLevel: 'max',
+          zeroAllowed: true,
+          dynamicAllowed: true,
+        },
+        extendedContext: true,
+      },
+      {
         id: 'claude-opus-4-8',
         name: 'Claude Opus 4.8',
         description: 'Latest flagship model',

--- a/src/web-server/model-pricing.ts
+++ b/src/web-server/model-pricing.ts
@@ -331,6 +331,28 @@ const PRICING_REGISTRY: Record<string, ModelPricing> = {
       fast: OPUS_48_FAST_RATES,
     },
   },
+  // Claude Opus 5 ($5/$25) — Claude 5 generation Opus (released 2026-07-14).
+  // Rates mirror Opus 4.8 (same Opus tier); fast mode reuses the 2x premium
+  // pending official Opus 5 numbers. Registered explicitly so it resolves to
+  // Opus-tier pricing instead of the unknown-model fallback.
+  'claude-opus-5': {
+    inputPerMillion: 5.0,
+    outputPerMillion: 25.0,
+    cacheCreationPerMillion: 6.25,
+    cacheReadPerMillion: 0.5,
+    serviceTiers: {
+      fast: OPUS_48_FAST_RATES,
+    },
+  },
+  'claude-opus-5-thinking': {
+    inputPerMillion: 5.0,
+    outputPerMillion: 25.0,
+    cacheCreationPerMillion: 6.25,
+    cacheReadPerMillion: 0.5,
+    serviceTiers: {
+      fast: OPUS_48_FAST_RATES,
+    },
+  },
   // Claude Fable 5 ($10/$50) — most powerful tier, above Opus
   'claude-fable-5': {
     inputPerMillion: 10.0,

--- a/src/web-server/model-pricing.ts
+++ b/src/web-server/model-pricing.ts
@@ -331,9 +331,9 @@ const PRICING_REGISTRY: Record<string, ModelPricing> = {
       fast: OPUS_48_FAST_RATES,
     },
   },
-  // Claude Opus 5 ($5/$25) — Claude 5 generation Opus (released 2026-07-14).
-  // Rates mirror Opus 4.8 (same Opus tier); fast mode reuses the 2x premium
-  // pending official Opus 5 numbers. Registered explicitly so it resolves to
+  // Claude Opus 5 ($5/$25) — Claude 5 generation Opus (released 2026-07-24).
+  // Rates mirror Opus 4.8 (same Opus tier); fast mode uses Anthropic's documented
+  // $10/$50 rates. Registered explicitly so it resolves to
   // Opus-tier pricing instead of the unknown-model fallback.
   'claude-opus-5': {
     inputPerMillion: 5.0,

--- a/tests/unit/model-pricing.test.ts
+++ b/tests/unit/model-pricing.test.ts
@@ -285,10 +285,26 @@ describe('model-pricing', () => {
       expect(sonnet5.cacheReadPerMillion).toBe(0.3);
     });
 
+    it('should return Opus-tier pricing for Claude Opus 5', () => {
+      // Opus 5 mirrors Opus 4.8 rates; date-stamped ids resolve via stripDateSuffix.
+      const opus5 = getModelPricing('claude-opus-5');
+      expect(opus5.inputPerMillion).toBe(5.0);
+      expect(opus5.outputPerMillion).toBe(25.0);
+      expect(opus5.cacheCreationPerMillion).toBe(6.25);
+      expect(opus5.cacheReadPerMillion).toBe(0.5);
+      expect(getModelPricing('claude-opus-5-20270101').inputPerMillion).toBe(5.0);
+    });
+
+    it('should apply fast-tier pricing for Claude Opus 5', () => {
+      const opus5fast = getModelPricing('claude-opus-5', { serviceTier: 'fast' });
+      expect(opus5fast.inputPerMillion).toBe(10.0);
+      expect(opus5fast.outputPerMillion).toBe(50.0);
+    });
+
     it('should not map unknown future model families onto known family pricing', () => {
       const fallback = getModelPricing('unknown-model-xyz');
 
-      expect(getModelPricing('claude-opus-5-20270101')).toEqual(fallback);
+      expect(getModelPricing('claude-opus-6-20270101')).toEqual(fallback);
       expect(getModelPricing('gemini-3.2-pro')).toEqual(fallback);
     });
   });

--- a/ui/src/lib/model-catalogs.ts
+++ b/ui/src/lib/model-catalogs.ts
@@ -983,6 +983,18 @@ export const MODEL_CATALOGS: Record<string, ProviderCatalog> = {
         },
       },
       {
+        id: 'claude-opus-5',
+        name: 'Claude Opus 5',
+        description: 'Latest premium model',
+        extendedContext: true,
+        presetMapping: {
+          default: 'claude-opus-5',
+          opus: 'claude-opus-5',
+          sonnet: 'claude-sonnet-5',
+          haiku: 'claude-haiku-4-5-20251001',
+        },
+      },
+      {
         id: 'claude-opus-4-8',
         name: 'Claude Opus 4.8',
         description: 'Latest flagship model',

--- a/ui/tests/unit/components/cliproxy/provider-model-selector.test.tsx
+++ b/ui/tests/unit/components/cliproxy/provider-model-selector.test.tsx
@@ -70,7 +70,7 @@ describe('FlexibleModelSelector', () => {
     expect(screen.queryByText(/All Models \(/i)).not.toBeInTheDocument();
   });
 
-  it('surfaces Claude Sonnet 5 in the curated Claude picker', async () => {
+  it('surfaces current Claude models in the curated Claude picker', async () => {
     render(
       <FlexibleModelSelector
         label="Primary model"
@@ -84,6 +84,7 @@ describe('FlexibleModelSelector', () => {
     await userEvent.click(screen.getByRole('button', { name: /select model/i }));
 
     expect(screen.getByRole('option', { name: /claude-sonnet-5/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /claude-opus-5/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /claude-opus-4-8/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /claude-sonnet-4-6/i })).toBeInTheDocument();
   });

--- a/ui/tests/unit/ui/lib/preset-utils.test.ts
+++ b/ui/tests/unit/ui/lib/preset-utils.test.ts
@@ -23,6 +23,7 @@ describe('claude preset utils', () => {
     expect(claudeCatalog.defaultModel).toBe('claude-sonnet-5');
     expect(ids).toContain('claude-sonnet-5');
     expect(ids).toContain('claude-fable-5');
+    expect(ids).toContain('claude-opus-5');
     expect(ids).toContain('claude-opus-4-8');
     expect(ids).toContain('claude-opus-4-7');
     expect(ids).toContain('claude-sonnet-4-6');


### PR DESCRIPTION
## Summary

- Registers `claude-opus-5` across the CLIProxy model catalog, the dashboard model catalog, and the cost/pricing registry so the model resolves natively instead of falling through to unknown-model handling.
- Models Opus 5 thinking as adaptive effort levels (`low | medium | high | xhigh | max`, `type: 'levels'`), matching Sonnet 5 and Opus 4.8 — Anthropic rejects manual `budget_tokens` with a 400 on this family.
- Adds Opus-tier pricing entries for `claude-opus-5` and `claude-opus-5-thinking` ($5/$25 in, cache $6.25/$0.50), using Anthropic’s documented $10/$50 fast-mode rates.
- Refreshes `docs/reports/hardening-inventory.{json,md}` — required by the CI parity gate because `src/web-server/model-pricing.ts` grew from 1105 to 1127 LOC.

Fast-mode pricing is sourced from Anthropic’s published Opus 5 rates: $10/M input tokens and $50/M output tokens. The shared `OPUS_48_FAST_RATES` constant is valid because Anthropic prices Opus 5 and Opus 4.8 identically in fast mode.

The pre-existing `model-pricing` test asserting that unknown future families do not inherit known-family pricing previously used `claude-opus-5-20270101` as its negative case. Since that id is now a real registered model, the guard was re-pointed at `claude-opus-6-20270101`, preserving the original intent.

## Changes

| Area | File | Change |
|---|---|---|
| CLIProxy catalog | `src/cliproxy/model-catalog.ts` | Added `claude-opus-5` entry with levels-based thinking, native image input, extended context |
| CLIProxy tests | `src/cliproxy/__tests__/model-catalog.test.js` | Added coverage for the Opus 5 catalog entry |
| Pricing | `src/web-server/model-pricing.ts` | Added `claude-opus-5` and `claude-opus-5-thinking` Opus-tier pricing |
| Pricing tests | `tests/unit/model-pricing.test.ts` | Added base + fast-tier pricing assertions; re-pointed the unknown-family guard to `claude-opus-6-*` |
| Dashboard | `ui/src/lib/model-catalogs.ts` | Added `claude-opus-5` with preset mapping (opus → Opus 5, sonnet → Sonnet 5, haiku → Haiku 4.5) |
| Reports | `docs/reports/hardening-inventory.{json,md}` | Regenerated via `bun run report:hardening` |

## Testing

- [x] `bun run format && bun run lint:fix && bun run validate`
- [x] `bun run validate:ci-parity` before requesting review
- [x] `bun run test:e2e` if this PR touches command routing, proxy flows, or workflow/release logic
- [x] `cd ui && bun run validate` if UI changed

All green: `validate` (fast bucket, 401 files), `validate:ci-parity` (typecheck, lint, format, fast + slow buckets, 80 e2e/integration files, hardening inventory check) exited 0, and `ui` validate (tsc, eslint, prettier) exited 0.

## Checklist

- [x] Base branch is `dev` unless this is an approved hotfix
- [x] Branch name follows `feat/*`, `fix/*`, `docs/*`, or approved hotfix naming
- [ ] Relevant `--help` output updated if CLI behavior changed — N/A, no CLI surface or flag changed
- [x] Tests added or updated if behavior changed
- [ ] README or local docs updated if user-facing behavior changed — N/A for README; the generated hardening report was refreshed as required by the parity gate
- [x] If a check failed, the PR body explains what failed and what changed to fix it — the parity gate initially failed on hardening-inventory drift caused by the `model-pricing.ts` line-count change; regenerating the report fixed it
- [x] No secrets, tokens, or private config data are included

## Docs Impact

Docs impact: `minor`

Action: no update made in this PR. If the public `kaitranntt/ccs-docs` site enumerates selectable Claude model IDs, it needs a matching `claude-opus-5` entry — flagging for a maintainer who can confirm whether that list is hand-maintained or generated from the catalog.


Closes #1661