### PR TITLE
fix(delegation): flush stdout before exit to prevent piped output truncation

### DIFF
--- a/src/delegation/delegation-handler.ts
+++ b/src/delegation/delegation-handler.ts
@@ -35,6 +35,17 @@ function isFlag(arg: string): boolean {
   return arg.startsWith('-');
 }
 
+/**
+ * Write to stdout and wait for the flush to complete.
+ * process.exit() right after a large piped write truncates output at the
+ * pipe buffer (~64 KiB), so delegation results must be drained first.
+ */
+function writeStdoutAndFlush(text: string): Promise<void> {
+  return new Promise((resolve) => {
+    process.stdout.write(text + '\n', () => resolve());
+  });
+}
+
 function isInlineCcsValueFlag(arg: string): boolean {
   return Array.from(CCS_FLAGS_WITH_VALUE).some(
     (flag) => flag.startsWith('--') && arg.startsWith(`${flag}=`)
@@ -147,7 +158,7 @@ export class DelegationHandler {
 
       // 5. Format and display results
       const formatted = await ResultFormatter.format(result);
-      console.log(formatted);
+      await writeStdoutAndFlush(formatted);
 
       // 6. Exit with proper code
       process.exit(result.exitCode || 0);
@@ -192,7 +203,7 @@ export class DelegationHandler {
     });
 
     const formatted = await ResultFormatter.format(result);
-    console.log(formatted);
+    await writeStdoutAndFlush(formatted);
 
     process.exit(result.exitCode || 0);
   }


### PR DESCRIPTION
## Problem

`console.log(formatted)` followed immediately by `process.exit()` truncated piped output at the pipe buffer (about 64 KiB). stdout writes to a pipe are asynchronous in Node, so `process.exit()` killed the process before the write queue drained. TTY runs are synchronous and unaffected, which is why interactive use never showed it.

Reproduced: a thinking heavy GLM delegation (`ccs glm -p --output-format json`) returned exactly 65536 bytes, exit 0, JSON cut mid-array. After the fix the same request returns 610303 bytes complete.

## Fix

Await an explicit `process.stdout.write(text, cb)` callback before exiting, in both `route()` and `_handleContinue()`, via a small `writeStdoutAndFlush()` helper.

## Testing

- bun run build: clean
- tests/unit/delegation: 108 pass, 0 fail
- test:fast bucket: 415 files, 0 fail
- Live: 65536-byte truncation case now returns complete output; piped parser succeeds