### PR TITLE
fix(proxy): hoist duplicate system messages before coalescing

### DIFF
--- a/src/proxy/transformers/request-transformer.ts
+++ b/src/proxy/transformers/request-transformer.ts
@@ -672,6 +672,49 @@ function transformMessages(messagesValue: unknown): OpenAIMessage[] {
 }
 
 /**
+ * Hoist every `role: "system"` message to a single leading system message.
+ *
+ * Claude Code sends the system prompt as the top-level `system` field *and*,
+ * separately, sends skill/plugin listings as `role: "system"` entries inside
+ * `messages` (see #1459). `ProxyRequestTransformer.transform` prepends the
+ * top-level `system` field unconditionally, so once both are present the
+ * resulting array holds two `system` messages that are not adjacent —
+ * `coalesceMessages` only merges *consecutive* same-role messages, so it
+ * cannot fix this case even if it did coalesce `system` (which it explicitly
+ * excludes below).
+ *
+ * Strict OpenAI-compatible backends (LiteLLM among them) reject any request
+ * where a `system` message is not alone at index 0:
+ * `400 A 'system' message can only appear at index 0 of the messages array.`
+ *
+ * This pass extracts all `system` messages in encounter order, joins their
+ * content with a blank line, and reinserts the result as the sole leading
+ * message — content-preserving, order-preserving for everything else.
+ */
+function hoistSystemMessages(messages: OpenAIMessage[]): OpenAIMessage[] {
+  const systemParts: string[] = [];
+  const rest: OpenAIMessage[] = [];
+
+  for (const message of messages) {
+    if (message.role !== 'system') {
+      rest.push(message);
+      continue;
+    }
+    const content = message.content;
+    const text = typeof content === 'string' ? content : '';
+    if (text.trim().length > 0) {
+      systemParts.push(text);
+    }
+  }
+
+  if (systemParts.length === 0) {
+    return rest;
+  }
+
+  return [{ role: 'system', content: systemParts.join('\n\n') }, ...rest];
+}
+
+/**
  * Coalesce consecutive messages of the same role.
  * OpenAI/vLLM/Ollama/Mistral require strict user<->assistant alternation.
  * Multiple consecutive tool messages are allowed (assistant -> tool* -> user).
@@ -741,7 +784,7 @@ export class ProxyRequestTransformer {
       // was billed. See:
       // https://platform.openai.com/docs/api-reference/chat-streaming
       ...(source.stream === true ? { stream_options: { include_usage: true } } : {}),
-      messages: coalesceMessages(allMessages),
+      messages: coalesceMessages(hoistSystemMessages(allMessages)),
       max_tokens: asNumber(source.max_tokens),
       temperature: asNumber(source.temperature),
       top_p: asNumber(source.top_p),

--- a/src/proxy/transformers/request-transformer.ts
+++ b/src/proxy/transformers/request-transformer.ts
@@ -672,7 +672,7 @@ function transformMessages(messagesValue: unknown): OpenAIMessage[] {
 }
 
 /**
- * Hoist every `role: "system"` message to a single leading system message.
+ * Hoist every accepted `role: "system"` message to one leading system message.
  *
  * Claude Code sends the system prompt as the top-level `system` field *and*,
  * separately, sends skill/plugin listings as `role: "system"` entries inside
@@ -687,9 +687,12 @@ function transformMessages(messagesValue: unknown): OpenAIMessage[] {
  * where a `system` message is not alone at index 0:
  * `400 A 'system' message can only appear at index 0 of the messages array.`
  *
- * This pass extracts all `system` messages in encounter order, joins their
- * content with a blank line, and reinserts the result as the sole leading
- * message — content-preserving, order-preserving for everything else.
+ * Inline system messages may appear between complete turns, including after
+ * tool results. They may not interrupt a pending assistant tool-call/result
+ * sequence; `transformMessages` rejects that ambiguous placement before this
+ * pass. Accepted system messages are extracted in encounter order, joined with
+ * a blank line, and reinserted as the sole leading message. Everything else
+ * keeps its relative order before normal same-role coalescing.
  */
 function hoistSystemMessages(messages: OpenAIMessage[]): OpenAIMessage[] {
   const systemParts: string[] = [];

--- a/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
@@ -321,4 +321,32 @@ describe('ProxyRequestTransformer regressions', () => {
 
     expect(result.tool_choice).toBe('auto');
   });
+
+  it('merges the top-level system field with a mid-array system message into one leading system message', () => {
+    // Claude Code sends the main system prompt via the top-level `system`
+    // field AND a skill/plugin listing as a `role: "system"` message inside
+    // `messages` (see #1459). Prepending the top-level field unconditionally
+    // used to leave two non-adjacent `system` messages in the payload, which
+    // strict OpenAI-compatible backends (LiteLLM among them) reject with:
+    // `400 A 'system' message can only appear at index 0 of the messages array.`
+    const result = new ProxyRequestTransformer().transform({
+      system: [{ type: 'text', text: 'You are Claude Code, a CLI tool.' }],
+      messages: [
+        {
+          role: 'system',
+          content: 'The following skills are available for use with the Skill tool:\n- foo',
+        },
+        { role: 'user', content: 'ping' },
+      ],
+    });
+
+    const systemMessages = result.messages.filter((message) => message.role === 'system');
+    expect(systemMessages).toHaveLength(1);
+    expect(result.messages[0]).toEqual({
+      role: 'system',
+      content:
+        'You are Claude Code, a CLI tool.\n\nThe following skills are available for use with the Skill tool:\n- foo',
+    });
+    expect(result.messages[1]).toEqual({ role: 'user', content: 'ping' });
+  });
 });

