### PR TITLE
fix(shared-manager): publish adopted settings by replacement

### DIFF
--- a/docs/reports/hardening-inventory.json
+++ b/docs/reports/hardening-inventory.json
@@ -1,15 +1,16 @@
 {
   "scope": "src/**/*.{ts,tsx,js,jsx,mjs,cjs}",
   "syncFs": {
-    "totalOccurrences": 2519,
+    "totalOccurrences": 2516,
     "filesAffected": 263,
-    "hotpathOccurrences": 1193,
+    "hotpathOccurrences": 1190,
     "hotpathFilesAffected": 156,
     "topHotpathFiles": [
       {
         "file": "src/management/shared-manager/diverged-file-adopter.ts",
-        "count": 39,
+        "count": 36,
         "calls": [
+          "chmodSync",
           "closeSync",
           "fsyncSync",
           "linkSync",
@@ -245,9 +246,24 @@
         "markers": []
       },
       {
-        "file": "src/management/shared-manager/diverged-file-adopter.ts",
-        "count": 39,
+        "file": "src/cliproxy/executor/__tests__/variant-port-integration.test.js",
+        "count": 36,
         "calls": [
+          "existsSync",
+          "mkdirSync",
+          "readdirSync",
+          "readFileSync",
+          "rmSync",
+          "unlinkSync",
+          "writeFileSync"
+        ],
+        "markers": []
+      },
+      {
+        "file": "src/management/shared-manager/diverged-file-adopter.ts",
+        "count": 36,
+        "calls": [
+          "chmodSync",
           "closeSync",
           "fsyncSync",
           "linkSync",
@@ -258,20 +274,6 @@
           "readlinkSync",
           "renameSync",
           "statSync",
-          "unlinkSync",
-          "writeFileSync"
-        ],
-        "markers": []
-      },
-      {
-        "file": "src/cliproxy/executor/__tests__/variant-port-integration.test.js",
-        "count": 36,
-        "calls": [
-          "existsSync",
-          "mkdirSync",
-          "readdirSync",
-          "readFileSync",
-          "rmSync",
           "unlinkSync",
           "writeFileSync"
         ],
@@ -720,7 +722,7 @@
       ]
     },
     "largeFiles": {
-      "countOver400": 92,
+      "countOver400": 93,
       "countOver600": 42,
       "topOver400": [
         {

--- a/docs/reports/hardening-inventory.json
+++ b/docs/reports/hardening-inventory.json
@@ -1,31 +1,11 @@
 {
   "scope": "src/**/*.{ts,tsx,js,jsx,mjs,cjs}",
   "syncFs": {
-    "totalOccurrences": 2516,
+    "totalOccurrences": 2509,
     "filesAffected": 263,
-    "hotpathOccurrences": 1190,
+    "hotpathOccurrences": 1183,
     "hotpathFilesAffected": 156,
     "topHotpathFiles": [
-      {
-        "file": "src/management/shared-manager/diverged-file-adopter.ts",
-        "count": 36,
-        "calls": [
-          "chmodSync",
-          "closeSync",
-          "fsyncSync",
-          "linkSync",
-          "lstatSync",
-          "openSync",
-          "readdirSync",
-          "readFileSync",
-          "readlinkSync",
-          "renameSync",
-          "statSync",
-          "unlinkSync",
-          "writeFileSync"
-        ],
-        "markers": []
-      },
       {
         "file": "src/utils/browser/mcp-installer.ts",
         "count": 32,
@@ -51,6 +31,26 @@
           "existsSync",
           "mkdirSync",
           "readFileSync",
+          "renameSync",
+          "statSync",
+          "unlinkSync",
+          "writeFileSync"
+        ],
+        "markers": []
+      },
+      {
+        "file": "src/management/shared-manager/diverged-file-adopter.ts",
+        "count": 29,
+        "calls": [
+          "chmodSync",
+          "closeSync",
+          "fsyncSync",
+          "linkSync",
+          "lstatSync",
+          "openSync",
+          "readdirSync",
+          "readFileSync",
+          "readlinkSync",
           "renameSync",
           "statSync",
           "unlinkSync",
@@ -260,26 +260,6 @@
         "markers": []
       },
       {
-        "file": "src/management/shared-manager/diverged-file-adopter.ts",
-        "count": 36,
-        "calls": [
-          "chmodSync",
-          "closeSync",
-          "fsyncSync",
-          "linkSync",
-          "lstatSync",
-          "openSync",
-          "readdirSync",
-          "readFileSync",
-          "readlinkSync",
-          "renameSync",
-          "statSync",
-          "unlinkSync",
-          "writeFileSync"
-        ],
-        "markers": []
-      },
-      {
         "file": "src/cliproxy/executor/__tests__/composite-variant-service.test.ts",
         "count": 33,
         "calls": [
@@ -300,6 +280,22 @@
           "mkdirSync",
           "readdirSync",
           "rmSync",
+          "unlinkSync",
+          "writeFileSync"
+        ],
+        "markers": []
+      },
+      {
+        "file": "src/utils/browser/mcp-installer.ts",
+        "count": 32,
+        "calls": [
+          "chmodSync",
+          "copyFileSync",
+          "existsSync",
+          "mkdirSync",
+          "readFileSync",
+          "renameSync",
+          "statSync",
           "unlinkSync",
           "writeFileSync"
         ],

--- a/docs/reports/hardening-inventory.md
+++ b/docs/reports/hardening-inventory.md
@@ -6,9 +6,9 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | Metric | Value |
 |---|---:|
-| Sync fs occurrences (all) | 2516 |
+| Sync fs occurrences (all) | 2509 |
 | Sync fs files affected (all) | 263 |
-| Sync fs occurrences (runtime hotpaths) | 1190 |
+| Sync fs occurrences (runtime hotpaths) | 1183 |
 | Sync fs files affected (runtime hotpaths) | 156 |
 | Legacy shim markers | 465 |
 | Legacy shim files affected | 176 |
@@ -17,9 +17,9 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | File | Sync Calls | API Names |
 |---|---:|---|
-| `src/management/shared-manager/diverged-file-adopter.ts` | 36 | chmodSync, closeSync, fsyncSync, linkSync, lstatSync, openSync, readdirSync, readFileSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync |
 | `src/utils/browser/mcp-installer.ts` | 32 | chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync |
 | `src/utils/image-analysis/mcp-installer.ts` | 30 | chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync |
+| `src/management/shared-manager/diverged-file-adopter.ts` | 29 | chmodSync, closeSync, fsyncSync, linkSync, lstatSync, openSync, readdirSync, readFileSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync |
 | `src/utils/claude-symlink-manager.ts` | 27 | copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readlinkSync, renameSync, rmSync, statSync, symlinkSync, unlinkSync |
 | `src/cliproxy/config/env-builder.ts` | 25 | existsSync, mkdirSync, readFileSync, writeFileSync |
 | `src/management/shared-manager/migrations.ts` | 25 | copyFileSync, cpSync, existsSync, lstatSync, mkdirSync, readdirSync, symlinkSync, unlinkSync, writeFileSync |

--- a/docs/reports/hardening-inventory.md
+++ b/docs/reports/hardening-inventory.md
@@ -6,9 +6,9 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | Metric | Value |
 |---|---:|
-| Sync fs occurrences (all) | 2519 |
+| Sync fs occurrences (all) | 2516 |
 | Sync fs files affected (all) | 263 |
-| Sync fs occurrences (runtime hotpaths) | 1193 |
+| Sync fs occurrences (runtime hotpaths) | 1190 |
 | Sync fs files affected (runtime hotpaths) | 156 |
 | Legacy shim markers | 465 |
 | Legacy shim files affected | 176 |
@@ -17,7 +17,7 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 
 | File | Sync Calls | API Names |
 |---|---:|---|
-| `src/management/shared-manager/diverged-file-adopter.ts` | 39 | closeSync, fsyncSync, linkSync, lstatSync, openSync, readdirSync, readFileSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync |
+| `src/management/shared-manager/diverged-file-adopter.ts` | 36 | chmodSync, closeSync, fsyncSync, linkSync, lstatSync, openSync, readdirSync, readFileSync, readlinkSync, renameSync, statSync, unlinkSync, writeFileSync |
 | `src/utils/browser/mcp-installer.ts` | 32 | chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync |
 | `src/utils/image-analysis/mcp-installer.ts` | 30 | chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync |
 | `src/utils/claude-symlink-manager.ts` | 27 | copyFileSync, existsSync, lstatSync, mkdirSync, readdirSync, readlinkSync, renameSync, rmSync, statSync, symlinkSync, unlinkSync |
@@ -62,7 +62,7 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 | hotpath console.error/warn files | 81 |
 | files with createLogger | 65/765 |
 | subdomains with zero createLogger | 15 (api, bin, channels, cliproxy, cliproxy/accounts, cliproxy/ai-providers, cliproxy/binary, cliproxy/config, cliproxy/management, cliproxy/sync, cliproxy/types, config, dispatcher, shared, types) |
-| files > 400 LOC | 92 |
+| files > 400 LOC | 93 |
 | files > 600 LOC | 42 |
 
 ### Top Hotpath console.error/warn Files

--- a/src/management/shared-manager/diverged-file-adopter.ts
+++ b/src/management/shared-manager/diverged-file-adopter.ts
@@ -148,9 +148,7 @@ interface CanonicalIdentity {
   size: number;
 }
 
-function readCanonicalIdentity(writePath: string): CanonicalIdentity | null {
-  const stats = getLstatSync(writePath);
-  if (!stats?.isFile()) return null;
+function canonicalIdentityOf(stats: fs.Stats): CanonicalIdentity {
   return { ino: stats.ino, mtimeMs: stats.mtimeMs, size: stats.size };
 }
 
@@ -246,9 +244,7 @@ function publishCanonicalContent(
     descriptor = null;
 
     const currentStats = getLstatSync(writePath);
-    const current = currentStats?.isFile()
-      ? { ino: currentStats.ino, mtimeMs: currentStats.mtimeMs, size: currentStats.size }
-      : null;
+    const current = currentStats?.isFile() ? canonicalIdentityOf(currentStats) : null;
     if (!canonicalIdentityMatches(expected, current)) {
       throw Object.assign(new TypeError(`Canonical file changed during adoption: ${writePath}`), {
         code: 'EEXIST',
@@ -297,12 +293,12 @@ function getCanonicalFile(canonicalPath: string): {
     });
   }
 
-  // Identity first: a write landing between the two reads leaves us holding
-  // newer bytes than the identity describes, and publication fails closed.
-  const identity = readCanonicalIdentity(writePath);
+  // The identity describes the inode as of the stat above, taken before the
+  // content read: a write landing in between leaves us holding newer bytes
+  // than the identity describes, and publication fails closed.
   return {
     content: fs.readFileSync(writePath),
-    identity,
+    identity: canonicalIdentityOf(canonicalStats),
     mode: canonicalStats.mode & 0o777,
     mtimeMs: canonicalStats.mtimeMs,
     writePath,

--- a/src/management/shared-manager/diverged-file-adopter.ts
+++ b/src/management/shared-manager/diverged-file-adopter.ts
@@ -164,6 +164,36 @@ function canonicalIdentityMatches(
   );
 }
 
+function tempWritePath(targetPath: string): string {
+  return `${targetPath}.ccs-write-${process.pid}-${Date.now()}-${adoptionClaimSequence++}`;
+}
+
+/**
+ * Write content into a fresh temp file and make it durable, so whatever
+ * publishes it under its final name publishes complete bytes.
+ */
+function writeDurableTempFile(tempPath: string, content: Buffer, mode: number): void {
+  let descriptor: number | null = null;
+  try {
+    descriptor = fs.openSync(tempPath, 'wx', mode);
+    fs.fchmodSync(descriptor, mode);
+    fs.writeFileSync(descriptor, content);
+    fs.fsyncSync(descriptor);
+  } finally {
+    if (descriptor !== null) {
+      fs.closeSync(descriptor);
+    }
+  }
+}
+
+function discardTempFile(tempPath: string): void {
+  try {
+    fs.unlinkSync(tempPath);
+  } catch {
+    // The temp file may not have been created or may already have been renamed.
+  }
+}
+
 /**
  * Create a file only if the path is free, writing the content atomically.
  *
@@ -171,26 +201,13 @@ function canonicalIdentityMatches(
  * cannot overwrite each other's sidecar artifacts.
  */
 function createFileNoReplace(targetPath: string, content: Buffer, mode: number): void {
-  const tempPath = `${targetPath}.ccs-write-${process.pid}-${Date.now()}-${adoptionClaimSequence++}`;
-  let descriptor: number | null = null;
+  const tempPath = tempWritePath(targetPath);
   try {
-    descriptor = fs.openSync(tempPath, 'wx', mode);
-    fs.fchmodSync(descriptor, mode);
-    fs.writeFileSync(descriptor, content);
-    fs.fsyncSync(descriptor);
-    fs.closeSync(descriptor);
-    descriptor = null;
+    writeDurableTempFile(tempPath, content, mode);
     fs.linkSync(tempPath, targetPath);
     fs.unlinkSync(tempPath);
   } catch (err) {
-    if (descriptor !== null) {
-      fs.closeSync(descriptor);
-    }
-    try {
-      fs.unlinkSync(tempPath);
-    } catch {
-      // The temp file may not have been created or may already have been renamed.
-    }
+    discardTempFile(tempPath);
     throw err;
   }
 }
@@ -226,6 +243,13 @@ function publishSidecarNoReplace(basePath: string, content: Buffer, mode: number
  * that got there first; the adopted bytes stay in the sidecars the caller
  * published. A pure chmod is not a content change, so the mode the inode
  * carries at publication time wins.
+ *
+ * The guard is read-then-act, not atomic: POSIX offers no compare-and-swap
+ * rename, so a writer landing between the check and the rename is still
+ * overwritten. That is a narrowing, not a guarantee - the window shrinks from
+ * the ~100 ms the old claim-and-republish path left open to two adjacent
+ * syscalls, and the pre-image sidecar the caller published keeps even that
+ * outcome recoverable. Do not build stricter guarantees on top of it.
  */
 function publishCanonicalContent(
   writePath: string,
@@ -233,15 +257,9 @@ function publishCanonicalContent(
   mode: number,
   expected: CanonicalIdentity | null
 ): void {
-  const tempPath = `${writePath}.ccs-write-${process.pid}-${Date.now()}-${adoptionClaimSequence++}`;
-  let descriptor: number | null = null;
+  const tempPath = tempWritePath(writePath);
   try {
-    descriptor = fs.openSync(tempPath, 'wx', mode);
-    fs.fchmodSync(descriptor, mode);
-    fs.writeFileSync(descriptor, content);
-    fs.fsyncSync(descriptor);
-    fs.closeSync(descriptor);
-    descriptor = null;
+    writeDurableTempFile(tempPath, content, mode);
 
     const currentStats = getLstatSync(writePath);
     const current = currentStats?.isFile() ? canonicalIdentityOf(currentStats) : null;
@@ -257,14 +275,7 @@ function publishCanonicalContent(
     }
     fs.renameSync(tempPath, writePath);
   } catch (err) {
-    if (descriptor !== null) {
-      fs.closeSync(descriptor);
-    }
-    try {
-      fs.unlinkSync(tempPath);
-    } catch {
-      // The temp file may not have been created or may already have been renamed.
-    }
+    discardTempFile(tempPath);
     throw err;
   }
 }

--- a/src/management/shared-manager/diverged-file-adopter.ts
+++ b/src/management/shared-manager/diverged-file-adopter.ts
@@ -264,6 +264,9 @@ function publishCanonicalContent(
     const currentStats = getLstatSync(writePath);
     const current = currentStats?.isFile() ? canonicalIdentityOf(currentStats) : null;
     if (!canonicalIdentityMatches(expected, current)) {
+      // EEXIST is this file's marker for "a race was detected", the same code
+      // the reappeared-path and concurrent-replacement guards raise. It does
+      // not mean a no-replace link() or open('wx') hit an existing path.
       throw Object.assign(new TypeError(`Canonical file changed during adoption: ${writePath}`), {
         code: 'EEXIST',
       });

--- a/src/management/shared-manager/diverged-file-adopter.ts
+++ b/src/management/shared-manager/diverged-file-adopter.ts
@@ -137,7 +137,42 @@ function validateManagedJson(filePath: string, content: Buffer): boolean {
   }
 }
 
-function atomicWriteFile(targetPath: string, content: Buffer, mode: number): void {
+/**
+ * Identity of the canonical inode as it was read. Publication compares it
+ * again immediately before replacing the file, so a concurrent writer is
+ * detected instead of silently overwritten.
+ */
+interface CanonicalIdentity {
+  ino: number;
+  mtimeMs: number;
+  size: number;
+}
+
+function readCanonicalIdentity(writePath: string): CanonicalIdentity | null {
+  const stats = getLstatSync(writePath);
+  if (!stats?.isFile()) return null;
+  return { ino: stats.ino, mtimeMs: stats.mtimeMs, size: stats.size };
+}
+
+function canonicalIdentityMatches(
+  expected: CanonicalIdentity | null,
+  current: CanonicalIdentity | null
+): boolean {
+  if (!expected || !current) return expected === current;
+  return (
+    expected.ino === current.ino &&
+    expected.mtimeMs === current.mtimeMs &&
+    expected.size === current.size
+  );
+}
+
+/**
+ * Create a file only if the path is free, writing the content atomically.
+ *
+ * link() is an atomic no-replace operation, so concurrent CCS processes
+ * cannot overwrite each other's sidecar artifacts.
+ */
+function createFileNoReplace(targetPath: string, content: Buffer, mode: number): void {
   const tempPath = `${targetPath}.ccs-write-${process.pid}-${Date.now()}-${adoptionClaimSequence++}`;
   let descriptor: number | null = null;
   try {
@@ -162,16 +197,17 @@ function atomicWriteFile(targetPath: string, content: Buffer, mode: number): voi
   }
 }
 
-function publishBackupNoReplace(sourcePath: string, canonicalPath: string): string {
-  const basePath = `${canonicalPath}.bak-ccs-adopt`;
-  const content = fs.readFileSync(sourcePath);
-  const mode = fs.statSync(sourcePath).mode & 0o777;
+/**
+ * Publish a sidecar next to a managed file, never replacing an existing one.
+ * Numbered suffixes keep every concurrent writer's artifact recoverable.
+ */
+function publishSidecarNoReplace(basePath: string, content: Buffer, mode: number): string {
   let sequence = 0;
   while (true) {
-    const backupPath = sequence === 0 ? basePath : `${basePath}-${sequence}`;
+    const sidecarPath = sequence === 0 ? basePath : `${basePath}-${sequence}`;
     try {
-      atomicWriteFile(backupPath, content, mode);
-      return backupPath;
+      createFileNoReplace(sidecarPath, content, mode);
+      return sidecarPath;
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
       sequence++;
@@ -179,43 +215,74 @@ function publishBackupNoReplace(sourcePath: string, canonicalPath: string): stri
   }
 }
 
-function publishAdoptedRecoveryNoReplace(sourcePath: string, divergedPath: string): string {
-  const basePath = `${divergedPath}.ccs-adopted-recovery`;
-  const content = fs.readFileSync(sourcePath);
-  const mode = fs.statSync(sourcePath).mode & 0o777;
-  let sequence = 0;
-  while (true) {
-    const recoveryPath = sequence === 0 ? basePath : `${basePath}-${sequence}`;
-    try {
-      atomicWriteFile(recoveryPath, content, mode);
-      return recoveryPath;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-      sequence++;
-    }
-  }
-}
-
-function restoreCanonicalClaim(claimPath: string, writePath: string, canonicalPath: string): void {
+/**
+ * Publish adopted content onto the canonical path by replacement.
+ *
+ * The canonical path is never emptied: a fully written temp file is renamed
+ * over it, so no window exists in which Claude Code or a second `ccs` can
+ * observe the path as missing and seed an empty placeholder there.
+ *
+ * A compare-and-swap guard runs as late as possible - after the temp file is
+ * durable, immediately before the rename. When the canonical inode changed
+ * since it was read, publication is refused rather than clobbering a writer
+ * that got there first; the adopted bytes stay in the sidecars the caller
+ * published. A pure chmod is not a content change, so the mode the inode
+ * carries at publication time wins.
+ */
+function publishCanonicalContent(
+  writePath: string,
+  content: Buffer,
+  mode: number,
+  expected: CanonicalIdentity | null
+): void {
+  const tempPath = `${writePath}.ccs-write-${process.pid}-${Date.now()}-${adoptionClaimSequence++}`;
+  let descriptor: number | null = null;
   try {
-    fs.linkSync(claimPath, writePath);
-    fs.unlinkSync(claimPath);
+    descriptor = fs.openSync(tempPath, 'wx', mode);
+    fs.fchmodSync(descriptor, mode);
+    fs.writeFileSync(descriptor, content);
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = null;
+
+    const currentStats = getLstatSync(writePath);
+    const current = currentStats?.isFile()
+      ? { ino: currentStats.ino, mtimeMs: currentStats.mtimeMs, size: currentStats.size }
+      : null;
+    if (!canonicalIdentityMatches(expected, current)) {
+      throw Object.assign(new TypeError(`Canonical file changed during adoption: ${writePath}`), {
+        code: 'EEXIST',
+      });
+    }
+
+    const publishMode = currentStats ? currentStats.mode & 0o777 : mode;
+    if (publishMode !== mode) {
+      fs.chmodSync(tempPath, publishMode);
+    }
+    fs.renameSync(tempPath, writePath);
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
-    publishBackupNoReplace(claimPath, canonicalPath);
-    fs.unlinkSync(claimPath);
+    if (descriptor !== null) {
+      fs.closeSync(descriptor);
+    }
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // The temp file may not have been created or may already have been renamed.
+    }
+    throw err;
   }
 }
 
 function getCanonicalFile(canonicalPath: string): {
   content: Buffer | null;
+  identity: CanonicalIdentity | null;
   mode: number;
   mtimeMs: number | null;
   writePath: string;
 } {
   const canonicalLstat = getLstatSync(canonicalPath);
   if (!canonicalLstat) {
-    return { content: null, mode: 0o600, mtimeMs: null, writePath: canonicalPath };
+    return { content: null, identity: null, mode: 0o600, mtimeMs: null, writePath: canonicalPath };
   }
 
   let writePath = canonicalPath;
@@ -230,8 +297,12 @@ function getCanonicalFile(canonicalPath: string): {
     });
   }
 
+  // Identity first: a write landing between the two reads leaves us holding
+  // newer bytes than the identity describes, and publication fails closed.
+  const identity = readCanonicalIdentity(writePath);
   return {
-    content: fs.readFileSync(canonicalPath),
+    content: fs.readFileSync(writePath),
+    identity,
     mode: canonicalStats.mode & 0o777,
     mtimeMs: canonicalStats.mtimeMs,
     writePath,
@@ -260,8 +331,6 @@ export function adoptDivergedFileContent(
     throw err;
   }
 
-  let canonicalClaimPath: string | null = null;
-  let canonicalWritePath: string | null = null;
   let divergencePreserved = false;
   try {
     const claimedStats = fs.lstatSync(claimPath);
@@ -288,24 +357,12 @@ export function adoptDivergedFileContent(
     }
 
     const canonical = getCanonicalFile(canonicalPath);
-    let current = canonical.content;
-    let publishMode = canonical.mode;
-    if (current) {
-      canonicalWritePath = canonical.writePath;
-      canonicalClaimPath = `${canonical.writePath}.ccs-canonical-claim-${process.pid}-${Date.now()}-${adoptionClaimSequence++}`;
-      fs.renameSync(canonical.writePath, canonicalClaimPath);
-      const currentStats = fs.statSync(canonicalClaimPath);
-      publishMode = currentStats.mode & 0o777;
-      current = fs.readFileSync(canonicalClaimPath);
-      if (diverged.equals(current)) {
-        restoreCanonicalClaim(canonicalClaimPath, canonical.writePath, canonicalPath);
-        canonicalClaimPath = null;
+    if (canonical.content) {
+      if (diverged.equals(canonical.content)) {
         fs.unlinkSync(claimPath);
         return 'claimed';
       }
-      if (claimedStats.mtimeMs <= currentStats.mtimeMs) {
-        restoreCanonicalClaim(canonicalClaimPath, canonical.writePath, canonicalPath);
-        canonicalClaimPath = null;
+      if (claimedStats.mtimeMs <= (canonical.mtimeMs ?? 0)) {
         preserveClaim(
           claimPath,
           divergedPath,
@@ -313,14 +370,17 @@ export function adoptDivergedFileContent(
         );
         return 'claimed';
       }
+      // Publish the pre-image before the canonical file is replaced, so an
+      // interruption mid-publication still leaves the old content recoverable.
+      publishSidecarNoReplace(`${canonicalPath}.bak-ccs-adopt`, canonical.content, canonical.mode);
     }
+    publishSidecarNoReplace(
+      `${divergedPath}.ccs-adopted-recovery`,
+      diverged,
+      claimedStats.mode & 0o777
+    );
 
-    if (canonicalClaimPath) {
-      publishBackupNoReplace(canonicalClaimPath, canonicalPath);
-    }
-    publishAdoptedRecoveryNoReplace(claimPath, divergedPath);
-
-    atomicWriteFile(canonical.writePath, diverged, publishMode);
+    publishCanonicalContent(canonical.writePath, diverged, canonical.mode, canonical.identity);
     if (!fs.readFileSync(canonicalPath).equals(diverged)) {
       throw Object.assign(
         new TypeError(`Canonical adoption postcondition failed: ${canonicalPath}`),
@@ -328,10 +388,6 @@ export function adoptDivergedFileContent(
           code: 'EAGAIN',
         }
       );
-    }
-    if (canonicalClaimPath) {
-      fs.unlinkSync(canonicalClaimPath);
-      canonicalClaimPath = null;
     }
     if (getLstatSync(divergedPath)) {
       preserveClaim(claimPath, divergedPath, `Concurrent replacement detected at ${divergedPath}`);
@@ -346,10 +402,6 @@ export function adoptDivergedFileContent(
     );
     return 'claimed';
   } catch (err) {
-    if (canonicalClaimPath && canonicalWritePath) {
-      restoreCanonicalClaim(canonicalClaimPath, canonicalWritePath, canonicalPath);
-      canonicalClaimPath = null;
-    }
     if (divergencePreserved) {
       throw err;
     }

--- a/tests/unit/shared-manager.test.ts
+++ b/tests/unit/shared-manager.test.ts
@@ -686,6 +686,10 @@ describe('SharedManager', () => {
           foreignWriter.restore();
         }
 
+        // The writer only fires when the canonical path is observed empty, so
+        // zero writes is the invariant itself: adoption never left the path
+        // without a regular file.
+        expect(foreignWriter.placeholderWrites()).toBe(0);
         expect(fs.existsSync(canonicalPath)).toBe(true);
         expect(fs.readFileSync(canonicalPath, 'utf8')).not.toBe(placeholder);
         expect([divergedSettings, previousSettings]).toContainEqual(readJson(canonicalPath));

--- a/tests/unit/shared-manager.test.ts
+++ b/tests/unit/shared-manager.test.ts
@@ -544,7 +544,18 @@ describe('SharedManager', () => {
       });
     });
 
-    it('preserves a canonical write that lands during no-replace publication', () => {
+    /**
+     * Replaces 'preserves a canonical write that lands during no-replace
+     * publication', which locked in the outcome of the CCS-4 incident.
+     *
+     * The intent it encoded - never clobber a writer that got to the canonical
+     * file first - is kept, but it is now enforced by the compare-and-swap
+     * guard instead of by an EEXIST from a no-replace link. The difference
+     * that matters: the canonical path is no longer emptied first, so only a
+     * genuinely concurrent write can land here, and it is preserved without
+     * costing the user the settings that were already there.
+     */
+    it('refuses to publish when the canonical file changes before publication', () => {
       const manager = new SharedManager();
       const instancePath = instanceDir('canonical-race');
       const canonicalPath = path.join(claudeDir(), 'settings.json');
@@ -555,23 +566,131 @@ describe('SharedManager', () => {
       writeJson(divergedPath, { generation: 1 });
       setMtime(divergedPath, fs.statSync(canonicalPath).mtimeMs + 2_000);
 
-      const originalLinkSync = fs.linkSync;
-      const linkSpy = spyOn(fs, 'linkSync').mockImplementation(((
-        existingPath: fs.PathLike,
-        newPath: fs.PathLike
+      // Land the competing write while the publication temp file is being
+      // prepared, i.e. after the canonical bytes were read but before the
+      // compare-and-swap guard re-checks the inode.
+      const originalOpenSync = fs.openSync;
+      const openSpy = spyOn(fs, 'openSync').mockImplementation(((
+        openPath: fs.PathLike,
+        flags: number | string,
+        mode?: fs.Mode
       ) => {
-        if (String(newPath) === canonicalPath && String(existingPath).includes('.ccs-write-')) {
+        if (String(openPath).startsWith(`${canonicalPath}.ccs-write-`)) {
           writeJson(canonicalPath, { generation: 99 });
         }
-        return originalLinkSync(existingPath, newPath);
-      }) as typeof fs.linkSync);
+        return originalOpenSync(openPath, flags, mode);
+      }) as typeof fs.openSync);
 
-      expect(() => manager.linkSharedDirectories(instancePath)).toThrow();
-      linkSpy.mockRestore();
+      expect(() => manager.linkSharedDirectories(instancePath)).toThrow(
+        'Canonical file changed during adoption'
+      );
+      openSpy.mockRestore();
       expect(readJson(canonicalPath)).toEqual({ generation: 99 });
       expect(readJson(divergedPath)).toEqual({ generation: 1 });
       expect(readJson(`${canonicalPath}.bak-ccs-adopt`)).toEqual({ generation: 0 });
+      expect(readJson(`${divergedPath}.ccs-adopted-recovery`)).toEqual({ generation: 1 });
     });
+
+    /**
+     * Model a foreign writer that shares ownership of the canonical
+     * settings.json: the instant the path is left without a file, it lands an
+     * empty-settings placeholder there. Claude Code does exactly this on
+     * startup, and a second concurrent `ccs` does the same through
+     * shared-dir-linker.ts:127.
+     *
+     * The writer reacts to the path becoming empty rather than to one specific
+     * call site, so it keeps modelling the race no matter which fs primitive
+     * the adopter uses to move the canonical file out of the way.
+     */
+    function installForeignCanonicalWriter(
+      canonicalPath: string,
+      placeholder: string
+    ): { placeholderWrites: () => number; restore: () => void } {
+      let placeholderWrites = 0;
+      const claimEmptyCanonicalPath = (): void => {
+        if (fs.existsSync(canonicalPath)) return;
+        fs.writeFileSync(canonicalPath, placeholder, 'utf8');
+        placeholderWrites++;
+      };
+
+      const originalRenameSync = fs.renameSync;
+      const renameSpy = spyOn(fs, 'renameSync').mockImplementation(((
+        oldPath: fs.PathLike,
+        newPath: fs.PathLike
+      ) => {
+        originalRenameSync(oldPath, newPath);
+        claimEmptyCanonicalPath();
+      }) as typeof fs.renameSync);
+
+      const originalUnlinkSync = fs.unlinkSync;
+      const unlinkSpy = spyOn(fs, 'unlinkSync').mockImplementation(((targetPath: fs.PathLike) => {
+        originalUnlinkSync(targetPath);
+        claimEmptyCanonicalPath();
+      }) as typeof fs.unlinkSync);
+
+      return {
+        placeholderWrites: () => placeholderWrites,
+        restore: () => {
+          renameSpy.mockRestore();
+          unlinkSpy.mockRestore();
+        },
+      };
+    }
+
+    /**
+     * Reproduce the 2026-08-20 incident: adoption moves the canonical
+     * settings.json aside, a foreign writer fills the empty path, and the user
+     * ends up with neither the adopted nor the previous settings on the live
+     * path.
+     *
+     * The opposite outcome used to be pinned by 'preserves a canonical write
+     * that lands during no-replace publication'; that test was rewritten as
+     * 'refuses to publish when the canonical file changes before publication'
+     * once publication stopped emptying the canonical path.
+     */
+    const foreignWriterCases: ReadonlyArray<{ writer: string; placeholder: string }> = [
+      // Claude Code starts, finds no settings file and writes empty settings.
+      { writer: 'Claude Code', placeholder: '{}\n' },
+      // A second concurrent `ccs` provisions the same placeholder without the
+      // trailing newline (shared-dir-linker.ts:127).
+      { writer: 'a concurrent ccs run', placeholder: JSON.stringify({}, null, 2) },
+    ];
+
+    for (const { writer, placeholder } of foreignWriterCases) {
+      it(`keeps live settings when ${writer} fills the canonical path during adoption`, () => {
+        const manager = new SharedManager();
+        const canonicalPath = path.join(claudeDir(), 'settings.json');
+        const sharedSettingsPath = path.join(ccsDir(), 'shared', 'settings.json');
+        const previousSettings = {
+          model: 'opus',
+          permissions: { allow: ['Bash(git status:*)'] },
+        };
+        const divergedSettings = {
+          model: 'opus',
+          permissions: { allow: ['Bash(git status:*)', 'Bash(git diff:*)'] },
+        };
+
+        fs.mkdirSync(claudeDir(), { recursive: true });
+        fs.mkdirSync(path.join(ccsDir(), 'shared'), { recursive: true });
+        writeJson(canonicalPath, previousSettings);
+        writeJson(sharedSettingsPath, divergedSettings);
+        setMtime(sharedSettingsPath, fs.statSync(canonicalPath).mtimeMs + 2_000);
+
+        const foreignWriter = installForeignCanonicalWriter(canonicalPath, placeholder);
+        try {
+          manager.ensureSharedDirectories();
+        } catch {
+          // Losing the race may abort reconciliation; the user's live settings
+          // must survive either way.
+        } finally {
+          foreignWriter.restore();
+        }
+
+        expect(fs.existsSync(canonicalPath)).toBe(true);
+        expect(fs.readFileSync(canonicalPath, 'utf8')).not.toBe(placeholder);
+        expect([divergedSettings, previousSettings]).toContainEqual(readJson(canonicalPath));
+      });
+    }
 
     it('keeps adopted bytes recoverable when canonical changes after verification', () => {
       const manager = new SharedManager();
@@ -584,10 +703,12 @@ describe('SharedManager', () => {
       writeJson(divergedPath, { generation: 1 });
       setMtime(divergedPath, fs.statSync(canonicalPath).mtimeMs + 2_000);
 
+      // The diverged claim is dropped only after publication was verified, so
+      // a write injected there lands strictly after adoption completed.
       const originalUnlinkSync = fs.unlinkSync;
       let injected = false;
       const unlinkSpy = spyOn(fs, 'unlinkSync').mockImplementation(((targetPath: fs.PathLike) => {
-        if (!injected && String(targetPath).includes('.ccs-canonical-claim-')) {
+        if (!injected && String(targetPath).includes('.ccs-adopt-claim-')) {
           injected = true;
           writeJson(canonicalPath, { generation: 99 });
         }
@@ -596,6 +717,7 @@ describe('SharedManager', () => {
 
       manager.linkSharedDirectories(instancePath);
       unlinkSpy.mockRestore();
+      expect(injected).toBe(true);
       expect(readJson(canonicalPath)).toEqual({ generation: 99 });
       expect(readJson(`${divergedPath}.ccs-adopted-recovery`)).toEqual({ generation: 1 });
     });
@@ -611,20 +733,30 @@ describe('SharedManager', () => {
       writeJson(divergedPath, { generation: 1 });
       setMtime(divergedPath, fs.statSync(canonicalPath).mtimeMs + 2_000);
 
-      const originalUnlinkSync = fs.unlinkSync;
+      // Recreate the managed source right after the canonical file was
+      // replaced, while the adopter is still cleaning up.
+      const originalRenameSync = fs.renameSync;
       let injected = false;
-      const unlinkSpy = spyOn(fs, 'unlinkSync').mockImplementation(((targetPath: fs.PathLike) => {
-        if (!injected && String(targetPath).includes('.ccs-canonical-claim-')) {
+      const renameSpy = spyOn(fs, 'renameSync').mockImplementation(((
+        oldPath: fs.PathLike,
+        newPath: fs.PathLike
+      ) => {
+        originalRenameSync(oldPath, newPath);
+        if (
+          !injected &&
+          String(newPath) === canonicalPath &&
+          String(oldPath).startsWith(`${canonicalPath}.ccs-write-`)
+        ) {
           injected = true;
           writeJson(divergedPath, { generation: 2 });
         }
-        return originalUnlinkSync(targetPath);
-      }) as typeof fs.unlinkSync);
+      }) as typeof fs.renameSync);
 
       expect(() => manager.linkSharedDirectories(instancePath)).toThrow(
         'Concurrent replacement detected'
       );
-      unlinkSpy.mockRestore();
+      renameSpy.mockRestore();
+      expect(injected).toBe(true);
       expect(readJson(divergedPath)).toEqual({ generation: 2 });
     });
 
@@ -694,7 +826,7 @@ describe('SharedManager', () => {
       }
     });
 
-    it('uses the mode of the canonical inode actually claimed for publication', () => {
+    it('publishes with the mode the canonical inode carries at publication time', () => {
       const manager = new SharedManager();
       const instancePath = instanceDir('concurrent-mode');
       const canonicalPath = path.join(claudeDir(), 'settings.json');
@@ -706,23 +838,24 @@ describe('SharedManager', () => {
       writeJson(divergedPath, { generation: 1 });
       setMtime(divergedPath, fs.statSync(canonicalPath).mtimeMs + 2_000);
 
-      const originalRenameSync = fs.renameSync;
-      const renameSpy = spyOn(fs, 'renameSync').mockImplementation(((
-        oldPath: fs.PathLike,
-        newPath: fs.PathLike
+      // A chmod between reading the canonical file and publishing it leaves
+      // the content untouched, so publication proceeds with the newer mode.
+      const originalOpenSync = fs.openSync;
+      const openSpy = spyOn(fs, 'openSync').mockImplementation(((
+        openPath: fs.PathLike,
+        flags: number | string,
+        mode?: fs.Mode
       ) => {
-        if (
-          String(oldPath) === canonicalPath &&
-          String(newPath).includes('.ccs-canonical-claim-')
-        ) {
+        if (String(openPath).startsWith(`${canonicalPath}.ccs-write-`)) {
           fs.chmodSync(canonicalPath, 0o664);
         }
-        return originalRenameSync(oldPath, newPath);
-      }) as typeof fs.renameSync);
+        return originalOpenSync(openPath, flags, mode);
+      }) as typeof fs.openSync);
 
       manager.linkSharedDirectories(instancePath);
-      renameSpy.mockRestore();
+      openSpy.mockRestore();
       expect(fs.statSync(canonicalPath).mode & 0o777).toBe(0o664);
+      expect(readJson(canonicalPath)).toEqual({ generation: 1 });
     });
 
     it('recovers an interrupted canonical claim before provisioning defaults', () => {


### PR DESCRIPTION
## Problem

Adopting a diverged `settings.json` can destroy the user's live settings.

`adoptDivergedFileContent` moves the canonical file aside with `rename()` (`diverged-file-adopter.ts:296` on `dev`) and leaves `~/.claude/settings.json` missing until publication, roughly 100 ms later — two full file copies (`publishBackupNoReplace`, `publishAdoptedRecoveryNoReplace`) run inside that window. Anything starting in it finds no file and seeds an empty placeholder: Claude Code does this on startup, and so does a second `ccs` through `shared-dir-linker.ts:127`. Publication then fails with `EEXIST`, because `atomicWriteFile` publishes through `link()`, which is no-replace. The rollback in `restoreCanonicalClaim` hits the same `EEXIST`, publishes a backup and unlinks the claim — destroying the inode that held the only remaining copy. The live path is left holding the placeholder, and the user gets no indication that anything happened.

We hit this on 2026-08-20: a 5580-byte `settings.json` with 168 `permissions.allow` rules, `model`, `hooks`, `theme` and `enabledPlugins` became `{}` — 3 bytes. Every instance shares that file through the managed symlink chain, so it went everywhere at once. The content survived only in `.bak-ccs-adopt` and `.ccs-adopted-recovery` sidecars, and recovering it meant matching them up by hand. The same code path had run correctly days earlier, which is what makes it a race rather than a plain bug.

Two concurrent `ccs` runs are enough to reproduce it; Claude Code is not required.

## Fix

Publish by replacement. A fully written, fsynced temp file is renamed over the canonical inode, so the path always holds a regular file and no placeholder can be seeded. The claim on the canonical file is gone entirely, along with `restoreCanonicalClaim`.

A compare-and-swap guard on `(ino, mtime, size)` runs immediately before the rename and refuses to publish when the canonical inode changed since it was read, so a writer that got there first is still never clobbered — that guarantee now costs nothing, because only a genuinely concurrent write can land there. The guard is read-then-act, not atomic; POSIX offers no compare-and-swap rename, so the window shrinks from ~100 ms to two adjacent syscalls rather than closing. That limit is stated in the code so it is not mistaken for strict atomicity, and the pre-image backup — published before the replacement — keeps even that outcome recoverable.

`recoverOrphanedCanonicalClaim` is kept: claims written by older versions may still be on disk.

Follow-on cleanups in the same area: the two identical sidecar publishers fold into one helper, and the duplicated durable-temp-write block behind both publishers is extracted (`writeDurableTempFile`, `discardTempFile`).

## Reversed test

`preserves a canonical write that lands during no-replace publication` pinned the incident's outcome as intended behaviour — the foreign write survives, the previous canonical content lives only in `.bak-ccs-adopt`. It is rewritten as `refuses to publish when the canonical file changes before publication`. The intent it encoded — never clobber a writer that got there first — is preserved and now enforced by the CAS guard. Three more tests keyed on the `.ccs-canonical-claim-` path were moved to injection points that still exist.

## Test plan

- Two new cases in `tests/unit/shared-manager.test.ts` reproduce the race deterministically: a foreign writer seeds an empty placeholder the moment the canonical path is observed missing, once as Claude Code (`{}` with a trailing newline) and once as a second `ccs` (the 2-byte seed from `shared-dir-linker`). Both fail on `dev` and pass here. They also assert the writer never fired at all, which is the invariant the fix establishes.
- `tests/unit/shared-manager.test.ts` — 41 pass / 0 fail.
- `bun test tests/unit` — 3842 pass, 24 skip.
- `bun run typecheck`, `bun run lint`, `bun run format:check` — clean.
- `scripts/ci-parity-gate.sh` — passes; `docs/reports/hardening-inventory.{json,md}` regenerated as the gate requires. The adopter drops from 36 to 29 sync-fs call sites after the dedup.
