### PR TITLE
ci(review): configure explicit reasoning effort

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -99,11 +99,12 @@ jobs:
       contents: read
     env:
       OPENAI_KEY: ${{ secrets.AI_REVIEW_API_KEY }}
-      "OPENAI.API_BASE": ${{ vars.AI_REVIEW_BASE_URL }}
-      "config.model": ${{ vars.AI_REVIEW_MODEL }}
-      "github_action_config.auto_review": "true"
-      "github_action_config.auto_describe": "false"
-      "github_action_config.auto_improve": "false"
+      'OPENAI.API_BASE': ${{ vars.AI_REVIEW_BASE_URL }}
+      'config.model': ${{ vars.AI_REVIEW_MODEL }}
+      'config.reasoning_effort': ${{ vars.AI_REVIEW_REASONING_EFFORT }}
+      'github_action_config.auto_review': 'true'
+      'github_action_config.auto_describe': 'false'
+      'github_action_config.auto_improve': 'false'
 
     steps:
       - name: Generate App Token

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ CCS PR review no longer depends on `anthropics/claude-code-action`. The reposito
 - Use `/review` on the PR when you need a fresh pass after follow-up commits.
 - Only the trusted `/review` comment path is enabled.
 - Keep repository-level reviewer instructions in the root `.pr_agent.toml`.
-- Keep runtime wiring and defaults in `ai-review.yml`, which still maps the existing `AI_REVIEW_BASE_URL`, `AI_REVIEW_MODEL`, and `AI_REVIEW_API_KEY` integrations onto PR-Agent's `OPENAI.*` and `config.*` settings.
+- Keep runtime wiring and defaults in `ai-review.yml`, which maps the existing `AI_REVIEW_BASE_URL`, `AI_REVIEW_MODEL`, `AI_REVIEW_REASONING_EFFORT`, and `AI_REVIEW_API_KEY` integrations onto PR-Agent's `OPENAI.*` and `config.*` settings.
 - If you change review defaults, update the workflow or `.pr_agent.toml` alongside the contributor or architecture docs in the same PR.
 
 Example:

--- a/tests/unit/scripts/github/ai-review-workflow.test.ts
+++ b/tests/unit/scripts/github/ai-review-workflow.test.ts
@@ -34,6 +34,7 @@ describe('PR-Agent review lane migration', () => {
     expect(workflow).toContain('OPENAI_KEY');
     expect(workflow).toContain('vars.AI_REVIEW_BASE_URL');
     expect(workflow).toContain('vars.AI_REVIEW_MODEL');
+    expect(workflow).toContain('vars.AI_REVIEW_REASONING_EFFORT');
     expect(workflow).toContain('secrets.AI_REVIEW_API_KEY');
     expect(workflow).toContain('github_action_config.auto_review');
     expect(workflow).toContain("github.event.comment.body == '/review'");


### PR DESCRIPTION
Map AI_REVIEW_REASONING_EFFORT into PR-Agent config, document it, and cover the contract.\n\nValidation:\n- focused Bun test: 1 pass / 47 assertions\n- YAML parse: passed\n- ci-parity: typecheck, lint (warnings only), format, build, all test buckets, and e2e\n- independent e2e rerun: 35 pass / 105 assertions\n\nRelated issues: none found in the brief search.