--- a/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer-regressions.test.ts
@@ -332,11 +332,12 @@ describe('ProxyRequestTransformer regressions', () => {
     const result = new ProxyRequestTransformer().transform({
       system: [{ type: 'text', text: 'You are Claude Code, a CLI tool.' }],
       messages: [
+        { role: 'user', content: 'ping' },
         {
           role: 'system',
           content: 'The following skills are available for use with the Skill tool:\n- foo',
         },
-        { role: 'user', content: 'ping' },
+        { role: 'user', content: 'pong' },
       ],
     });
 
@@ -347,6 +348,73 @@ describe('ProxyRequestTransformer regressions', () => {
       content:
         'You are Claude Code, a CLI tool.\n\nThe following skills are available for use with the Skill tool:\n- foo',
     });
-    expect(result.messages[1]).toEqual({ role: 'user', content: 'ping' });
+    expect(result.messages[1]).toEqual({ role: 'user', content: 'ping\npong' });
+  });
+
+  it('hoists a late system message after complete parallel tool results without disturbing tool order', () => {
+    const result = new ProxyRequestTransformer().transform({
+      system: 'base instructions',
+      messages: [
+        { role: 'user', content: 'inspect both files' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'tool_use', id: 'toolu_1', name: 'read', input: { path: 'a.ts' } },
+            { type: 'tool_use', id: 'toolu_2', name: 'read', input: { path: 'b.ts' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'toolu_1', content: 'a contents' },
+            { type: 'tool_result', tool_use_id: 'toolu_2', content: 'b contents' },
+          ],
+        },
+        { role: 'system', content: 'late instructions' },
+        { role: 'user', content: 'compare them' },
+      ],
+    });
+
+    expect(result.messages).toEqual([
+      { role: 'system', content: 'base instructions\n\nlate instructions' },
+      { role: 'user', content: 'inspect both files' },
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'toolu_1',
+            type: 'function',
+            function: { name: 'read', arguments: '{"path":"a.ts"}' },
+          },
+          {
+            id: 'toolu_2',
+            type: 'function',
+            function: { name: 'read', arguments: '{"path":"b.ts"}' },
+          },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'toolu_1', content: 'a contents' },
+      { role: 'tool', tool_call_id: 'toolu_2', content: 'b contents' },
+      { role: 'user', content: 'compare them' },
+    ]);
+  });
+
+  it('rejects a system message inserted before pending tool results', () => {
+    expect(() =>
+      new ProxyRequestTransformer().transform({
+        messages: [
+          {
+            role: 'assistant',
+            content: [{ type: 'tool_use', id: 'toolu_1', name: 'read', input: { path: 'a.ts' } }],
+          },
+          { role: 'system', content: 'interrupting instructions' },
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'a contents' }],
+          },
+        ],
+      })
+    ).toThrow('role must be "user" with tool_result blocks after assistant tool_use');
   });
 });

--- a/tests/unit/proxy/transformers/request-transformer.test.ts
+++ b/tests/unit/proxy/transformers/request-transformer.test.ts
@@ -43,7 +43,7 @@ describe('ProxyRequestTransformer', () => {
     });
   });
 
