### PR TITLE
fix(ci): publish dev releases with public access for scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "url": "git+https://github.com/kaitranntt/ccs.git"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "author": {
     "name": "Tam Nhu Tran (Kai)",
     "email": "kaitranntt@users.noreply.github.com"

--- a/scripts/dev-release.sh
+++ b/scripts/dev-release.sh
@@ -115,7 +115,7 @@ PACKAGE_NAME=$(jq -r '.name' package.json)
 if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
   log_info "npm already has ${PACKAGE_NAME}@${VERSION}, skipping publish"
 else
-  npm publish --tag dev
+  npm publish --tag dev --access public
   log_info "Published to npm with @dev tag"
 fi
 

--- a/tests/unit/scripts/github/dev-release-workflow.test.ts
+++ b/tests/unit/scripts/github/dev-release-workflow.test.ts
@@ -60,4 +60,16 @@ describe('dev release workflow', () => {
     expect(script).toContain('git commit -m "chore(release): ${VERSION}"');
     expect(script).not.toContain('git commit -m "chore(release): ${VERSION} [skip ci]"');
   });
+
+  test('publishes dev releases with explicit public access for scoped package', () => {
+    const packageJsonPath = resolvePath('../../../../package.json');
+    const scriptPath = resolvePath('../../../../scripts/dev-release.sh');
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const script = fs.readFileSync(scriptPath, 'utf8');
+
+    expect(packageJson.name).toBe('@kaitranntt/ccs');
+    expect(packageJson.publishConfig).toEqual({ access: 'public' });
+    expect(script).toContain('npm publish --tag dev --access public');
+  });
 });


### PR DESCRIPTION
## Description
Fixes the Dev Release workflow on the `dev` branch by configuring explicit public access for the `@kaitranntt/ccs` scoped npm package.

## Root Cause
When publishing scoped packages (`@kaitranntt/ccs`), `npm publish` defaults to restricted access unless `publishConfig.access = "public"` is declared in `package.json` or `--access public` is passed to the CLI command. This resulted in HTTP 404 errors on `PUT https://registry.npmjs.org/@kaitranntt%2fccs`.

## Changes
- `package.json`: Add `"publishConfig": { "access": "public" }`
- `scripts/dev-release.sh`: Add `--access public` to `npm publish --tag dev`
- `tests/unit/scripts/github/dev-release-workflow.test.ts`: Add test coverage for dev release public access configuration

## Verification
- `bun run validate`: 419 test files passed (0 failures)
- `bun run validate:ci-parity`: fast (419 files), slow (81 files, 968 passed), e2e (35 passed) - CI parity gate passed

Closes #1713
