### PR TITLE
docs: refresh hardening inventory and add 75% quota test

### DIFF
--- a/docs/reports/hardening-inventory.json
+++ b/docs/reports/hardening-inventory.json
@@ -718,7 +718,7 @@
       ]
     },
     "largeFiles": {
-      "countOver400": 93,
+      "countOver400": 94,
       "countOver600": 42,
       "topOver400": [
         {

--- a/docs/reports/hardening-inventory.md
+++ b/docs/reports/hardening-inventory.md
@@ -62,7 +62,7 @@ Scope: `src/**/*.{ts,tsx,js,jsx,mjs,cjs}`
 | hotpath console.error/warn files | 81 |
 | files with createLogger | 65/765 |
 | subdomains with zero createLogger | 15 (api, bin, channels, cliproxy, cliproxy/accounts, cliproxy/ai-providers, cliproxy/binary, cliproxy/config, cliproxy/management, cliproxy/sync, cliproxy/types, config, dispatcher, shared, types) |
-| files > 400 LOC | 93 |
+| files > 400 LOC | 94 |
 | files > 600 LOC | 42 |
 
 ### Top Hotpath console.error/warn Files

--- a/tests/unit/commands/cliproxy-quota-subcommand.test.ts
+++ b/tests/unit/commands/cliproxy-quota-subcommand.test.ts
@@ -193,12 +193,14 @@ function captureConsoleLog(fn: () => void): string {
 describe('cliproxy quota remaining percent labels and ASCII compliance', () => {
   it('renders formatQuotaBar with pure ASCII characters', () => {
     const bar100 = formatQuotaBar(100);
+    const bar75 = formatQuotaBar(75);
     const bar50 = formatQuotaBar(50);
     const bar25 = formatQuotaBar(25);
     const bar5 = formatQuotaBar(5);
     const bar0 = formatQuotaBar(0);
 
     expect(bar100).toBe(`[${'#'.repeat(20)}]`);
+    expect(bar75).toBe(`[${'#'.repeat(15)}${' '.repeat(5)}]`);
     expect(bar50).toBe(`[${'+'.repeat(10)}${' '.repeat(10)}]`);
     expect(bar25).toBe(`[${'+'.repeat(5)}${' '.repeat(15)}]`);
     expect(bar5).toBe(`[${'-'.repeat(1)}${' '.repeat(19)}]`);
@@ -206,6 +208,7 @@ describe('cliproxy quota remaining percent labels and ASCII compliance', () => {
 
     // Strict ASCII verification
     expect(bar100).toMatch(/^[\x00-\x7F]+$/);
+    expect(bar75).toMatch(/^[\x00-\x7F]+$/);
     expect(bar50).toMatch(/^[\x00-\x7F]+$/);
     expect(bar25).toMatch(/^[\x00-\x7F]+$/);
     expect(bar5).toMatch(/^[\x00-\x7F]+$/);


### PR DESCRIPTION
## Summary
Refreshes the generated hardening inventory (`docs/reports/hardening-inventory.{json,md}`) after recent PR merges and adds an exact 75% `formatQuotaBar` test case in `tests/unit/commands/cliproxy-quota-subcommand.test.ts`.