### PR TITLE
feat(cliproxy): add Grok 4.6 selection

### DIFF
--- a/src/cliproxy/__tests__/model-catalog-compat.test.ts
+++ b/src/cliproxy/__tests__/model-catalog-compat.test.ts
@@ -46,21 +46,62 @@ describe('model-catalog compatibility lookups', () => {
     expect(PROVIDER_TO_CHANNEL.xai).toBe('xai');
   });
 
-  it('merges live xAI model metadata while preserving the static coding default', () => {
+  it('merges live Grok 4.6 metadata while preserving the static coding default', () => {
     const catalog = mergeCatalog('xai', [
       { id: 'grok-build-0.1', display_name: 'Grok Build 0.1' },
       {
-        id: 'grok-4.5',
-        display_name: 'Grok 4.5',
-        thinking: { levels: ['low', 'medium', 'high'] },
+        id: 'grok-4.6',
+        display_name: 'Grok 4.6',
+        context_length: 500_000,
+        thinking: {
+          levels: ['low', 'medium', 'high', 'xhigh'],
+          zero_allowed: false,
+        },
       },
     ]);
 
     expect(catalog?.defaultModel).toBe('grok-build-0.1');
-    expect(catalog?.models[1]?.thinking).toMatchObject({
-      type: 'levels',
-      levels: ['low', 'medium', 'high'],
+    expect(catalog?.models[1]).toMatchObject({
+      id: 'grok-4.6',
+      contextWindow: 500_000,
+      thinking: {
+        type: 'levels',
+        levels: ['low', 'medium', 'high', 'xhigh'],
+        zeroAllowed: false,
+      },
     });
+    expect(catalog?.models[1]?.extendedContext).toBeUndefined();
+  });
+
+  it('preserves static zeroAllowed when live level metadata omits it', () => {
+    const catalog = mergeCatalog('xai', [
+      {
+        id: 'grok-4.3',
+        display_name: 'Grok 4.3',
+        thinking: { levels: ['none', 'low', 'medium', 'high'] },
+      },
+    ]);
+
+    expect(catalog?.models[0]?.thinking).toMatchObject({
+      type: 'levels',
+      levels: ['none', 'low', 'medium', 'high'],
+      zeroAllowed: true,
+    });
+  });
+
+  it('prefers explicit live zeroAllowed over static level metadata', () => {
+    const catalog = mergeCatalog('xai', [
+      {
+        id: 'grok-4.3',
+        display_name: 'Grok 4.3',
+        thinking: {
+          levels: ['low', 'medium', 'high'],
+          zero_allowed: false,
+        },
+      },
+    ]);
+
+    expect(catalog?.models[0]?.thinking?.zeroAllowed).toBe(false);
   });
 
   it('does not export extended-context capability from live xAI context length', () => {

--- a/src/cliproxy/__tests__/model-catalog.test.js
+++ b/src/cliproxy/__tests__/model-catalog.test.js
@@ -77,6 +77,7 @@ describe('Model Catalog', () => {
       const ids = MODEL_CATALOG.xai.models.map((model) => model.id);
       assert.deepStrictEqual(ids, [
         'grok-build-0.1',
+        'grok-4.6',
         'grok-4.5',
         'grok-4.3',
         'grok-4.20-0309-reasoning',
@@ -86,6 +87,18 @@ describe('Model Catalog', () => {
         'grok-3-mini-fast',
         'grok-composer-2.5-fast',
       ]);
+    });
+
+    it('includes Grok 4.6 with upstream reasoning metadata', () => {
+      const { MODEL_CATALOG } = modelCatalog;
+      const grok46 = MODEL_CATALOG.xai.models.find((model) => model.id === 'grok-4.6');
+
+      assert(grok46, 'Should include grok-4.6');
+      assert.strictEqual(grok46.name, 'Grok 4.6');
+      assert.strictEqual(grok46.contextWindow, 500000);
+      assert.strictEqual(grok46.thinking.type, 'levels');
+      assert.deepStrictEqual(grok46.thinking.levels, ['low', 'medium', 'high', 'xhigh']);
+      assert.strictEqual(grok46.thinking.zeroAllowed, false);
     });
 
     it('does not expose Claude [1m] suffix support for xAI model IDs', () => {

--- a/src/cliproxy/model-catalog.ts
+++ b/src/cliproxy/model-catalog.ts
@@ -324,6 +324,18 @@ export const MODEL_CATALOG: Partial<Record<CLIProxyProvider, ProviderCatalog>> =
         contextWindow: 256000,
       },
       {
+        id: 'grok-4.6',
+        name: 'Grok 4.6',
+        description:
+          "SpaceXAI's smartest model built for long-running agents, interactive and visual work.",
+        contextWindow: 500000,
+        thinking: {
+          type: 'levels',
+          levels: ['low', 'medium', 'high', 'xhigh'],
+          zeroAllowed: false,
+        },
+      },
+      {
         id: 'grok-4.5',
         name: 'Grok 4.5',
         description: 'Frontier model for coding, engineering, and agentic workflows',

--- a/src/cliproxy/services/catalog-cache.ts
+++ b/src/cliproxy/services/catalog-cache.ts
@@ -198,6 +198,7 @@ function mapThinking(remote?: RemoteThinkingSupport): ThinkingSupport | undefine
     return {
       type: 'levels',
       levels: remote.levels,
+      zeroAllowed: remote.zero_allowed,
       dynamicAllowed: remote.dynamic_allowed,
     };
   }
@@ -279,6 +280,7 @@ export function mergeCatalog(
       const mergedThinking = remoteEntry.thinking
         ? {
             ...remoteEntry.thinking,
+            zeroAllowed: remoteEntry.thinking.zeroAllowed ?? staticEntry.thinking?.zeroAllowed,
             maxLevel: remoteEntry.thinking.maxLevel ?? staticEntry.thinking?.maxLevel,
           }
         : staticEntry.thinking;

--- a/ui/src/lib/model-catalogs.ts
+++ b/ui/src/lib/model-catalogs.ts
@@ -399,6 +399,13 @@ export const MODEL_CATALOGS: Record<string, ProviderCatalog> = {
         },
       },
       {
+        id: 'grok-4.6',
+        name: 'Grok 4.6',
+        description:
+          "SpaceXAI's smartest model built for long-running agents, interactive and visual work.",
+        reasoningLevels: ['low', 'medium', 'high', 'xhigh'],
+      },
+      {
         id: 'grok-4.5',
         name: 'Grok 4.5',
         description: 'Frontier model for coding, engineering, and agentic workflows',

--- a/ui/tests/unit/ui/lib/model-catalogs-xai.test.ts
+++ b/ui/tests/unit/ui/lib/model-catalogs-xai.test.ts
@@ -11,6 +11,7 @@ describe('xAI model catalog defaults', () => {
     expect(catalog.defaultModel).toBe('grok-build-0.1');
     expect(ids).toEqual([
       'grok-build-0.1',
+      'grok-4.6',
       'grok-4.5',
       'grok-4.3',
       'grok-4.20-0309-reasoning',
@@ -19,6 +20,12 @@ describe('xAI model catalog defaults', () => {
       'grok-3-mini',
       'grok-3-mini-fast',
       'grok-composer-2.5-fast',
+    ]);
+    expect(catalog.models.find((model) => model.id === 'grok-4.6')?.reasoningLevels).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
     ]);
     expect(defaultModel?.presetMapping).toEqual({
       default: 'grok-build-0.1',

--- a/ui/tests/unit/ui/lib/reasoning-control.test.ts
+++ b/ui/tests/unit/ui/lib/reasoning-control.test.ts
@@ -13,6 +13,11 @@ const xaiCatalog: ProviderCatalog = {
   defaultModel: 'grok-build-0.1',
   models: [
     { id: 'grok-build-0.1', name: 'Grok Build 0.1' },
+    {
+      id: 'grok-4.6',
+      name: 'Grok 4.6',
+      reasoningLevels: ['low', 'medium', 'high', 'xhigh'],
+    },
     { id: 'grok-4.5', name: 'Grok 4.5', reasoningLevels: ['low', 'medium', 'high'] },
     { id: 'grok-4.3', name: 'Grok 4.3', reasoningLevels: ['none', 'low', 'medium', 'high'] },
   ],
@@ -96,6 +101,7 @@ describe('xai adapter', () => {
   const adapter = requireAdapter('xai');
 
   it('returns per-model levels from catalog metadata', () => {
+    expect(adapter.getOptions('grok-4.6', xaiCatalog)).toEqual(['low', 'medium', 'high', 'xhigh']);
     expect(adapter.getOptions('grok-4.5', xaiCatalog)).toEqual(['low', 'medium', 'high']);
     expect(adapter.getOptions('grok-4.3', xaiCatalog)).toEqual(['none', 'low', 'medium', 'high']);
   });
@@ -107,6 +113,7 @@ describe('xai adapter', () => {
   });
 
   it('writes and clears suffixed values through apply', () => {
+    expect(adapter.apply('grok-4.6', 'xhigh')).toBe('grok-4.6(xhigh)');
     expect(adapter.apply('grok-4.5', 'high')).toBe('grok-4.5(high)');
     expect(adapter.apply('grok-4.5(high)', undefined)).toBe('grok-4.5');
     expect(adapter.apply('grok-4.3', 'none')).toBe('grok-4.3(none)');


### PR DESCRIPTION
## Summary

- Add `grok-4.6` to the static xAI catalogs used by CLIProxy and the dashboard so Grok 4.6 is selectable.
- Keep the xAI coding default on `grok-build-0.1` and leave the opus preset on `grok-4.5`.
- Forward live `zero_allowed` through `mergeCatalog`, and keep the static `zeroAllowed` value when the live catalog omits it.

## Testing

- [x] `bun run format && bun run lint:fix && bun run validate` — `bun run validate` passed (typecheck, eslint 0 errors / 52 pre-existing `max-lines` warnings, prettier, `test:fast` 415 files OK). Format/lint were already clean; no source rewrite in this ship.
- [ ] `bun run validate:ci-parity` before requesting review — not run locally; pre-push hook ran the feature-branch fast gate + `cd ui && bun run validate` + workflow tests, all green.
- [ ] `bun run test:e2e` — skipped: this PR does not touch command routing, proxy flows, or workflow/release logic.
- [x] `cd ui && bun run validate` — passed.
- Focused extra coverage:
  - `bun test ./src/cliproxy/__tests__/model-catalog.test.js ./src/cliproxy/__tests__/model-catalog-compat.test.ts` — 78 pass / 0 fail
  - `cd ui && bun run test:run tests/unit/ui/lib/model-catalogs-xai.test.ts tests/unit/ui/lib/reasoning-control.test.ts` — 19 pass / 0 fail

## Checklist

- [x] Base branch is `dev` unless this is an approved hotfix
- [x] Branch name follows `feat/*`, `fix/*`, `docs/*`, or approved hotfix naming
- [x] Relevant `--help` output updated if CLI behavior changed — N/A, no CLI flag/help change
- [x] Tests added or updated if behavior changed
- [x] README or local docs updated if user-facing behavior changed — no README change; model picker data only
- [x] If a check failed, the PR body explains what failed and what changed to fix it — N/A locally
- [x] No secrets, tokens, or private config data are included

## Docs Impact

Docs impact: `none`

Action: `no update needed` — this only adds a catalog model id and reasoning levels. Public CCS docs do not inventory model lists.

## End-to-end work summary

Implemented `feat(cliproxy): add Grok 4.6 selection` on `feat/grok-4-6-selection` (`c30e9ca6`). Merged `upstream/dev` first (already up to date). Verified with focused catalog tests plus `bun run validate` and `cd ui && bun run validate`. Pre-landing review found 0 critical / 2 informational. Pushed to `minhbi245/ccs` and opened this PR against `kaitranntt/ccs` `dev`.

## Subagent delegation

- Count: 2
- tester: focused catalog tests + validate gates — DONE — 78 backend + 19 UI pass; both validate gates pass
- code-reviewer: pre-landing review of `upstream/dev...HEAD` — DONE — 0 critical, 2 informational test-coverage nits

## Technical decisions

- Insert `grok-4.6` above `grok-4.5` in both catalogs, with levels `low/medium/high/xhigh`, `zeroAllowed: false`, and 500k context — matches current xAI reasoning metadata.
- Do not retarget opus-tier mapping to 4.6 — existing tests and `base-xai.settings.json` keep opus on `grok-4.5`.
- `mergeCatalog` now copies `remote.zero_allowed` and falls back to static `zeroAllowed` when live omits it, so a live levels-only payload cannot drop the static flag.

## Deviations from plan

No plan.

Ship-protocol deviations:
- No tracking issue created on `kaitranntt/ccs` — contributor-only catalog PR; search found no open Grok 4.6 issue.
- Version / changelog not bumped — semantic-release owns those on this repo.
- Journal / docs update skipped — would add noise to an upstream contribution.

## Completion evidence

- Acceptance: `grok-4.6` selectable in CLI + dashboard catalogs with `xhigh` → `src/cliproxy/model-catalog.ts`, `ui/src/lib/model-catalogs.ts`, and the focused tests above.
- Acceptance: live merge preserves / overrides `zeroAllowed` correctly → `src/cliproxy/services/catalog-cache.ts` plus `model-catalog-compat.test.ts`.
- Tests: focused 78 + 19 pass; `bun run validate` pass; `cd ui && bun run validate` pass; pre-push fast gate pass.
- Review: 0 critical. Informational: live-merge fixture now covers 4.6 instead of 4.5; no `validateThinking('xai', 'grok-4.6', …)` test yet.
- CI: pending after open.
- UI screenshots: Unavailable: local dashboard was verified against the contributor's installed `~/.ccs` config; no checked-in screenshot asset for this catalog-only change.
- Changes: 7 files, +95 / −6 vs `upstream/dev`.

## Human actions required

None from the author. Maintainer review / CI on `kaitranntt/ccs`.

## Linked Issues

No linked issues.

## Ship Mode

- Mode: beta
- Target: dev
- Writing language: en (source: fallback; fallback: writing-language resolver unavailable)
