### PR TITLE
docs: refresh hardening inventory counts

### DIFF
--- a/docs/reports/hardening-inventory.json
+++ b/docs/reports/hardening-inventory.json
@@ -720,7 +720,7 @@
       ]
     },
     "largeFiles": {
-      "countOver400": 91,
+      "countOver400": 92,
       "countOver600": 42,
       "topOver400": [
         {

--- a/docs/reports/hardening-inventory.md
+++ b/docs/reports/hardening-inventory.md
@@ -62,7 +62,7 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 | hotpath console.error/warn files | 81 |
 | files with createLogger | 65/765 |
 | subdomains with zero createLogger | 15 (api, bin, channels, cliproxy, cliproxy/accounts, cliproxy/ai-providers, cliproxy/binary, cliproxy/config, cliproxy/management, cliproxy/sync, cliproxy/types, config, dispatcher, shared, types) |
-| files > 400 LOC | 91 |
+| files > 400 LOC | 92 |
 | files > 600 LOC | 42 |
 
 ### Top Hotpath console.error/warn Files


### PR DESCRIPTION
Regenerated `docs/reports/hardening-inventory.{json,md}` after merging #1701, #1702, #1704, #1707, #1708. Count-only drift: files >400 LOC 91 → 92. Required to restore the Docs – Parity and Freshness check on `dev`.