### PR TITLE
feat(proxy): add OpenCode Zen/Go protocol adapter

### DIFF
--- a/docs/opencode-zen-go-compat.md
+++ b/docs/opencode-zen-go-compat.md
@@ -1,0 +1,176 @@
+# OpenCode Zen / Go — API Compatibility Spec (CCS CLIProxy integration)
+
+Status: research output, verified against live endpoints 2026-08-04
+Task: t_c7bed65c — handoff for implementers of Zen/Go support in CCS.
+
+OpenCode Zen (`https://opencode.ai/zen`) and OpenCode Go (`https://opencode.ai/zen/go`)
+are **multi-protocol AI gateways**. One API key works across four different
+protocols; the protocol is chosen **per model family**, not per gateway. The
+gateway mimics each upstream provider's native auth header and request shape, so
+there is no single "OpenCode API" — there are four protocol shims under one
+host with one billing key.
+
+---
+
+## 1. Base URLs and auth
+
+| Gateway | Base URL | Auth mechanism |
+| --- | --- | --- |
+| Zen | `https://opencode.ai/zen/v1` | protocol-native header (see below) |
+| Go  | `https://opencode.ai/zen/go/v1` | protocol-native header (see below) |
+
+Key obtained at https://opencode.ai/auth. Same key works for Zen and Go.
+
+Auth header is **per endpoint protocol** (verified live 2026-08-04 with dummy keys):
+
+| Protocol / path family | Header | Notes |
+| --- | --- | --- |
+| OpenAI Chat Completions `POST /chat/completions` | `Authorization: Bearer <key>` | wrong header → 401 `Missing API key.` |
+| OpenAI Responses `POST /responses` | `Authorization: Bearer <key>` | wrong header → 401 `Missing API key.` |
+| Anthropic Messages `POST /messages` | `x-api-key: <key>` (+ `anthropic-version: 2023-06-01`) | Bearer → 401 `Missing API key.` |
+| Google GenAI `POST /models/{model}:generateContent` | `x-goog-api-key: <key>` | Bearer → 401 `Missing API key.` |
+
+Error bodies are protocol-native: `{"type":"error","error":{"type":"AuthError","message":"..."}}`
+(anthropic shape) or OpenAI-style JSON.
+
+## 2. Endpoint matrix (docs table, opencode.ai/docs/zen and /docs/go)
+
+Zen:
+
+| Model family (examples) | Path | Protocol | AI SDK |
+| --- | --- | --- | --- |
+| GPT 5.x / Codex family (`gpt-5.6-sol`, `gpt-5.5`, `gpt-5.1-codex`, …) | `/zen/v1/responses` | OpenAI Responses API | `@ai-sdk/openai` |
+| Claude (`claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`), Qwen3.7/3.6/3.5 Plus/Max, MiniMax M3/M2.x | `/zen/v1/messages` | Anthropic Messages API | `@ai-sdk/anthropic` |
+| Gemini (`gemini-3.6-flash`, `gemini-3.5-flash`, `gemini-3-flash`, `gemini-3.1-pro`) | `/zen/v1/models/{model}` | Google Generative Language API | `@ai-sdk/google` |
+| Grok 4.5, DeepSeek V4 Pro/Flash, GLM 5.x, Kimi K2.x/K3, MiniMax (openai-routed), all `*-free` models | `/zen/v1/chat/completions` | OpenAI Chat Completions | `@ai-sdk/openai-compatible` |
+
+Go (subscription, usage-limited): only two protocol families are exposed:
+
+| Model family | Path | Protocol |
+| --- | --- | --- |
+| Grok 4.5, GLM 5.x, Kimi K2.x/K3, DeepSeek V4, MiMo, Hy3 | `/zen/go/v1/chat/completions` | OpenAI Chat Completions |
+| MiniMax M3/M2.7/M2.5, Qwen3.7/3.6 Plus/Max | `/zen/go/v1/messages` | Anthropic Messages API |
+
+Go has **no** `/responses` and no Gemini protocol family.
+
+## 3. Request / response shapes
+
+There is no OpenCode-specific schema. Requests and responses are byte-for-byte
+the upstream protocols:
+
+- Chat Completions: standard OpenAI `POST /chat/completions` — `{model, messages, stream?, tools?, …}`, response `choices[].message`, usage in `usage`.
+- Responses: standard OpenAI `POST /responses` — `{model, input, stream?, tools?, …}`, response `output[]` with `response.completed` event carrying `usage` in streamed mode.
+- Messages: standard Anthropic `POST /messages` — `{model, max_tokens, messages, system?, tools?, stream?, …}`, response `content[]` + `usage`. `anthropic-version` header required per Anthropic convention.
+- Gemini: standard Google `generateContent` / `streamGenerateContent` — `{contents, systemInstruction?, generationConfig?, tools?}`.
+
+**Model field handling:** the `model` field in any request body is the **bare
+model ID** (`gpt-5.5`, `claude-sonnet-4-6`, `deepseek-v4-flash`, …). The
+`opencode/…` / `opencode-go/…` prefixes seen in OpenCode config
+(`opencode/gpt-5.5`) are OpenCode-internal provider prefixes only — never send
+them in API requests.
+
+## 4. Streaming / SSE
+
+Streaming is native SSE of the protocol used (`stream: true`):
+
+- Chat Completions: `text/event-stream`, `data: {…choices[0].delta…}` chunks, `data: [DONE]` terminator; usage via `stream_options.include_usage`.
+- Responses: SSE events `response.created`, `response.output_item.added`, `response.content_part.delta`, `response.completed` (final usage), …
+- Anthropic: SSE events `message_start`, `content_block_delta`, `message_delta`, `message_stop` (final usage in `message_delta`).
+- Gemini: `streamGenerateContent` returns SSE chunks.
+
+A proxy must forward the event stream untouched (same framing, same event
+names) for the protocol family in use; do not normalize across families unless
+the client explicitly requires a conversion layer.
+
+## 5. Model discovery
+
+- `GET {base}/models` — **public, no auth required**, OpenAI list shape:
+  `{"object":"list","data":[{"id":"claude-fable-5","object":"model","created":<ts>,"owned_by":"opencode"}, …]}`.
+  Verified live on both `/zen/v1/models` and `/zen/go/v1/models`.
+- The list carries **no protocol metadata** — mapping model → protocol must come
+  from the docs endpoint table or from Models.dev:
+  - Zen: https://models.dev → provider `opencode`, base `https://opencode.ai/zen/v1`, 85 models
+  - Go: https://models.dev → provider `opencode-go`, base `https://opencode.ai/zen/go/v1`, 24 models
+- OpenCode's own client (packages/opencode/src/provider/provider.ts) resolves
+  the per-model SDK from Models.dev data + AI SDK packages, then uses the SDK's
+  native auth header — the same contract described here.
+
+## 6. Compatibility caveats
+
+1. **Gemini via Zen had a server-side 500 bug** (`Cannot read properties of undefined (reading 'promptTokenCount')`) affecting all `generateContent` calls, reported in anomalyco/opencode#8228 (Jan 2026), closed "not planned". Verify Gemini works with a real key before shipping; if still broken, exclude Gemini models from the catalog.
+2. **Cross-protocol requests are undocumented.** Routing an Anthropic-shaped request to `/chat/completions` (or vice versa) is not a supported contract — some third-party proxies do body conversion (e.g. GOST example rewrites `/v1/messages` → `/zen/v1/chat/completions` with an `openai-converter`), but treat it as fragile, not a feature to depend on.
+3. **Per-model routing is the hard part.** Neither the model list nor the gateway routes by prefix; the implementer must carry a model→protocol table (from the docs table + models.dev) and route the request to the right path + auth header.
+4. **Go usage limits** (5h/$12, week/$30, month/$60) and Zen pay-as-you-go pricing apply per key; gateway returns provider-style errors when limits are hit. Free models (DeepSeek V4 Flash Free, MiMo-V2.5 Free, …) may use data for training — see privacy section of the docs.
+5. **Anthropic-family models** (Claude, Qwen, MiniMax on `/messages`) need the `anthropic-version` header or the Anthropic SDK rejects them client-side.
+6. Claude Sonnet 4.5 / Gemini 3.1 Pro / GPT 5.x / Grok 4.5 have tiered pricing above ~200–272K tokens; token counts come back in the protocol-native `usage` objects.
+
+## 7. Requirements CCS must satisfy to proxy OpenCode
+
+Current CCS surface (docs/openai-compatible-providers.md, src/cliproxy):
+- `openai-compatibility` config entries: `name`, `base-url`, `headers` (custom map), `api-key-entries`, `models[{name, alias}]`. This covers **chat-completions-family** models directly:
+  - provider `opencode` → `base-url: https://opencode.ai/zen/v1`, header `Authorization: Bearer <key>`
+  - provider `opencode-go` → `base-url: https://opencode.ai/zen/go/v1`, header `Authorization: Bearer <key>`
+- Anthropic-protocol models (Claude / Qwen / MiniMax) and Responses-protocol models (GPT) and Gemini **cannot** be reached through the existing openai-compat path — the gateway rejects them on the chat-completions route (undocumented cross-protocol; do not attempt body conversion).
+
+So a complete integration requires, in order of value:
+
+1. **OpenAI-compat coverage (smallest, do first):** register `opencode` and `opencode-go` as openai-compatibility providers; pull model lists from `GET /models` (public); seed `models[]` with the chat-completions-family IDs only; honor per-model aliases.
+2. **Anthropic-protocol coverage (needed for Claude/Qwen/MiniMax):** extend the CLIProxy upstream layer with an anthropic-compatible provider type: base URL + `x-api-key` + `anthropic-version: 2023-06-01`, passthrough of Anthropic SSE. If the CLIProxy already serves `/api/provider/<name>/v1/messages` to Claude Code clients, this is an upstream-side mirror of the same protocol — no shape conversion needed.
+3. **Responses-protocol coverage (needed for GPT models):** add an OpenAI-Responses upstream type (Bearer auth, responses SSE event passthrough), or exclude GPT models from the catalog until then.
+4. **Gemini:** only after verifying caveat 1; requires `x-goog-api-key` header support on a google-protocol upstream type.
+5. **Streaming:** forward protocol-native SSE untouched for every family above; only the CCS-facing side may convert (e.g. to Anthropic events for Claude Code clients), and that conversion must map delta/usage/stop events per family.
+6. **Catalog hygiene:** merge `GET /models` (live) with the protocol table (static); models appear/disappear over time (deprecations listed in the Zen docs); disable-model → gateway returns error, surface it, don't crash.
+
+## 8. Implementation status (2026-08-04, task t_8f91083d)
+
+Implemented in the OpenAI-compat proxy daemon (`src/proxy`):
+
+- `src/proxy/opencode-protocol.ts` — model→protocol classification for OpenCode
+  hosts (Anthropic family → `anthropic`, GPT/Codex → `responses`, Gemini →
+  `gemini`, everything else → `chat-completions`), provider-prefix stripping
+  (`opencode/…`, `opencode-go/…`), and `resolveOpenCodeUpstreamMode(baseUrl,
+  model)` returning the upstream mode or null for non-OpenCode hosts.
+- `src/proxy/server/messages-route.ts` — per-request OpenCode routing:
+  - Anthropic-family models → passthrough to `<base>/messages` with
+    `x-api-key` + `anthropic-version: 2023-06-01`; Anthropic SSE forwarded
+    untouched (existing passthrough pipe).
+  - Chat-completions models → existing Anthropic→OpenAI translation to
+    `<base>/chat/completions` with `Authorization: Bearer`.
+  - Responses/Gemini models → rejected with a 400 explaining the protocol is
+    not supported (Responses untranslated; Gemini disabled due to upstream
+    bug #8228).
+
+No new config flag or env var is required: OpenCode hosts (`opencode.ai` /
+`*.opencode.ai`) are auto-detected, matching the existing Kimi/Anthropic
+passthrough convention. OpenCode host detection overrides the generic
+`CCS_OPENAI_PROXY_PASSTHROUGH` force flag so chat-completions models are never
+sent to `/messages`.
+
+Usage: point any OpenAI-compat profile at an OpenCode base URL, e.g.
+
+```bash
+export ANTHROPIC_BASE_URL="https://opencode.ai/zen/v1"
+export ANTHROPIC_AUTH_TOKEN="<opencode key>"
+export ANTHROPIC_MODEL="deepseek-v4-flash"        # chat-completions family
+export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"  # anthropic family
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5"
+```
+
+`/zen/go/v1` works identically for the Go subscription models (chat
+completions + MiniMax/Qwen on `/messages`).
+
+Not implemented (tracked in the spec's integration steps 3–6): Responses
+protocol for GPT/Codex models, Gemini (blocked upstream), live `GET /models`
+catalog merge (the proxy still serves configured model IDs), and CLIProxy-side
+provider presets for `opencode` / `opencode-go`.
+
+## Verification record (2026-08-04)
+
+- `GET https://opencode.ai/zen/v1/models` → 200, public, OpenAI list shape
+- `GET https://opencode.ai/zen/go/v1/models` → 200, public, OpenAI list shape
+- `POST /zen/v1/chat/completions` + Bearer dummy → 401 `Invalid API key.` (route + Bearer auth confirmed)
+- `POST /zen/v1/responses` + Bearer dummy → 401 `Invalid API key.` (route + Bearer auth confirmed)
+- `POST /zen/v1/messages` + `x-api-key` dummy → 401 `Invalid API key.`; + Bearer → 401 `Missing API key.`
+- `POST /zen/v1/models/gemini-3.6-flash:generateContent` + `x-goog-api-key` dummy → 401 `Invalid API key.`; + Bearer → 401 `Missing API key.`
+- `POST /zen/go/v1/messages` + `x-api-key` dummy → 401 `Invalid API key.`
+- Sources: opencode.ai/docs/zen, opencode.ai/docs/go, models.dev api.json, anomalyco/opencode issue #8228, GOST blog proxy example.

--- a/docs/opencode-zen-go-compat.md
+++ b/docs/opencode-zen-go-compat.md
@@ -184,4 +184,28 @@ provider presets for `opencode` / `opencode-go`.
     supported` (auth accepted; the go tier catalog has no `claude-*` models —
     use `qwen3*` / `minimax-m*` for the Anthropic protocol on `/zen/go/v1`).
     `/zen/v1` remains the tier for Claude models.
+- Local proxy daemon e2e against `https://opencode.ai/zen/go/v1` with a real
+  key (2026-08-04, task t_2be8f081, run 9, `scripts/verify-opencode-local-e2e.sh`):
+  - Claude Code contract `POST /v1/messages` + `qwen3.7-max`, non-streaming →
+    200, Anthropic `message` type with real content
+  - Claude Code contract `POST /v1/messages` + `qwen3.7-max`, `stream: true` →
+    200, 78 SSE events including `message_stop`
+  - OpenAI contract via `/v1/messages` + `deepseek-v4-flash` (translated to
+    `<base>/chat/completions` + Bearer), non-streaming → 200 Anthropic-shaped reply
+  - Same with `stream: true` → 200, 51 SSE events including `message_stop`
+  - `gpt-5.5` via `/v1/messages` → local 400, no upstream dispatch
+  - `claude-sonnet-4-6` via `/v1/messages` → routed upstream (not short-circuited),
+    gateway answered 401 `ModelError: Model claude-sonnet-4-6 is not supported`
+  - The daemon's local surface is Anthropic-shaped (`/v1/messages`, `/v1/models`),
+    so the OpenAI contract is exercised through `/v1/messages` with a
+    chat-completions-family model; `POST /v1/chat/completions` on the daemon is
+    intentionally 404 (this daemon is the Claude-Code-facing OpenAI-compat proxy).
+- OpenCode CLI (opencode-ai 1.18.12) e2e: attempted, blocked by the Hermes
+  sandbox guard — the 179 MB bun-bundled `opencode.exe` embeds gateway
+  management strings (llmgateway, cloudflare-ai-gateway, …) that trip the
+  "cannot restart/stop the gateway" guard, a false positive. Run `opencode run`
+  from a normal shell against `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`
+  with a config provider using `@ai-sdk/anthropic` + the local proxy token;
+  the wire contract it sends (`/v1/messages`, `x-api-key`,
+  `anthropic-version: 2023-06-01`) is exactly what the local e2e above verified.
 - Sources: opencode.ai/docs/zen, opencode.ai/docs/go, models.dev api.json, anomalyco/opencode issue #8228, GOST blog proxy example.

--- a/docs/opencode-zen-go-compat.md
+++ b/docs/opencode-zen-go-compat.md
@@ -173,4 +173,15 @@ provider presets for `opencode` / `opencode-go`.
 - `POST /zen/v1/messages` + `x-api-key` dummy → 401 `Invalid API key.`; + Bearer → 401 `Missing API key.`
 - `POST /zen/v1/models/gemini-3.6-flash:generateContent` + `x-goog-api-key` dummy → 401 `Invalid API key.`; + Bearer → 401 `Missing API key.`
 - `POST /zen/go/v1/messages` + `x-api-key` dummy → 401 `Invalid API key.`
+- Live e2e through the CCS proxy daemon against `https://opencode.ai/zen/go/v1`
+  with a real key (2026-08-04, run 8):
+  - `deepseek-v4-flash` (chat-completions family) → 200, real completion via
+    `<base>/chat/completions` + Bearer
+  - `qwen3.7-max` (Anthropic family) → 200, Anthropic-shaped response via
+    `<base>/messages` + `x-api-key` + `anthropic-version: 2023-06-01`
+  - `gpt-5.5` (Responses family) → local 400, no upstream dispatch
+  - `claude-sonnet-4-6` → gateway `ModelError: Model claude-sonnet-4-6 is not
+    supported` (auth accepted; the go tier catalog has no `claude-*` models —
+    use `qwen3*` / `minimax-m*` for the Anthropic protocol on `/zen/go/v1`).
+    `/zen/v1` remains the tier for Claude models.
 - Sources: opencode.ai/docs/zen, opencode.ai/docs/go, models.dev api.json, anomalyco/opencode issue #8228, GOST blog proxy example.

--- a/scripts/verify-opencode-local-e2e.sh
+++ b/scripts/verify-opencode-local-e2e.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Live local-proxy e2e for the OpenCode Zen/Go adapter (t_2be8f081).
+# Starts the CCS OpenAI-compat proxy daemon against opencode.ai zen/go/v1 with
+# a real key. The daemon's local surface is Anthropic-shaped (/v1/messages +
+# /v1/models); the OpenAI-compatible upstream contract is exercised through
+# /v1/messages with chat-completions-family models (deepseek-v4-flash), which
+# the proxy translates to <base>/chat/completions with Bearer auth, and with
+# Anthropic-family models (qwen3.7-max), which pass through to
+# <base>/messages with x-api-key. Both non-streaming and streaming/SSE.
+set -uo pipefail
+
+PORT="${1:-3999}"
+BASE_URL="${OPENCODE_BASE_URL:-https://opencode.ai/zen/go/v1}"
+API_KEY="${OPENCODE_API_KEY:?set OPENCODE_API_KEY to the dashboard key}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SMOKE_DIR="$(mktemp -d)"
+DAEMON_PID=""
+LOCAL_TOKEN="local-test-token"
+
+cleanup() {
+  if [ -n "$DAEMON_PID" ]; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  rm -rf "$SMOKE_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$SMOKE_DIR/.ccs"
+cat > "$SMOKE_DIR/.ccs/oc.settings.json" <<EOF
+{"env":{"ANTHROPIC_BASE_URL":"${BASE_URL}","ANTHROPIC_AUTH_TOKEN":"${API_KEY}","ANTHROPIC_MODEL":"deepseek-v4-flash","CCS_DROID_PROVIDER":"generic-chat-completion-api"}}
+EOF
+cat > "$SMOKE_DIR/.ccs/config.json" <<EOF
+{"profiles":{"oc":"${SMOKE_DIR}/.ccs/oc.settings.json"},"proxy":{"routing":{}}}
+EOF
+
+CCS_HOME="$SMOKE_DIR" bun "$REPO_ROOT/src/proxy/proxy-daemon-entry.ts" \
+  --port "$PORT" --host 127.0.0.1 --profile oc \
+  --settings-path "$SMOKE_DIR/.ccs/oc.settings.json" --auth-token "$LOCAL_TOKEN" >"$SMOKE_DIR/daemon.log" 2>&1 &
+DAEMON_PID=$!
+
+for _ in $(seq 1 50); do
+  if curl -s -m 2 "http://127.0.0.1:${PORT}/v1/models" -o /dev/null; then
+    break
+  fi
+  sleep 0.2
+done
+
+pass=0; fail=0
+check() { # label expected_code actual_code
+  if [ "$2" = "$3" ]; then
+    echo "[OK] $1 (HTTP $3)"
+    pass=$((pass+1))
+  else
+    echo "[X] $1: expected HTTP $2, got $3"
+    fail=$((fail+1))
+  fi
+}
+
+msg_probe() { # label model extra_body
+  local label="$1" model="$2" extra="$3"
+  curl -s -m 180 -X POST "http://127.0.0.1:${PORT}/v1/messages" \
+    -H "x-api-key: ${LOCAL_TOKEN}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+    -d "{\"model\":\"${model}\",\"max_tokens\":96,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: pong\"}]${extra}}"
+}
+
+echo "== 1. Anthropic protocol (Claude Code /v1/messages, qwen3.7-max) — non-streaming =="
+body=$(msg_probe "qwen3.7-max non-stream" qwen3.7-max "")
+code=$(echo "$body" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('type',''))" 2>/dev/null || echo "non-json")
+if [ "$code" = "message" ]; then
+  echo "[OK] claude-code /v1/messages qwen3.7-max non-stream (Anthropic message type)"
+  pass=$((pass+1))
+else
+  echo "[X] expected Anthropic message type, got: $(echo "$body" | head -c 300)"
+  fail=$((fail+1))
+fi
+
+echo "== 2. Anthropic protocol — streaming SSE (qwen3.7-max) =="
+body=$(curl -s -m 180 -N -X POST "http://127.0.0.1:${PORT}/v1/messages" \
+  -H "x-api-key: ${LOCAL_TOKEN}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"qwen3.7-max","max_tokens":96,"stream":true,"messages":[{"role":"user","content":"Count from 1 to 3."}]}')
+events=$(echo "$body" | grep -c '^event:')
+echo "  SSE events received: $events"
+[ "$events" -ge 3 ] && { echo "[OK] qwen3.7-max streaming SSE"; pass=$((pass+1)); } || { echo "[X] too few SSE events"; fail=$((fail+1)); }
+echo "$body" | grep -q 'message_stop' && { echo "[OK] message_stop event present"; pass=$((pass+1)); } || { echo "[X] no message_stop"; fail=$((fail+1)); }
+
+echo "== 3. OpenAI protocol (deepseek-v4-flash via /v1/messages → /chat/completions) — non-streaming =="
+body=$(msg_probe "deepseek non-stream" deepseek-v4-flash "")
+if echo "$body" | grep -q '"type":"message"'; then
+  echo "[OK] deepseek-v4-flash non-stream (translated to chat/completions, Anthropic-shaped reply)"
+  pass=$((pass+1))
+else
+  echo "[X] expected Anthropic-shaped reply, got: $(echo "$body" | head -c 300)"
+  fail=$((fail+1))
+fi
+
+echo "== 4. OpenAI protocol — streaming SSE (deepseek-v4-flash) =="
+body=$(curl -s -m 180 -N -X POST "http://127.0.0.1:${PORT}/v1/messages" \
+  -H "x-api-key: ${LOCAL_TOKEN}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"deepseek-v4-flash","max_tokens":96,"stream":true,"messages":[{"role":"user","content":"Count from 1 to 3."}]}')
+events=$(echo "$body" | grep -c '^event:')
+echo "  SSE events received: $events"
+[ "$events" -ge 3 ] && { echo "[OK] deepseek-v4-flash streaming SSE"; pass=$((pass+1)); } || { echo "[X] too few SSE events"; fail=$((fail+1)); }
+echo "$body" | grep -q 'message_stop' && { echo "[OK] message_stop present"; pass=$((pass+1)); } || { echo "[X] no message_stop"; fail=$((fail+1)); }
+
+echo "== 5. Responses-protocol model rejected locally (gpt-5.5) =="
+code=$(curl -s -m 30 -o /dev/null -w "%{http_code}" -X POST "http://127.0.0.1:${PORT}/v1/messages" \
+  -H "x-api-key: ${LOCAL_TOKEN}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}')
+check "gpt-5.5 local 400, no dispatch" 400 "$code"
+
+echo "== 6. /v1/messages claude-sonnet-4-6 (go tier has no claude-* models; expect upstream error, not local 400) =="
+resp=$(curl -s -m 60 -w '\n%{http_code}' -X POST "http://127.0.0.1:${PORT}/v1/messages" \
+  -H "x-api-key: ${LOCAL_TOKEN}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d '{"model":"claude-sonnet-4-6","max_tokens":16,"messages":[{"role":"user","content":"hi"}]}')
+code=$(echo "$resp" | tail -1)
+body=$(echo "$resp" | head -n -1)
+echo "  status: $code, body: $(echo "$body" | head -c 220)"
+if [ "$code" != "400" ] || echo "$body" | grep -q 'invalid_request_error'; then
+  echo "[OK] claude-sonnet-4-6 did NOT short-circuit locally (routed to /messages, upstream answered)"
+  pass=$((pass+1))
+else
+  echo "[X] claude-sonnet-4-6 rejected locally (should have been routed upstream)"
+  fail=$((fail+1))
+fi
+
+echo
+echo "RESULT: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/verify-opencode-proxy.sh
+++ b/scripts/verify-opencode-proxy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Live verification for the OpenCode Zen/Go proxy adapter.
+#
+# Starts the OpenAI-compat proxy daemon against a scratch profile pointing at
+# an OpenCode gateway and exercises the three routing paths:
+#   - Anthropic-family model  -> <base>/messages with x-api-key        (expect 401 from gateway)
+#   - chat-completions model  -> <base>/chat/completions with Bearer   (expect 401 from gateway)
+#   - Responses-protocol model -> local 400, no upstream dispatch
+#
+# Without a real key the gateway answers 401 "Invalid API key." — the 401 body
+# shape is protocol-native, which is what proves the route + auth header are
+# correct. Set OPENCODE_API_KEY to a real key to see 200 responses instead.
+#
+# Usage:
+#   OPENCODE_API_KEY=<key> bash scripts/verify-opencode-proxy.sh [port]
+# Defaults: base https://opencode.ai/zen/v1, port 3999, dummy probe key.
+
+set -euo pipefail
+
+PORT="${1:-3999}"
+BASE_URL="${OPENCODE_BASE_URL:-https://opencode.ai/zen/v1}"
+API_KEY="${OPENCODE_API_KEY:-ccs_smoke_probe_key}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SMOKE_DIR="$(mktemp -d)"
+DAEMON_PID=""
+
+cleanup() {
+  if [ -n "$DAEMON_PID" ]; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  rm -rf "$SMOKE_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$SMOKE_DIR/.ccs"
+cat > "$SMOKE_DIR/.ccs/oc.settings.json" <<EOF
+{"env":{"ANTHROPIC_BASE_URL":"${BASE_URL}","ANTHROPIC_AUTH_TOKEN":"${API_KEY}","ANTHROPIC_MODEL":"claude-sonnet-4-6","CCS_DROID_PROVIDER":"generic-chat-completion-api"}}
+EOF
+cat > "$SMOKE_DIR/.ccs/config.json" <<EOF
+{"profiles":{"oc":"${SMOKE_DIR}/.ccs/oc.settings.json"},"proxy":{"routing":{}}}
+EOF
+
+CCS_HOME="$SMOKE_DIR" bun "$REPO_ROOT/src/proxy/proxy-daemon-entry.ts" \
+  --port "$PORT" --host 127.0.0.1 --profile oc \
+  --settings-path "$SMOKE_DIR/.ccs/oc.settings.json" --auth-token local-token &
+DAEMON_PID=$!
+
+for _ in $(seq 1 50); do
+  if curl -s -m 2 "http://127.0.0.1:${PORT}/v1/models" -o /dev/null; then
+    break
+  fi
+  sleep 0.2
+done
+
+probe() {
+  local model="$1" expected="$2" label="$3"
+  local code
+  code=$(curl -s -m 30 -o /dev/null -w "%{http_code}" -X POST \
+    "http://127.0.0.1:${PORT}/v1/messages" \
+    -H "x-api-key: local-token" -H "content-type: application/json" \
+    -d "{\"model\":\"${model}\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}]}")
+  if [ "$code" = "$expected" ]; then
+    echo "[OK] ${label} (HTTP ${code})"
+  else
+    echo "[X] ${label}: expected HTTP ${expected}, got ${code}"
+    exit 1
+  fi
+}
+
+probe claude-sonnet-4-6 401 "Anthropic-family model -> /messages with x-api-key"
+probe deepseek-v4-flash 401 "chat-completions model -> /chat/completions with Bearer"
+probe gpt-5.5 400 "Responses-protocol model rejected locally before dispatch"

--- a/src/proxy/opencode-protocol.ts
+++ b/src/proxy/opencode-protocol.ts
@@ -1,0 +1,111 @@
+/**
+ * OpenCode Zen / Go protocol adapter.
+ *
+ * OpenCode Zen (`https://opencode.ai/zen/v1`) and OpenCode Go
+ * (`https://opencode.ai/zen/go/v1`) are multi-protocol gateways: one API key,
+ * four protocol shims under one host. The protocol is chosen per model
+ * family, and the gateway rejects cross-protocol requests, so the proxy must
+ * route each request to the protocol-native path and auth header.
+ *
+ *   Anthropic  /messages                    -> Claude, Qwen Plus/Max, MiniMax M3/M2.x
+ *   OpenAI     /chat/completions            -> Grok, DeepSeek, GLM, Kimi, free models (default)
+ *   OpenAI     /responses                   -> GPT-5.x / Codex (not translated by this adapter)
+ *   Google     /models/{model}:generateContent -> Gemini (blocked by upstream bug, issue #8228)
+ *
+ * Verified against the live endpoints 2026-08-04; see
+ * docs/opencode-zen-go-compat.md for the full matrix and caveats.
+ */
+
+export type OpenCodeProtocol = 'chat-completions' | 'anthropic' | 'responses' | 'gemini';
+
+export type OpenCodeUpstreamMode =
+  | { mode: 'chat-completions' }
+  | { mode: 'anthropic' }
+  | { mode: 'unsupported'; reason: string };
+
+/** Required on every Anthropic-protocol request per Anthropic convention. */
+export const OPENCODE_ANTHROPIC_VERSION = '2023-06-01';
+
+const OPENCODE_ANTHROPIC_MODEL_PATTERNS = [/^claude-/i, /^qwen3/i, /^minimax-m/i];
+const OPENCODE_RESPONSES_MODEL_PATTERNS = [/^gpt-/i, /^codex-/i];
+const OPENCODE_GEMINI_MODEL_PATTERNS = [/^gemini-/i];
+
+/** OpenCode-internal provider prefixes; never sent to the gateway. */
+const OPENCODE_PROVIDER_PREFIXES = [/^opencode-go\//i, /^opencode\//i];
+
+/** True when the upstream host is an OpenCode Zen/Go gateway. */
+export function isOpenCodeHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'opencode.ai' || normalized.endsWith('.opencode.ai');
+}
+
+function stripOpenCodeProviderPrefix(model: string): string {
+  let normalized = model.trim();
+  for (const prefix of OPENCODE_PROVIDER_PREFIXES) {
+    normalized = normalized.replace(prefix, '');
+  }
+  return normalized;
+}
+
+/**
+ * Map a bare OpenCode model id to its protocol family. Unknown or missing
+ * models default to chat-completions, the gateway's default protocol.
+ * `opencode/…` / `opencode-go/…` provider prefixes are stripped before
+ * classification; they are OpenCode-internal and never sent upstream.
+ */
+export function classifyOpenCodeModel(model: string | undefined | null): OpenCodeProtocol {
+  const normalized = stripOpenCodeProviderPrefix(model?.trim() || '');
+  if (!normalized) {
+    return 'chat-completions';
+  }
+
+  if (OPENCODE_ANTHROPIC_MODEL_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return 'anthropic';
+  }
+  if (OPENCODE_RESPONSES_MODEL_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return 'responses';
+  }
+  if (OPENCODE_GEMINI_MODEL_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return 'gemini';
+  }
+  return 'chat-completions';
+}
+
+/**
+ * Resolve the upstream mode for a request against an OpenCode gateway.
+ * Returns null when the base URL is not an OpenCode host, so callers keep
+ * their existing passthrough/translation logic for every other provider.
+ */
+export function resolveOpenCodeUpstreamMode(
+  baseUrl: string,
+  model: string | undefined | null
+): OpenCodeUpstreamMode | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (!isOpenCodeHost(parsed.hostname)) {
+    return null;
+  }
+
+  const protocol = classifyOpenCodeModel(model);
+  if (protocol === 'anthropic') {
+    return { mode: 'anthropic' };
+  }
+  if (protocol === 'responses') {
+    return {
+      mode: 'unsupported',
+      reason: `Model '${model}' uses the OpenAI Responses protocol (/v1/responses), which the CCS OpenCode adapter does not translate yet. Use a chat-completions or Anthropic-protocol model.`,
+    };
+  }
+  if (protocol === 'gemini') {
+    return {
+      mode: 'unsupported',
+      reason: `Model '${model}' uses the Google Generative Language protocol, which is disabled in the CCS OpenCode adapter because Zen's generateContent endpoint has a known server-side bug (opencode issue #8228).`,
+    };
+  }
+  return { mode: 'chat-completions' };
+}

--- a/src/proxy/server/messages-route.ts
+++ b/src/proxy/server/messages-route.ts
@@ -8,6 +8,7 @@ import {
   type ProxyOpenAIRequest,
 } from '../transformers/request-transformer';
 import { ProxySseStreamTransformer } from '../transformers/sse-stream-transformer';
+import { OPENCODE_ANTHROPIC_VERSION, resolveOpenCodeUpstreamMode } from '../opencode-protocol';
 import { isAnthropicPassthroughProfile, resolveOpenAIChatCompletionsUrl } from '../upstream-url';
 import { createLogger } from '../../services/logging';
 import {
@@ -40,13 +41,21 @@ class ProxyInputError extends Error {
 function buildUpstreamHeaders(
   profile: OpenAICompatProfileConfig,
   incomingHeaders: http.IncomingHttpHeaders,
-  options: { preserveUserAgent?: boolean } = {}
+  options: { preserveUserAgent?: boolean; openCodeAnthropic?: boolean } = {}
 ): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${profile.apiKey}`,
     'User-Agent': 'CCS-OpenAI-Compat-Proxy/1.0',
   };
+
+  if (options.openCodeAnthropic) {
+    // OpenCode's Anthropic shim (/messages) authenticates with x-api-key and
+    // requires the anthropic-version header; Bearer is rejected with 401.
+    headers['x-api-key'] = profile.apiKey;
+    headers['anthropic-version'] = OPENCODE_ANTHROPIC_VERSION;
+  } else {
+    headers['Authorization'] = `Bearer ${profile.apiKey}`;
+  }
 
   if (options.preserveUserAgent) {
     // Preserve the original User-Agent (or x-stainless-user-agent fallback) so
@@ -382,11 +391,15 @@ function buildFetchInit(
   signal: AbortSignal,
   incomingHeaders: http.IncomingHttpHeaders,
   preserveUserAgent: boolean,
-  dispatcher?: Dispatcher
+  dispatcher?: Dispatcher,
+  openCodeAnthropic?: boolean
 ): RequestInit {
   const init: RequestInit = {
     method: 'POST',
-    headers: buildUpstreamHeaders(profile, incomingHeaders, { preserveUserAgent }),
+    headers: buildUpstreamHeaders(profile, incomingHeaders, {
+      preserveUserAgent,
+      openCodeAnthropic,
+    }),
     body,
     signal,
   };
@@ -523,13 +536,34 @@ export async function handleProxyMessagesRequest(
     const rawBodyText = await readRawBody(req);
     const rawBody = parseJsonBodyText(rawBodyText);
     const initialRoute = resolveProxyRequestRoute(profile, buildRoutingRequest(rawBody));
-    const passthrough = isAnthropicPassthroughProfile(initialRoute.profile.baseUrl, {
-      forcePassthrough: initialRoute.profile.passthrough === true,
-    });
+    const initialOpenCodeMode = resolveOpenCodeUpstreamMode(
+      initialRoute.profile.baseUrl,
+      initialRoute.model || initialRoute.profile.model
+    );
+    if (initialOpenCodeMode?.mode === 'unsupported') {
+      await pipeWebResponseToNode(
+        transformer.error(400, 'invalid_request_error', initialOpenCodeMode.reason),
+        res
+      );
+      return;
+    }
+    // OpenCode gateways route by model family: Anthropic-protocol models must
+    // hit /messages with x-api-key, chat-completions models must stay on the
+    // OpenAI path. OpenCode hosts override the generic host-based passthrough
+    // (and the force-passthrough flag) so chat models are never sent to
+    // /messages, which the gateway rejects.
+    let passthrough: boolean;
+    passthrough = initialOpenCodeMode
+      ? initialOpenCodeMode.mode === 'anthropic'
+      : isAnthropicPassthroughProfile(initialRoute.profile.baseUrl, {
+          forcePassthrough: initialRoute.profile.passthrough === true,
+        });
     logger.stage('transform', 'request.transform.start', 'Transforming inbound proxy body', {
       passthrough,
+      openCodeMode: initialOpenCodeMode?.mode ?? null,
     });
-    const upstream = buildUpstreamRequest(profile, rawBody, {
+    let upstream: ReturnType<typeof buildUpstreamRequest>;
+    upstream = buildUpstreamRequest(profile, rawBody, {
       passthrough,
       rawBodyText,
       route: passthrough ? initialRoute : undefined,
@@ -585,6 +619,38 @@ export async function handleProxyMessagesRequest(
         insecureTls,
         passthrough,
       });
+      const routedOpenCodeMode = resolveOpenCodeUpstreamMode(
+        upstream.route.profile.baseUrl,
+        upstream.route.model || upstream.route.profile.model
+      );
+      if (routedOpenCodeMode?.mode === 'unsupported') {
+        await pipeWebResponseToNode(
+          transformer.error(400, 'invalid_request_error', routedOpenCodeMode.reason),
+          res
+        );
+        return;
+      }
+      const openCodeAnthropic = routedOpenCodeMode?.mode === 'anthropic';
+      if (openCodeAnthropic && !passthrough) {
+        // Scenario routing (think/webSearch/…) can land on an OpenCode
+        // profile after the body was already translated to OpenAI shape.
+        // Rebuild as a passthrough so the Anthropic-family model receives
+        // an Anthropic-shaped body on /messages.
+        logger.stage(
+          'transform',
+          'request.transform.reroute',
+          'Rebuilding request as OpenCode Anthropic passthrough',
+          {
+            routedProfileName: upstream.route.profile.profileName,
+          }
+        );
+        upstream = buildUpstreamRequest(profile, rawBody, {
+          passthrough: true,
+          rawBodyText,
+          route: upstream.route,
+        });
+        passthrough = true;
+      }
       const upstreamUrl = resolveOpenAIChatCompletionsUrl(upstream.route.profile.baseUrl, {
         passthrough,
       });
@@ -596,7 +662,8 @@ export async function handleProxyMessagesRequest(
           controller.signal,
           req.headers,
           passthrough,
-          dispatcher
+          dispatcher,
+          openCodeAnthropic
         )
       );
       logger.stage('upstream', 'upstream.response', 'Received upstream response', {

--- a/tests/unit/proxy/messages-route.test.ts
+++ b/tests/unit/proxy/messages-route.test.ts
@@ -110,6 +110,12 @@ beforeEach(() => {
       ANTHROPIC_MODEL: 'kimi-k2p7-coding',
       CCS_DROID_PROVIDER: 'generic-chat-completion-api',
     }),
+    opencode: writeSettings('opencode', {
+      ANTHROPIC_BASE_URL: 'https://opencode.ai/zen/v1',
+      ANTHROPIC_AUTH_TOKEN: 'opencode_key',
+      ANTHROPIC_MODEL: 'deepseek-v4-flash',
+      CCS_DROID_PROVIDER: 'generic-chat-completion-api',
+    }),
   };
 
   fs.writeFileSync(
@@ -205,7 +211,12 @@ describe('handleProxyMessagesRequest', () => {
       'x-api-key': 'local-token',
     });
     const res = new FakeResponse();
-    const pending = handleProxyMessagesRequest(req as never, res as never, activeProfile, 'local-token');
+    const pending = handleProxyMessagesRequest(
+      req as never,
+      res as never,
+      activeProfile,
+      'local-token'
+    );
     req.end(
       JSON.stringify({
         model: 'hf-default',
@@ -546,5 +557,166 @@ describe('handleProxyMessagesRequest', () => {
     expect((capturedBody as { messages: Array<{ role: string }> }).messages).not.toContainEqual(
       expect.objectContaining({ role: 'system' })
     );
+  });
+
+  it('routes OpenCode Claude-family models to /messages with x-api-key auth and verbatim body', async () => {
+    const activeProfile = buildProfile('opencode');
+    let capturedInput: RequestInfo | URL | undefined;
+    let capturedInit: RequestInit | undefined;
+    const rawBody = JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 50,
+      messages: [{ role: 'user', content: 'Say hi' }],
+    });
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedInput = input;
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          id: 'msg_opencode_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello!' }],
+          model: 'claude-sonnet-4-6',
+          stop_reason: 'end_turn',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as typeof globalThis.fetch;
+
+    const req = new FakeRequest({
+      'x-api-key': 'local-token',
+      'user-agent': 'claude-cli/2.1.170',
+    });
+    const res = new FakeResponse();
+    const pending = handleProxyMessagesRequest(
+      req as never,
+      res as never,
+      activeProfile,
+      'local-token'
+    );
+    req.end(rawBody);
+    await pending;
+
+    expect(String(capturedInput)).toBe('https://opencode.ai/zen/v1/messages');
+    expect(capturedInit?.body).toBe(rawBody);
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('opencode_key');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['Authorization']).toBeUndefined();
+    expect(headers['User-Agent']).toBe('claude-cli/2.1.170');
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('routes OpenCode chat-completions models to /chat/completions with Bearer auth', async () => {
+    const activeProfile = buildProfile('opencode');
+    let capturedInput: RequestInfo | URL | undefined;
+    let capturedInit: RequestInit | undefined;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      capturedInput = input;
+      capturedInit = init;
+      return new Response(
+        JSON.stringify({
+          id: 'chatcmpl_opencode_1',
+          object: 'chat.completion',
+          created: 1,
+          model: 'deepseek-v4-flash',
+          choices: [{ index: 0, message: { role: 'assistant', content: 'ok' } }],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as typeof globalThis.fetch;
+
+    const req = new FakeRequest({
+      'x-api-key': 'local-token',
+    });
+    const res = new FakeResponse();
+    const pending = handleProxyMessagesRequest(
+      req as never,
+      res as never,
+      activeProfile,
+      'local-token'
+    );
+    req.end(
+      JSON.stringify({
+        model: 'deepseek-v4-flash',
+        messages: [{ role: 'user', content: 'stay translated' }],
+      })
+    );
+    await pending;
+
+    expect(String(capturedInput)).toBe('https://opencode.ai/zen/v1/chat/completions');
+    expect(JSON.parse(String(capturedInit?.body))).toMatchObject({
+      model: 'deepseek-v4-flash',
+      messages: [{ role: 'user', content: 'stay translated' }],
+    });
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer opencode_key');
+    expect(headers['x-api-key']).toBeUndefined();
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects OpenCode Responses-protocol models with a 400 before dispatch', async () => {
+    const activeProfile = buildProfile('opencode');
+    let fetchCalled = false;
+
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response('{}', { status: 500 });
+    }) as typeof globalThis.fetch;
+
+    const req = new FakeRequest({
+      'x-api-key': 'local-token',
+    });
+    const res = new FakeResponse();
+    const pending = handleProxyMessagesRequest(
+      req as never,
+      res as never,
+      activeProfile,
+      'local-token'
+    );
+    req.end(
+      JSON.stringify({
+        model: 'gpt-5.5',
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+    );
+    await pending;
+
+    expect(fetchCalled).toBe(false);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects OpenCode Gemini models with a 400 before dispatch', async () => {
+    const activeProfile = buildProfile('opencode');
+    let fetchCalled = false;
+
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response('{}', { status: 500 });
+    }) as typeof globalThis.fetch;
+
+    const req = new FakeRequest({
+      'x-api-key': 'local-token',
+    });
+    const res = new FakeResponse();
+    const pending = handleProxyMessagesRequest(
+      req as never,
+      res as never,
+      activeProfile,
+      'local-token'
+    );
+    req.end(
+      JSON.stringify({
+        model: 'gemini-3.6-flash',
+        messages: [{ role: 'user', content: 'hi' }],
+      })
+    );
+    await pending;
+
+    expect(fetchCalled).toBe(false);
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/tests/unit/proxy/opencode-protocol.test.ts
+++ b/tests/unit/proxy/opencode-protocol.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  OPENCODE_ANTHROPIC_VERSION,
+  classifyOpenCodeModel,
+  isOpenCodeHost,
+  resolveOpenCodeUpstreamMode,
+} from '../../../src/proxy/opencode-protocol';
+
+describe('isOpenCodeHost', () => {
+  it('detects opencode.ai and subdomains', () => {
+    expect(isOpenCodeHost('opencode.ai')).toBe(true);
+    expect(isOpenCodeHost('api.opencode.ai')).toBe(true);
+    expect(isOpenCodeHost('OPENCODE.AI')).toBe(true);
+  });
+
+  it('rejects unrelated hosts', () => {
+    expect(isOpenCodeHost('api.anthropic.com')).toBe(false);
+    expect(isOpenCodeHost('opencode.example.com')).toBe(false);
+    expect(isOpenCodeHost('notopencode.ai')).toBe(false);
+  });
+});
+
+describe('classifyOpenCodeModel', () => {
+  it('routes Anthropic-family models to the /messages protocol', () => {
+    expect(classifyOpenCodeModel('claude-sonnet-4-6')).toBe('anthropic');
+    expect(classifyOpenCodeModel('claude-fable-5')).toBe('anthropic');
+    expect(classifyOpenCodeModel('qwen3-max')).toBe('anthropic');
+    expect(classifyOpenCodeModel('minimax-m3')).toBe('anthropic');
+    expect(classifyOpenCodeModel('MiniMax-M2.7')).toBe('anthropic');
+  });
+
+  it('routes GPT/Codex models to the responses protocol', () => {
+    expect(classifyOpenCodeModel('gpt-5.5')).toBe('responses');
+    expect(classifyOpenCodeModel('gpt-5.6-sol')).toBe('responses');
+    expect(classifyOpenCodeModel('gpt-5.1-codex')).toBe('responses');
+  });
+
+  it('routes Gemini models to the gemini protocol', () => {
+    expect(classifyOpenCodeModel('gemini-3.6-flash')).toBe('gemini');
+    expect(classifyOpenCodeModel('gemini-3.1-pro')).toBe('gemini');
+  });
+
+  it('defaults chat-completions models and unknown ids to chat-completions', () => {
+    expect(classifyOpenCodeModel('deepseek-v4-flash')).toBe('chat-completions');
+    expect(classifyOpenCodeModel('grok-4.5')).toBe('chat-completions');
+    expect(classifyOpenCodeModel('glm-5')).toBe('chat-completions');
+    expect(classifyOpenCodeModel('kimi-k2.7')).toBe('chat-completions');
+    expect(classifyOpenCodeModel('deepseek-v4-flash-free')).toBe('chat-completions');
+    expect(classifyOpenCodeModel('some-unknown-model')).toBe('chat-completions');
+  });
+
+  it('handles missing or empty model ids', () => {
+    expect(classifyOpenCodeModel(undefined)).toBe('chat-completions');
+    expect(classifyOpenCodeModel(null)).toBe('chat-completions');
+    expect(classifyOpenCodeModel('  ')).toBe('chat-completions');
+  });
+
+  it('strips OpenCode-internal provider prefixes before classifying', () => {
+    expect(classifyOpenCodeModel('opencode/claude-sonnet-4-6')).toBe('anthropic');
+    expect(classifyOpenCodeModel('opencode-go/deepseek-v4-flash')).toBe('chat-completions');
+    expect(classifyOpenCodeModel('opencode-go/MiniMax-M3')).toBe('anthropic');
+    expect(classifyOpenCodeModel('opencode/gpt-5.5')).toBe('responses');
+  });
+});
+
+describe('resolveOpenCodeUpstreamMode', () => {
+  it('returns null for non-OpenCode hosts', () => {
+    expect(
+      resolveOpenCodeUpstreamMode('https://api.anthropic.com', 'claude-sonnet-4-6')
+    ).toBeNull();
+    expect(resolveOpenCodeUpstreamMode('https://api.deepseek.com/v1', 'deepseek-chat')).toBeNull();
+  });
+
+  it('returns null for malformed base URLs', () => {
+    expect(resolveOpenCodeUpstreamMode('not a url', 'deepseek-v4-flash')).toBeNull();
+  });
+
+  it('resolves anthropic mode for Claude-family models on OpenCode hosts', () => {
+    expect(resolveOpenCodeUpstreamMode('https://opencode.ai/zen/v1', 'claude-sonnet-4-6')).toEqual({
+      mode: 'anthropic',
+    });
+    expect(resolveOpenCodeUpstreamMode('https://opencode.ai/zen/go/v1', 'qwen3-max')).toEqual({
+      mode: 'anthropic',
+    });
+  });
+
+  it('resolves chat-completions mode for OpenAI-compatible models', () => {
+    expect(resolveOpenCodeUpstreamMode('https://opencode.ai/zen/v1', 'deepseek-v4-flash')).toEqual({
+      mode: 'chat-completions',
+    });
+    expect(resolveOpenCodeUpstreamMode('https://opencode.ai/zen/v1', undefined)).toEqual({
+      mode: 'chat-completions',
+    });
+  });
+
+  it('flags responses-protocol models as unsupported', () => {
+    const mode = resolveOpenCodeUpstreamMode('https://opencode.ai/zen/v1', 'gpt-5.5');
+    expect(mode).not.toBeNull();
+    expect(mode!.mode).toBe('unsupported');
+    expect(mode!.mode === 'unsupported' && mode.reason).toContain('Responses');
+  });
+
+  it('flags gemini-protocol models as unsupported', () => {
+    const mode = resolveOpenCodeUpstreamMode('https://opencode.ai/zen/v1', 'gemini-3.6-flash');
+    expect(mode).not.toBeNull();
+    expect(mode!.mode).toBe('unsupported');
+    expect(mode!.mode === 'unsupported' && mode.reason).toContain('generateContent');
+  });
+});
+
+describe('OPENCODE_ANTHROPIC_VERSION', () => {
+  it('matches the Anthropic API version required by the gateway', () => {
+    expect(OPENCODE_ANTHROPIC_VERSION).toBe('2023-06-01');
+  });
+});


### PR DESCRIPTION
## OpenCode Zen/Go protocol adapter for the OpenAI-compat proxy

Adds automatic model-to-protocol routing for OpenCode Zen/Go gateways
(`opencode.ai` / `*.opencode.ai`) to the OpenAI-compat proxy daemon. OpenCode
is a multi-protocol gateway: one API key, one host, four protocol shims. The
gateway rejects cross-protocol requests, so the proxy now picks the
protocol-native path and auth header per model family.

### Adapter behavior

| Model family | Upstream path | Auth header |
|---|---|---|
| `claude-*`, `qwen3*`, `minimax-m*` | `<base>/messages` | `x-api-key` + `anthropic-version: 2023-06-01` |
| everything else (deepseek, grok, glm, kimi, free models) | `<base>/chat/completions` | `Authorization: Bearer` |
| `gpt-*`, `codex-*` (Responses protocol) | — | local 400 with explanation, no dispatch |
| `gemini-*` (Google protocol) | — | local 400 (upstream bug opencode issue #8228) |

No new config flag or env var: OpenCode hosts are auto-detected, matching the
existing Kimi/Anthropic passthrough convention. OpenCode host detection
overrides `CCS_OPENAI_PROXY_PASSTHROUGH` so chat-completions models are never
sent to `/messages`, which the gateway rejects. Anthropic-family models on an
OpenCode profile get a passthrough rebuild even when scenario routing lands on
the profile after translation.

### Changes

- `src/proxy/opencode-protocol.ts` — host detection, model classification, upstream-mode resolution
- `src/proxy/server/messages-route.ts` — OpenCode-aware passthrough decision + `x-api-key`/`anthropic-version` upstream headers
- `tests/unit/proxy/opencode-protocol.test.ts`, `tests/unit/proxy/messages-route.test.ts` — 20 new unit cases
- `scripts/verify-opencode-proxy.sh` — dummy-key smoke script (401/400 routing proof)
- `scripts/verify-opencode-local-e2e.sh` — live local-proxy e2e with a real key
- `docs/opencode-zen-go-compat.md` — full protocol matrix + verification record

### Verification (all green)

- Unit: 88 proxy tests pass; fast bucket 410 files pass; typecheck, lint (0 errors), prettier clean
- Live e2e through the local proxy daemon against `https://opencode.ai/zen/go/v1`
  with a real key (2026-08-04, `scripts/verify-opencode-local-e2e.sh`):
  - Claude Code contract `POST /v1/messages` + `qwen3.7-max` — non-streaming: 200, Anthropic `message` with real content; `stream: true`: 200, 78 SSE events incl. `message_stop`
  - OpenAI contract via `/v1/messages` + `deepseek-v4-flash` (translated to `<base>/chat/completions` + Bearer) — non-streaming: 200; streaming: 200, 51 SSE events
  - `gpt-5.5` → local 400, no upstream dispatch
  - `claude-sonnet-4-6` → routed upstream (not short-circuited); gateway answers `401 ModelError: Model claude-sonnet-4-6 is not supported` (the go tier catalog has no `claude-*` models — use `qwen3*`/`minimax-m*` there; `/zen/v1` remains the Claude tier)
- OpenCode CLI (`opencode-ai`) e2e attempted: the binary is blocked by the Hermes sandbox guard (embeds gateway-management strings; false positive). Wire contract OpenCode sends (`/v1/messages`, `x-api-key`, `anthropic-version`) is exactly what the local e2e above exercises. Details in `docs/opencode-zen-go-compat.md`.

### Notes for maintainers

- `/zen/go/v1` works identically for Go-tier models; `claude-*` models exist on `/zen/v1` only.
- Gemini remains disabled upstream-side (opencode issue #8228); Responses protocol translation is future work tracked in the compat doc.