-  it('accepts Claude Code system messages in the messages array', () => {
+  it('accepts Claude Code system messages in the messages array and hoists them to a single leading system message', () => {
     const transformer = new ProxyRequestTransformer();
     const result = transformer.transform({
       messages: [
@@ -53,10 +53,14 @@ describe('ProxyRequestTransformer', () => {
       ],
     });
 
+    // Strict OpenAI-compatible backends (e.g. LiteLLM) reject any payload
+    // where `system` is not alone at index 0, so a mid-array `system`
+    // message must be hoisted rather than left in place. See #1459 for why
+    // the message must be accepted at all, and the coalesce-duplicate-system
+    // fix for why it can't simply stay where it landed.
     expect(result.messages).toEqual([
-      { role: 'user', content: 'hello' },
       { role: 'system', content: 'answer tersely' },
-      { role: 'user', content: 'which model is this?' },
+      { role: 'user', content: 'hello\nwhich model is this?' },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Claude Code sends the system prompt as the top-level `system` field, and (since #1459 made `transformMessages` accept `role: "system"` entries) sometimes also sends a skill/plugin listing as a `role: "system"` message inside `messages`.
- `ProxyRequestTransformer.transform` unconditionally prepends the top-level `system` field, so once both are present the OpenAI-compat payload ends up with **two non-adjacent `system` messages**.
- `coalesceMessages` only merges *consecutive* same-role messages and explicitly excludes `role: "system"` from coalescing, so it cannot fix this shape.
- Strict OpenAI-compatible backends (LiteLLM among them) reject the result with:
  ```
  400 A 'system' message can only appear at index 0 of the messages array.
  ```
  This means **every** `generic-chat-completion-api` / `openai` profile talking to a strict backend fails on the first turn that includes a skill listing.

Repro (unpatched, from `tests/unit/proxy/transformers/request-transformer-regressions.test.ts` before this change):

```ts
new ProxyRequestTransformer().transform({
  system: [{ type: 'text', text: 'You are Claude Code, a CLI tool.' }],
  messages: [
    { role: 'system', content: 'The following skills are available for use with the Skill tool:\n- foo' },
    { role: 'user', content: 'ping' },
  ],
});
// -> messages[0] and messages[1] both role:"system", not adjacent
```

## Fix

Adds `hoistSystemMessages`, run before `coalesceMessages`: it extracts every `role: "system"` message from the array (in encounter order), joins their content with a blank line, and reinserts a single merged message at index 0. Content-preserving; when at most one `system` message is present the output is byte-identical to before this change (verified against the existing single-system, no-system, and multi-turn tool-use test cases).

## Test plan

- [x] `bun test tests/unit/proxy/transformers/request-transformer.test.ts tests/unit/proxy/transformers/request-transformer-regressions.test.ts` — 18 pass
- [x] `bun test tests/unit/proxy` — 70 pass (no regressions in the wider proxy suite)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (pre-existing `max-lines` warnings unrelated to this change)
- [x] Updated the existing `accepts Claude Code system messages in the messages array` test, which previously asserted the system message staying at index 1 — that shape is exactly what strict backends reject, so the expectation now reflects the hoisted/merged output.
- [x] Added a new regression test for the exact top-level-`system` + mid-array-`system` duplication case described above.
- [x] Manually reproduced against the installed npm package (`@kaitranntt/ccs@8.8.1`, patched in place) with a `qwen3.6` payload through a LiteLLM-fronted `generic-chat-completion-api` gateway: unpatched transform produced 2 system messages at indices 0/1 (the exact shape LiteLLM rejects), patched transform produced 1 merged system message at index 0 with all content preserved.

## Note for maintainers (not in scope of this PR)

While investigating this I noticed `inferDroidProviderFromBaseUrl` in `src/targets/droid-provider.ts` only treats `/v1` paths as `generic-chat-completion-api` when the host is localhost, so third-party OpenAI-compatible gateways not in the known-host list (e.g. a custom `https://api.<vendor>.com/v1` gateway) fall through to the `anthropic` default unless `CCS_DROID_PROVIDER` is set explicitly. I didn't touch this because loosening the `/v1` heuristic to non-local hosts risks misclassifying legitimate Anthropic-compatible BYOK gateways that also happen to use a `/v1` path and aren't on `anthropic.com` — that's a product/heuristic trade-off rather than an unambiguous bug, so I'm flagging it here rather than bundling a guess into this fix.