### PR TITLE
fix(README): update star history chart to use working domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,4 +228,4 @@ ccs ollama "summarize these logs"
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=kaitranntt/ccs&type=date&legend=top-left)](https://www.star-history.com/#kaitranntt/ccs&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=kaitranntt/ccs&type=date&legend=top-left)](https://star-history.dera.page/#kaitranntt/ccs&type=date&legend=top-left)


### PR DESCRIPTION
The current star history chart linked in the README is broken due to GitHub stargazer API restrictions. This switches to star-history.dera.page, a compatible fork that uses an alternative data source without requiring an API token. Many other projects (e.g. Snailclimb/JavaGuide, langgenius/dify) have already migrated to this domain.