### PR TITLE
fix(codex): use current hooks feature key

### DIFF
--- a/src/web-server/services/codex-dashboard-service.ts
+++ b/src/web-server/services/codex-dashboard-service.ts
@@ -50,7 +50,7 @@ export {
 const KNOWN_CODEX_FEATURES = new Set([
   'apps',
   'apply_patch_freeform',
-  'codex_hooks',
+  'hooks',
   'fast_mode',
   'js_repl',
   'multi_agent',

--- a/tests/unit/web-server/codex-dashboard-service.test.ts
+++ b/tests/unit/web-server/codex-dashboard-service.test.ts
@@ -463,6 +463,27 @@ bearer_token = "secret"
     expect(result.config?.features).toEqual({ multi_agent: true });
   });
 
+  it('uses the current hooks feature key and rejects the deprecated codex_hooks key', async () => {
+    const result = await patchCodexConfig({
+      kind: 'feature',
+      feature: 'hooks',
+      enabled: true,
+    });
+
+    expect(result.rawText).toContain('[features]');
+    expect(result.rawText).toContain('hooks = true');
+    expect(result.rawText).not.toContain('codex_hooks');
+
+    await expect(
+      patchCodexConfig({
+        kind: 'feature',
+        feature: 'codex_hooks',
+        enabled: true,
+        expectedMtime: result.mtime,
+      })
+    ).rejects.toThrow(CodexRawConfigValidationError);
+  });
+
   it('preserves unsupported approval_policy objects when structured saves touch other fields', async () => {
     fs.writeFileSync(
       path.join(codexHome, 'config.toml'),


### PR DESCRIPTION
## Summary

- replace the deprecated `features.codex_hooks` dashboard key with `features.hooks`
- reject structured writes that would recreate `codex_hooks`
- add a regression test for the current key

## Validation

- `bun test tests/unit/web-server/codex-dashboard-service.test.ts` — 32 passed
- typecheck, lint, source format check, runtime matrix, and build stages passed locally
- local full/fast buckets hit the existing 2-second timeout in `tests/unit/cliproxy/concurrent-state-locks.test.ts`; the same file passed 6/6 when the local diagnostic wait was raised to 10 seconds, and that diagnostic edit was reverted before commit
- upstream CI jobs are gated to `COLLABORATOR`, `MEMBER`, or `OWNER`; this fork-authored PR therefore has no CI execution and requires maintainer review or an authorized rerun
